### PR TITLE
Rename a whole bunch of funtions to a shorter version.

### DIFF
--- a/libcentrifugo/admin.go
+++ b/libcentrifugo/admin.go
@@ -17,7 +17,7 @@ type adminSession interface {
 type adminClient struct {
 	app       *application
 	Uid       string
-	ses       adminSession
+	sess      adminSession
 	writeChan chan []byte
 	closeChan chan struct{}
 }
@@ -30,7 +30,7 @@ func newAdminClient(app *application, s adminSession) (*adminClient, error) {
 	return &adminClient{
 		Uid:       uid.String(),
 		app:       app,
-		ses:       s,
+		sess:      s,
 		writeChan: make(chan []byte, 256),
 		closeChan: make(chan struct{}),
 	}, nil
@@ -55,7 +55,7 @@ func (c *adminClient) writer() {
 	for {
 		select {
 		case message := <-c.writeChan:
-			err := c.ses.WriteMessage(websocket.TextMessage, message)
+			err := c.sess.WriteMessage(websocket.TextMessage, message)
 			if err != nil {
 				return
 			}

--- a/libcentrifugo/admin.go
+++ b/libcentrifugo/admin.go
@@ -16,8 +16,8 @@ type adminSession interface {
 // adminClient is a wrapper over admin websocket connection
 type adminClient struct {
 	app       *application
-	uid       string
-	session   adminSession
+	Uid       string
+	ses       adminSession
 	writeChan chan []byte
 	closeChan chan struct{}
 }
@@ -28,16 +28,16 @@ func newAdminClient(app *application, s adminSession) (*adminClient, error) {
 		return nil, err
 	}
 	return &adminClient{
-		uid:       uid.String(),
+		Uid:       uid.String(),
 		app:       app,
-		session:   s,
+		ses:       s,
 		writeChan: make(chan []byte, 256),
 		closeChan: make(chan struct{}),
 	}, nil
 }
 
-func (c *adminClient) getUid() string {
-	return c.uid
+func (c *adminClient) uid() string {
+	return c.Uid
 }
 
 func (c *adminClient) send(message string) error {
@@ -55,7 +55,7 @@ func (c *adminClient) writer() {
 	for {
 		select {
 		case message := <-c.writeChan:
-			err := c.session.WriteMessage(websocket.TextMessage, message)
+			err := c.ses.WriteMessage(websocket.TextMessage, message)
 			if err != nil {
 				return
 			}
@@ -88,25 +88,25 @@ func (c *adminClient) handleMessage(message []byte) (*response, error) {
 			logger.ERROR.Println(err)
 			return nil, ErrInvalidAdminMessage
 		}
-		resp, err = c.handleAuthCommand(&cmd)
+		resp, err = c.authCmd(&cmd)
 	case "ping":
-		resp, err = c.handlePingCommand()
+		resp, err = c.pingCmd()
 	default:
 		return nil, ErrInvalidAdminMessage
 	}
 	return resp, err
 }
 
-// handleAuthCommand checks provided token and adds admin connection into application
+// authCmd checks provided token and adds admin connection into application
 // registry if token correct
-func (c *adminClient) handleAuthCommand(cmd *authAdminCommand) (*response, error) {
+func (c *adminClient) authCmd(cmd *authAdminCommand) (*response, error) {
 
 	err := c.app.checkAuthToken(cmd.Token)
 	if err != nil {
 		return nil, ErrUnauthorized
 	}
 
-	err = c.app.addAdminConnection(c)
+	err = c.app.addAdminConn(c)
 	if err != nil {
 		logger.ERROR.Println(err)
 		return nil, ErrInternalServerError
@@ -117,8 +117,8 @@ func (c *adminClient) handleAuthCommand(cmd *authAdminCommand) (*response, error
 	return resp, nil
 }
 
-// handlePingCommand handles ping command from admin client
-func (c *adminClient) handlePingCommand() (*response, error) {
+// pingCmd handles ping command from admin client
+func (c *adminClient) pingCmd() (*response, error) {
 	resp := newResponse("ping")
 	resp.Body = "pong"
 	return resp, nil

--- a/libcentrifugo/admin_test.go
+++ b/libcentrifugo/admin_test.go
@@ -33,7 +33,7 @@ func newTestAdminClient() (*adminClient, error) {
 func TestAdminClient(t *testing.T) {
 	c, err := newTestAdminClient()
 	assert.Equal(t, nil, err)
-	assert.NotEqual(t, c.getUid(), "")
+	assert.NotEqual(t, c.uid(), "")
 	err = c.send("message")
 	assert.Equal(t, nil, err)
 }

--- a/libcentrifugo/application.go
+++ b/libcentrifugo/application.go
@@ -477,16 +477,16 @@ func (app *application) disconnectUser(projectKey, user string) error {
 	return nil
 }
 
-// projByKey returns a project by project key (name) using structure
-func (app *application) projByKey(projectKey string) (*project, bool) {
+// projectByKey returns a project by project key (name) using structure
+func (app *application) projectByKey(projectKey string) (*project, bool) {
 	app.RLock()
 	defer app.RUnlock()
 	return app.structure.projByKey(projectKey)
 }
 
-// channelNs returns namespace name from channel name if exists or
+// channelNamespace returns namespace name from channel name if exists or
 // empty string
-func (app *application) channelNs(channel string) string {
+func (app *application) channelNamespace(channel string) string {
 	channel = strings.TrimPrefix(channel, app.config.privateChannelPrefix)
 	parts := strings.SplitN(channel, app.config.namespaceChannelBoundary, 2)
 	if len(parts) >= 2 {
@@ -500,7 +500,7 @@ func (app *application) channelNs(channel string) string {
 func (app *application) channelOpts(projectKey, channel string) *ChannelOptions {
 	app.RLock()
 	defer app.RUnlock()
-	namespaceName := app.channelNs(channel)
+	namespaceName := app.channelNamespace(channel)
 	return app.structure.channelOpts(projectKey, namespaceName)
 }
 
@@ -536,7 +536,7 @@ func (app *application) history(projectKey, channel string) ([]Message, error) {
 
 // privateCh checks if channel private and therefore subscription
 // request on it must be properly signed on web application backend
-func (app *application) privateCh(channel string) bool {
+func (app *application) privateChannel(channel string) bool {
 	app.RLock()
 	defer app.RUnlock()
 	return strings.HasPrefix(channel, app.config.privateChannelPrefix)

--- a/libcentrifugo/application.go
+++ b/libcentrifugo/application.go
@@ -26,14 +26,14 @@ type application struct {
 	// nodes is a map with information about nodes known
 	nodes map[string]*nodeInfo
 	// nodesMutex allows to synchronize access to nodes
-	nodesMutex sync.Mutex
+	nodesMu sync.Mutex
 
 	// hub to manage client connections
-	clientConnectionHub *clientConnectionHub
+	connHub *clientHub
 	// hub to manage client subscriptions
-	clientSubscriptionHub *clientSubscriptionHub
+	subs *subHub
 	// hub to manage admin connections
-	adminConnectionHub *adminConnectionHub
+	admins *adminHub
 
 	// engine to use - in memory or redis
 	engine engine
@@ -61,24 +61,24 @@ func newApplication() (*application, error) {
 		return nil, err
 	}
 	app := &application{
-		uid:                   uid.String(),
-		nodes:                 make(map[string]*nodeInfo),
-		clientConnectionHub:   newClientConnectionHub(),
-		clientSubscriptionHub: newClientSubscriptionHub(),
-		adminConnectionHub:    newAdminConnectionHub(),
-		started:               time.Now().Unix(),
+		uid:     uid.String(),
+		nodes:   make(map[string]*nodeInfo),
+		connHub: newClientHub(),
+		subs:    newSubHub(),
+		admins:  newAdminHub(),
+		started: time.Now().Unix(),
 	}
 	return app, nil
 }
 
 func (app *application) run() {
-	go app.sendPingMessage()
+	go app.sendPingMsg()
 	go app.cleanNodeInfo()
 }
 
-func (app *application) sendPingMessage() {
+func (app *application) sendPingMsg() {
 	for {
-		err := app.publishPingControlMessage()
+		err := app.pubPing()
 		if err != nil {
 			logger.CRITICAL.Println(err)
 		}
@@ -95,13 +95,13 @@ func (app *application) cleanNodeInfo() {
 		delay := app.config.nodeInfoMaxDelay
 		app.RUnlock()
 
-		app.nodesMutex.Lock()
+		app.nodesMu.Lock()
 		for uid, info := range app.nodes {
 			if time.Now().Unix()-info.Updated > delay {
 				delete(app.nodes, uid)
 			}
 		}
-		app.nodesMutex.Unlock()
+		app.nodesMu.Unlock()
 
 		app.RLock()
 		interval := app.config.nodeInfoCleanInterval
@@ -132,23 +132,23 @@ func (app *application) setEngine(e engine) {
 	app.engine = e
 }
 
-// handleMessage called when new message of any type received by this node.
+// handleMsg called when new message of any type received by this node.
 // It looks at channel and decides which message handler to call
-func (app *application) handleMessage(channel string, message []byte) error {
+func (app *application) handleMsg(channel string, message []byte) error {
 	switch channel {
 	case app.config.controlChannel:
-		return app.handleControlMessage(message)
+		return app.controlMsg(message)
 	case app.config.adminChannel:
-		return app.handleAdminMessage(message)
+		return app.adminMsg(message)
 	default:
-		return app.handleClientMessage(channel, message)
+		return app.clientMsg(channel, message)
 	}
 }
 
-// handleControlMessage handles messages from control channel - control
+// controlMsg handles messages from control channel - control
 // messages used for internal communication between nodes to share state
 // or commands
-func (app *application) handleControlMessage(message []byte) error {
+func (app *application) controlMsg(message []byte) error {
 
 	var cmd controlCommand
 	err := json.Unmarshal(message, &cmd)
@@ -173,7 +173,7 @@ func (app *application) handleControlMessage(message []byte) error {
 			logger.ERROR.Println(err)
 			return ErrInvalidControlMessage
 		}
-		return app.handlePingControlCommand(&cmd)
+		return app.pingCmd(&cmd)
 	case "unsubscribe":
 		var cmd unsubscribeControlCommand
 		err := json.Unmarshal(params, &cmd)
@@ -181,7 +181,7 @@ func (app *application) handleControlMessage(message []byte) error {
 			logger.ERROR.Println(err)
 			return ErrInvalidControlMessage
 		}
-		return app.handleUnsubscribeControlCommand(&cmd)
+		return app.unsubscribeCmd(&cmd)
 	case "disconnect":
 		var cmd disconnectControlCommand
 		err := json.Unmarshal(params, &cmd)
@@ -189,39 +189,38 @@ func (app *application) handleControlMessage(message []byte) error {
 			logger.ERROR.Println(err)
 			return ErrInvalidControlMessage
 		}
-		return app.handleDisconnectControlCommand(&cmd)
+		return app.disconnectUser(cmd.Project, cmd.User)
 	default:
 		logger.ERROR.Println("unknown control message method", method)
 		return ErrInvalidControlMessage
 	}
-
-	return nil
+	panic("unreachable")
 }
 
-// handleAdminMessage handles messages from admin channel - those messages
+// adminMsg handles messages from admin channel - those messages
 // must be delivered to all admins connected to this node
-func (app *application) handleAdminMessage(message []byte) error {
-	return app.adminConnectionHub.broadcast(string(message))
+func (app *application) adminMsg(message []byte) error {
+	return app.admins.broadcast(string(message))
 }
 
-// handleClientMessage handles messages published by web application or client
+// clientMsg handles messages published by web application or client
 // into channel. The goal of this method to deliver this message to all clients
 // on this node subscribed on channel
-func (app *application) handleClientMessage(channel string, message []byte) error {
-	return app.clientSubscriptionHub.broadcast(channel, string(message))
+func (app *application) clientMsg(channel string, message []byte) error {
+	return app.subs.broadcast(channel, string(message))
 }
 
-// publishControlMessage publishes message into control channel so all running
+// pubControl publishes message into control channel so all running
 // nodes will receive and handle it
-func (app *application) publishControlMessage(message []byte) error {
+func (app *application) pubControl(message []byte) error {
 	app.RLock()
 	defer app.RUnlock()
 	return app.engine.publish(app.config.controlChannel, message)
 }
 
-// publishAdminMessage publishes message into admin channel so all running
+// pubAdmin publishes message into admin channel so all running
 // nodes will receive it and send to admins connected
-func (app *application) publishAdminMessage(message []byte) error {
+func (app *application) pubAdmin(message []byte) error {
 	app.RLock()
 	defer app.RUnlock()
 	return app.engine.publish(app.config.adminChannel, message)
@@ -235,9 +234,9 @@ type Message struct {
 	Data      *json.RawMessage `json:"data"`
 }
 
-// publishClientMessage publishes message into channel so all running nodes
+// pubClient publishes message into channel so all running nodes
 // will receive it and will send to all clients on node subscribed on channel
-func (app *application) publishClientMessage(p *project, channel string, chOpts *ChannelOptions, data []byte, info *ClientInfo) error {
+func (app *application) pubClient(p *project, channel string, chOpts *ChannelOptions, data []byte, info *ClientInfo) error {
 
 	uid, err := uuid.NewV4()
 	if err != nil {
@@ -264,14 +263,14 @@ func (app *application) publishClientMessage(p *project, channel string, chOpts 
 		if err != nil {
 			logger.ERROR.Println(err)
 		} else {
-			err = app.publishAdminMessage(messageBytes)
+			err = app.pubAdmin(messageBytes)
 			if err != nil {
 				logger.ERROR.Println(err)
 			}
 		}
 	}
 
-	projectChannel := app.getProjectChannel(p.Name, channel)
+	projectChannel := app.projectChannel(p.Name, channel)
 
 	resp := newResponse("message")
 	resp.Body = message
@@ -287,7 +286,7 @@ func (app *application) publishClientMessage(p *project, channel string, chOpts 
 	}
 
 	if chOpts.HistorySize > 0 && chOpts.HistoryLifetime > 0 {
-		err := app.addHistoryMessage(p.Name, channel, message, chOpts.HistorySize, chOpts.HistoryLifetime)
+		err := app.addHistory(p.Name, channel, message, chOpts.HistorySize, chOpts.HistoryLifetime)
 		if err != nil {
 			logger.ERROR.Println(err)
 		}
@@ -296,10 +295,10 @@ func (app *application) publishClientMessage(p *project, channel string, chOpts 
 	return nil
 }
 
-// publishJoinLeaveMessage allows to publish join message into channel when
+// pubJoinLeave allows to publish join message into channel when
 // someone subscribes on it or leave message when someone unsubscribed from channel
-func (app *application) publishJoinLeaveMessage(projectKey, channel, method string, info ClientInfo) error {
-	projectChannel := app.getProjectChannel(projectKey, channel)
+func (app *application) pubJoinLeave(projectKey, channel, method string, info ClientInfo) error {
+	projectChannel := app.projectChannel(projectKey, channel)
 	resp := newResponse(method)
 	resp.Body = map[string]interface{}{
 		"channel": channel,
@@ -312,19 +311,19 @@ func (app *application) publishJoinLeaveMessage(projectKey, channel, method stri
 	return app.engine.publish(projectChannel, byteMessage)
 }
 
-func (app *application) publishPingControlMessage() error {
+func (app *application) pubPing() error {
 	app.RLock()
 	defer app.RUnlock()
 	cmd := &pingControlCommand{
 		Uid:      app.uid,
 		Name:     app.config.name,
-		Clients:  app.getClientsCount(),
-		Unique:   app.getUniqueChannelsCount(),
-		Channels: app.getChannelsCount(),
+		Clients:  app.nClients(),
+		Unique:   app.nUniqueClients(),
+		Channels: app.nChannels(),
 		Started:  app.started,
 	}
 
-	err := app.handlePingControlCommand(cmd)
+	err := app.pingCmd(cmd)
 	if err != nil {
 		logger.ERROR.Println(err)
 	}
@@ -338,10 +337,10 @@ func (app *application) publishPingControlMessage() error {
 	if err != nil {
 		return err
 	}
-	return app.publishControlMessage(messageBytes)
+	return app.pubControl(messageBytes)
 }
 
-func (app *application) publishUnsubscribeControlMessage(projectKey, user, channel string) error {
+func (app *application) pubUnsub(projectKey, user, channel string) error {
 	message := map[string]interface{}{
 		"uid":    app.uid,
 		"method": "unsubscribe",
@@ -355,10 +354,10 @@ func (app *application) publishUnsubscribeControlMessage(projectKey, user, chann
 	if err != nil {
 		return err
 	}
-	return app.publishControlMessage(messageBytes)
+	return app.pubControl(messageBytes)
 }
 
-func (app *application) publishDisconnectControlMessage(projectKey, user string) error {
+func (app *application) pubDisconnect(projectKey, user string) error {
 	message := map[string]interface{}{
 		"uid":    app.uid,
 		"method": "disconnect",
@@ -371,11 +370,11 @@ func (app *application) publishDisconnectControlMessage(projectKey, user string)
 	if err != nil {
 		return err
 	}
-	return app.publishControlMessage(messageBytes)
+	return app.pubControl(messageBytes)
 }
 
-// handlePingControlCommand updates information about known nodes
-func (app *application) handlePingControlCommand(cmd *pingControlCommand) error {
+// pingCmd updates information about known nodes
+func (app *application) pingCmd(cmd *pingControlCommand) error {
 	info := &nodeInfo{
 		Uid:      cmd.Uid,
 		Name:     cmd.Name,
@@ -385,72 +384,73 @@ func (app *application) handlePingControlCommand(cmd *pingControlCommand) error 
 		Started:  cmd.Started,
 		Updated:  time.Now().Unix(),
 	}
-	app.nodesMutex.Lock()
+	app.nodesMu.Lock()
 	app.nodes[cmd.Uid] = info
-	app.nodesMutex.Unlock()
+	app.nodesMu.Unlock()
 	return nil
 }
 
-func (app *application) handleUnsubscribeControlCommand(cmd *unsubscribeControlCommand) error {
-	return app.unsubscribeUserFromChannel(cmd.Project, cmd.User, cmd.Channel)
+func (app *application) unsubscribeCmd(cmd *unsubscribeControlCommand) error {
+	return app.unsubUser(cmd.Project, cmd.User, cmd.Channel)
 }
 
-func (app *application) handleDisconnectControlCommand(cmd *disconnectControlCommand) error {
+/*
+func (app *application) disconnectCmd(cmd *disconnectControlCommand) error {
 	return app.disconnectUser(cmd.Project, cmd.User)
 }
-
-// getProjectChannel returns internal name of channel - as
+*/
+// projectChannel returns internal name of channel - as
 // every project can have channels with the same name we should distinguish
 // between them. This also prevents collapses with admin and control
 // channel names
-func (app *application) getProjectChannel(projectKey, channel string) string {
+func (app *application) projectChannel(projectKey, channel string) string {
 	app.RLock()
 	defer app.RUnlock()
 	return app.config.channelPrefix + "." + projectKey + "." + channel
 }
 
-// addConnection registers authenticated connection in clientConnectionHub
+// addConn registers authenticated connection in clientConnectionHub
 // this allows to make operations with user connection on demand
-func (app *application) addConnection(c clientConnection) error {
-	return app.clientConnectionHub.add(c)
+func (app *application) addConn(c clientConn) error {
+	return app.connHub.add(c)
 }
 
-// removeConnection removes client connection from connection registry
-func (app *application) removeConnection(c clientConnection) error {
-	return app.clientConnectionHub.remove(c)
+// removeConn removes client connection from connection registry
+func (app *application) removeConn(c clientConn) error {
+	return app.connHub.remove(c)
 }
 
-// addSubscription registers subscription of connection on channel in both
+// addSub registers subscription of connection on channel in both
 // engine and clientSubscriptionHub
-func (app *application) addSubscription(projectKey, channel string, c clientConnection) error {
-	projectChannel := app.getProjectChannel(projectKey, channel)
+func (app *application) addSub(projectKey, channel string, c clientConn) error {
+	projectChannel := app.projectChannel(projectKey, channel)
 	err := app.engine.subscribe(projectChannel)
 	if err != nil {
 		return err
 	}
-	return app.clientSubscriptionHub.add(projectChannel, c)
+	return app.subs.add(projectChannel, c)
 }
 
-// removeSubscription removes subscription of connection on channel
+// removeSub removes subscription of connection on channel
 // from both engine and clientSubscriptionHub
-func (app *application) removeSubscription(projectKey, channel string, c clientConnection) error {
-	projectChannel := app.getProjectChannel(projectKey, channel)
+func (app *application) removeSub(projectKey, channel string, c clientConn) error {
+	projectChannel := app.projectChannel(projectKey, channel)
 	err := app.engine.unsubscribe(projectChannel)
 	if err != nil {
 		return err
 	}
-	return app.clientSubscriptionHub.remove(projectChannel, c)
+	return app.subs.remove(projectChannel, c)
 }
 
-// unsubscribeUserFromChannel unsubscribes user from channel on this node. If channel
+// unsubUser unsubscribes user from channel on this node. If channel
 // is an empty string then user will be unsubscribed from all channels
-func (app *application) unsubscribeUserFromChannel(projectKey, user, channel string) error {
-	userConnections := app.clientConnectionHub.getUserConnections(projectKey, user)
+func (app *application) unsubUser(projectKey, user, channel string) error {
+	userConnections := app.connHub.userConnections(projectKey, user)
 	for _, c := range userConnections {
 		var channels []string
 		if channel == "" {
 			// unsubscribe from all channels
-			channels = c.getChannels()
+			channels = c.channels()
 		} else {
 			channels = []string{channel}
 		}
@@ -467,7 +467,7 @@ func (app *application) unsubscribeUserFromChannel(projectKey, user, channel str
 
 // disconnectUser closes client connections of user
 func (app *application) disconnectUser(projectKey, user string) error {
-	userConnections := app.clientConnectionHub.getUserConnections(projectKey, user)
+	userConnections := app.connHub.userConnections(projectKey, user)
 	for _, c := range userConnections {
 		err := c.close("disconnect")
 		if err != nil {
@@ -477,16 +477,16 @@ func (app *application) disconnectUser(projectKey, user string) error {
 	return nil
 }
 
-// getProjectByKey returns a project by project key (name) using structure
-func (app *application) getProjectByKey(projectKey string) (*project, bool) {
+// projByKey returns a project by project key (name) using structure
+func (app *application) projByKey(projectKey string) (*project, bool) {
 	app.RLock()
 	defer app.RUnlock()
-	return app.structure.getProjectByKey(projectKey)
+	return app.structure.projByKey(projectKey)
 }
 
-// extractNamespaceName returns namespace name from channel name if exists or
+// channelNs returns namespace name from channel name if exists or
 // empty string
-func (app *application) extractNamespaceName(channel string) string {
+func (app *application) channelNs(channel string) string {
 	channel = strings.TrimPrefix(channel, app.config.privateChannelPrefix)
 	parts := strings.SplitN(channel, app.config.namespaceChannelBoundary, 2)
 	if len(parts) >= 2 {
@@ -496,56 +496,56 @@ func (app *application) extractNamespaceName(channel string) string {
 	}
 }
 
-// getChannelOptions returns channel options for channel using structure
-func (app *application) getChannelOptions(projectKey, channel string) *ChannelOptions {
+// channelOpts returns channel options for channel using structure
+func (app *application) channelOpts(projectKey, channel string) *ChannelOptions {
 	app.RLock()
 	defer app.RUnlock()
-	namespaceName := app.extractNamespaceName(channel)
-	return app.structure.getChannelOptions(projectKey, namespaceName)
+	namespaceName := app.channelNs(channel)
+	return app.structure.channelOpts(projectKey, namespaceName)
 }
 
 // addPresence proxies presence adding to engine
 func (app *application) addPresence(projectKey, channel, uid string, info ClientInfo) error {
-	projectChannel := app.getProjectChannel(projectKey, channel)
+	projectChannel := app.projectChannel(projectKey, channel)
 	return app.engine.addPresence(projectChannel, uid, info)
 }
 
 // removePresence proxies presence removing to engine
 func (app *application) removePresence(projectKey, channel, uid string) error {
-	projectChannel := app.getProjectChannel(projectKey, channel)
+	projectChannel := app.projectChannel(projectKey, channel)
 	return app.engine.removePresence(projectChannel, uid)
 }
 
 // getPresence proxies presence extraction to engine
-func (app *application) getPresence(projectKey, channel string) (map[string]ClientInfo, error) {
-	projectChannel := app.getProjectChannel(projectKey, channel)
-	return app.engine.getPresence(projectChannel)
+func (app *application) presence(projectKey, channel string) (map[string]ClientInfo, error) {
+	projectChannel := app.projectChannel(projectKey, channel)
+	return app.engine.presence(projectChannel)
 }
 
-// addHistoryMessage proxies history message adding to engine
-func (app *application) addHistoryMessage(projectKey, channel string, message Message, size, lifetime int64) error {
-	projectChannel := app.getProjectChannel(projectKey, channel)
+// addHistory proxies history message adding to engine
+func (app *application) addHistory(projectKey, channel string, message Message, size, lifetime int64) error {
+	projectChannel := app.projectChannel(projectKey, channel)
 	return app.engine.addHistoryMessage(projectChannel, message, size, lifetime)
 }
 
 // getHistory proxies history extraction to engine
-func (app *application) getHistory(projectKey, channel string) ([]Message, error) {
-	projectChannel := app.getProjectChannel(projectKey, channel)
-	return app.engine.getHistory(projectChannel)
+func (app *application) history(projectKey, channel string) ([]Message, error) {
+	projectChannel := app.projectChannel(projectKey, channel)
+	return app.engine.history(projectChannel)
 }
 
-// isPrivateChannel checks if channel private and therefore subscription
+// privateCh checks if channel private and therefore subscription
 // request on it must be properly signed on web application backend
-func (app *application) isPrivateChannel(channel string) bool {
+func (app *application) privateCh(channel string) bool {
 	app.RLock()
 	defer app.RUnlock()
 	return strings.HasPrefix(channel, app.config.privateChannelPrefix)
 }
 
-// isUserAllowed checks if user can subscribe on channel - as channel
+// userAllowed checks if user can subscribe on channel - as channel
 // can contain special part in the end to indicate which users allowed
 // to subscribe on it
-func (app *application) isUserAllowed(channel, user string) bool {
+func (app *application) userAllowed(channel, user string) bool {
 	app.RLock()
 	defer app.RUnlock()
 	if !strings.Contains(channel, app.config.userChannelBoundary) {
@@ -561,30 +561,30 @@ func (app *application) isUserAllowed(channel, user string) bool {
 	return false
 }
 
-// register admin connection in adminConnectionHub
-func (app *application) addAdminConnection(c adminConnection) error {
-	return app.adminConnectionHub.add(c)
+// addAdminConn registers an admin connection in adminConnectionHub
+func (app *application) addAdminConn(c adminConn) error {
+	return app.admins.add(c)
 }
 
-// unregister admin connection from adminConnectionHub
-func (app *application) removeAdminConnection(c adminConnection) error {
-	return app.adminConnectionHub.remove(c)
+// removeAdminConn admin connection from adminConnectionHub
+func (app *application) removeAdminConn(c adminConn) error {
+	return app.admins.remove(c)
 }
 
-// getChannelsCount returns total amount of active channels on this node
-func (app *application) getChannelsCount() int {
-	return app.clientSubscriptionHub.getChannelsCount()
+// nChannels returns total amount of active channels on this node
+func (app *application) nChannels() int {
+	return app.subs.nChannels()
 }
 
-// getClientsCount returns total amount of client connections to this node
-func (app *application) getClientsCount() int {
-	return app.clientConnectionHub.getClientsCount()
+// nClients returns total amount of client connections to this node
+func (app *application) nClients() int {
+	return app.connHub.nClients()
 }
 
-// getUniqueChannelsCount returns total amount of unique client
+// nUniqueClients returns total amount of unique client
 // connections to this node
-func (app *application) getUniqueChannelsCount() int {
-	return app.clientConnectionHub.getUniqueClientsCount()
+func (app *application) nUniqueClients() int {
+	return app.connHub.nUniqueClients()
 }
 
 const (

--- a/libcentrifugo/client.go
+++ b/libcentrifugo/client.go
@@ -22,7 +22,7 @@ type client struct {
 	User          string
 	timestamp     int64
 	token         string
-	Info          []byte
+	defaultInfo   []byte
 	authenticated bool
 	channelInfo   map[string][]byte
 	Channels      map[string]bool
@@ -197,8 +197,8 @@ func (c *client) info(channel string) ClientInfo {
 	}
 	var rawDefaultInfo *json.RawMessage
 	var rawChannelInfo *json.RawMessage
-	if len(c.Info) > 0 {
-		raw := json.RawMessage(c.Info)
+	if len(c.defaultInfo) > 0 {
+		raw := json.RawMessage(c.defaultInfo)
 		rawDefaultInfo = &raw
 	} else {
 		rawDefaultInfo = nil
@@ -452,7 +452,7 @@ func (c *client) connectCmd(cmd *connectClientCommand) (*response, error) {
 	}
 
 	c.authenticated = true
-	c.Info = []byte(info)
+	c.defaultInfo = []byte(info)
 	c.Channels = map[string]bool{}
 	c.channelInfo = map[string][]byte{}
 
@@ -518,7 +518,7 @@ func (c *client) refreshCmd(cmd *refreshClientCommand) (*response, error) {
 		if timeToExpire > 0 {
 			// connection refreshed, update client timestamp and set new expiration timeout
 			c.timestamp = int64(ts)
-			c.Info = []byte(info)
+			c.defaultInfo = []byte(info)
 			if c.expireTimer != nil {
 				c.expireTimer.Stop()
 			}

--- a/libcentrifugo/client.go
+++ b/libcentrifugo/client.go
@@ -15,20 +15,20 @@ import (
 // or SockJS connection.
 type client struct {
 	sync.Mutex
-	app             *application
-	session         session
-	uid             string
-	project         string
-	user            string
-	timestamp       int64
-	token           string
-	info            []byte
-	isAuthenticated bool
-	channelInfo     map[string][]byte
-	channels        map[string]bool
-	messageChan     chan string
-	closeChan       chan struct{}
-	expireTimer     *time.Timer
+	app           *application
+	ses           session
+	Uid           string
+	Project       string
+	User          string
+	timestamp     int64
+	token         string
+	Info          []byte
+	authenticated bool
+	channelInfo   map[string][]byte
+	Channels      map[string]bool
+	messageChan   chan string
+	closeChan     chan struct{}
+	expireTimer   *time.Timer
 }
 
 // ClientInfo contains information about client to use in message
@@ -46,9 +46,9 @@ func newClient(app *application, s session) (*client, error) {
 		return nil, err
 	}
 	return &client{
-		uid:         uid.String(),
+		Uid:         uid.String(),
 		app:         app,
-		session:     s,
+		ses:         s,
 		messageChan: make(chan string, 256),
 		closeChan:   make(chan struct{}),
 	}, nil
@@ -59,9 +59,9 @@ func (c *client) sendMessages() {
 	for {
 		select {
 		case message := <-c.messageChan:
-			err := c.session.Send(message)
+			err := c.ses.Send(message)
 			if err != nil {
-				c.session.Close(3000, "error sending message")
+				c.ses.Close(3000, "error sending message")
 			}
 		case <-c.closeChan:
 			return
@@ -72,21 +72,21 @@ func (c *client) sendMessages() {
 // updateChannelPresence updates client presence info for channel so it
 // won't expire until client disconnect
 func (c *client) updateChannelPresence(channel string) {
-	chOpts := c.app.getChannelOptions(c.project, channel)
+	chOpts := c.app.channelOpts(c.Project, channel)
 	if chOpts == nil {
 		return
 	}
 	if !chOpts.Presence {
 		return
 	}
-	c.app.addPresence(c.project, channel, c.uid, c.getInfo(channel))
+	c.app.addPresence(c.Project, channel, c.Uid, c.info(channel))
 }
 
 // updatePresence updates presence info for all client channels
 func (c *client) updatePresence() {
 	c.Lock()
 	defer c.Unlock()
-	for _, channel := range c.getChannels() {
+	for _, channel := range c.channels() {
 		c.updateChannelPresence(channel)
 	}
 }
@@ -106,22 +106,22 @@ func (c *client) presencePing() {
 	}
 }
 
-func (c *client) getUid() string {
-	return c.uid
+func (c *client) uid() string {
+	return c.Uid
 }
 
-func (c *client) getProject() string {
-	return c.project
+func (c *client) project() string {
+	return c.Project
 }
 
-func (c *client) getUser() string {
-	return c.user
+func (c *client) user() string {
+	return c.User
 }
 
-func (c *client) getChannels() []string {
-	keys := make([]string, len(c.channels))
+func (c *client) channels() []string {
+	keys := make([]string, len(c.Channels))
 	i := 0
-	for k := range c.channels {
+	for k := range c.Channels {
 		keys[i] = k
 		i += 1
 	}
@@ -134,7 +134,7 @@ func (c *client) unsubscribe(channel string) error {
 	cmd := &unsubscribeClientCommand{
 		Channel: channel,
 	}
-	resp, err := c.handleUnsubscribeCommand(cmd)
+	resp, err := c.unsubscribeCmd(cmd)
 	if err != nil {
 		return err
 	}
@@ -149,13 +149,13 @@ func (c *client) send(message string) error {
 	case c.messageChan <- message:
 		return nil
 	default:
-		c.session.Close(3000, "error sending message")
+		c.ses.Close(3000, "error sending message")
 		return ErrInternalServerError
 	}
 }
 
 func (c *client) close(reason string) error {
-	return c.session.Close(3000, reason)
+	return c.ses.Close(3000, reason)
 }
 
 // clean called when connection was closed to make different clean up
@@ -163,15 +163,15 @@ func (c *client) close(reason string) error {
 func (c *client) clean() error {
 	c.Lock()
 	defer c.Unlock()
-	projectKey := c.project
+	projectKey := c.Project
 
-	if projectKey != "" && len(c.channels) > 0 {
+	if projectKey != "" && len(c.Channels) > 0 {
 		// unsubscribe from all channels
-		for channel, _ := range c.channels {
+		for channel, _ := range c.Channels {
 			cmd := &unsubscribeClientCommand{
 				Channel: channel,
 			}
-			_, err := c.handleUnsubscribeCommand(cmd)
+			_, err := c.unsubscribeCmd(cmd)
 			if err != nil {
 				logger.ERROR.Println(err)
 			}
@@ -179,7 +179,7 @@ func (c *client) clean() error {
 	}
 
 	if projectKey != "" {
-		err := c.app.removeConnection(c)
+		err := c.app.removeConn(c)
 		if err != nil {
 			logger.ERROR.Println(err)
 		}
@@ -190,15 +190,15 @@ func (c *client) clean() error {
 	return nil
 }
 
-func (c *client) getInfo(channel string) ClientInfo {
+func (c *client) info(channel string) ClientInfo {
 	channelInfo, ok := c.channelInfo[channel]
 	if !ok {
 		channelInfo = []byte{}
 	}
 	var rawDefaultInfo *json.RawMessage
 	var rawChannelInfo *json.RawMessage
-	if len(c.info) > 0 {
-		raw := json.RawMessage(c.info)
+	if len(c.Info) > 0 {
+		raw := json.RawMessage(c.Info)
 		rawDefaultInfo = &raw
 	} else {
 		rawDefaultInfo = nil
@@ -210,14 +210,14 @@ func (c *client) getInfo(channel string) ClientInfo {
 		rawChannelInfo = nil
 	}
 	return ClientInfo{
-		User:        c.user,
-		Client:      c.uid,
+		User:        c.User,
+		Client:      c.Uid,
 		DefaultInfo: rawDefaultInfo,
 		ChannelInfo: rawChannelInfo,
 	}
 }
 
-func getCommandsFromClientMessage(msgBytes []byte) ([]clientCommand, error) {
+func cmdFromClientMsg(msgBytes []byte) ([]clientCommand, error) {
 	var commands []clientCommand
 	firstByte := msgBytes[0]
 	switch firstByte {
@@ -239,12 +239,12 @@ func getCommandsFromClientMessage(msgBytes []byte) ([]clientCommand, error) {
 	return commands, nil
 }
 
-func (c *client) handleMessage(msg []byte) error {
+func (c *client) message(msg []byte) error {
 	if len(msg) == 0 {
 		logger.ERROR.Println("empty client message received")
 		return ErrInvalidClientMessage
 	}
-	commands, err := getCommandsFromClientMessage(msg)
+	commands, err := cmdFromClientMsg(msg)
 	if err != nil {
 		return err
 	}
@@ -259,7 +259,7 @@ func (c *client) handleCommands(commands []clientCommand) error {
 	var err error
 	var mr multiResponse
 	for _, command := range commands {
-		resp, err := c.handleCommand(command)
+		resp, err := c.handleCmd(command)
 		if err != nil {
 			return err
 		}
@@ -269,12 +269,12 @@ func (c *client) handleCommands(commands []clientCommand) error {
 	if err != nil {
 		return err
 	}
-	err = c.session.Send(string(jsonResp))
+	err = c.ses.Send(string(jsonResp))
 	return err
 }
 
 // handleCommand dispatches clientCommand into correct command handler
-func (c *client) handleCommand(command clientCommand) (*response, error) {
+func (c *client) handleCmd(command clientCommand) (*response, error) {
 
 	var err error
 	var resp *response
@@ -282,7 +282,7 @@ func (c *client) handleCommand(command clientCommand) (*response, error) {
 	method := command.Method
 	params := command.Params
 
-	if method != "connect" && !c.isAuthenticated {
+	if method != "connect" && !c.authenticated {
 		return nil, ErrUnauthorized
 	}
 
@@ -293,51 +293,51 @@ func (c *client) handleCommand(command clientCommand) (*response, error) {
 		if err != nil {
 			return nil, ErrInvalidClientMessage
 		}
-		resp, err = c.handleConnectCommand(&cmd)
+		resp, err = c.connectCmd(&cmd)
 	case "refresh":
 		var cmd refreshClientCommand
 		err = json.Unmarshal(params, &cmd)
 		if err != nil {
 			return nil, ErrInvalidClientMessage
 		}
-		resp, err = c.handleRefreshCommand(&cmd)
+		resp, err = c.refreshCmd(&cmd)
 	case "subscribe":
 		var cmd subscribeClientCommand
 		err = json.Unmarshal(params, &cmd)
 		if err != nil {
 			return nil, ErrInvalidClientMessage
 		}
-		resp, err = c.handleSubscribeCommand(&cmd)
+		resp, err = c.subscribeCmd(&cmd)
 	case "unsubscribe":
 		var cmd unsubscribeClientCommand
 		err = json.Unmarshal(params, &cmd)
 		if err != nil {
 			return nil, ErrInvalidClientMessage
 		}
-		resp, err = c.handleUnsubscribeCommand(&cmd)
+		resp, err = c.unsubscribeCmd(&cmd)
 	case "publish":
 		var cmd publishClientCommand
 		err = json.Unmarshal(params, &cmd)
 		if err != nil {
 			return nil, ErrInvalidClientMessage
 		}
-		resp, err = c.handlePublishCommand(&cmd)
+		resp, err = c.publishCmd(&cmd)
 	case "ping":
-		resp, err = c.handlePingCommand()
+		resp, err = c.pingCmd()
 	case "presence":
 		var cmd presenceClientCommand
 		err = json.Unmarshal(params, &cmd)
 		if err != nil {
 			return nil, ErrInvalidClientMessage
 		}
-		resp, err = c.handlePresenceCommand(&cmd)
+		resp, err = c.presenceCmd(&cmd)
 	case "history":
 		var cmd historyClientCommand
 		err = json.Unmarshal(params, &cmd)
 		if err != nil {
 			return nil, ErrInvalidClientMessage
 		}
-		resp, err = c.handleHistoryCommand(&cmd)
+		resp, err = c.historyCmd(&cmd)
 	default:
 		return nil, ErrMethodNotFound
 	}
@@ -348,10 +348,10 @@ func (c *client) handleCommand(command clientCommand) (*response, error) {
 	return resp, nil
 }
 
-// handlePingCommand handles ping command from client - this is necessary sometimes
+// pingCmd handles ping command from client - this is necessary sometimes
 // for example Heroku closes websocket connection after 55 seconds
 // of inactive period when no messages with payload travelled over wire
-func (c *client) handlePingCommand() (*response, error) {
+func (c *client) pingCmd() (*response, error) {
 	resp := newResponse("ping")
 	resp.Body = "pong"
 	return resp, nil
@@ -361,16 +361,16 @@ func (c *client) expire() {
 	c.Lock()
 	defer c.Unlock()
 
-	project, exists := c.app.getProjectByKey(c.project)
+	project, exists := c.app.projByKey(c.Project)
 	if !exists {
 		return
 	}
 
-	if project.ConnectionLifetime <= 0 {
+	if project.Lifetime <= 0 {
 		return
 	}
 
-	timeToExpire := c.timestamp + project.ConnectionLifetime - time.Now().Unix()
+	timeToExpire := c.timestamp + project.Lifetime - time.Now().Unix()
 	if timeToExpire > 0 {
 		// connection was succesfully refreshed
 		return
@@ -380,15 +380,15 @@ func (c *client) expire() {
 	return
 }
 
-// handleConnectCommand handles connect command from client - client must send this
+// connectCmd handles connect command from client - client must send this
 // command immediately after establishing Websocket or SockJS connection with
 // Centrifugo
-func (c *client) handleConnectCommand(cmd *connectClientCommand) (*response, error) {
+func (c *client) connectCmd(cmd *connectClientCommand) (*response, error) {
 
 	resp := newResponse("connect")
 
-	if c.isAuthenticated {
-		resp.Body = c.uid
+	if c.authenticated {
+		resp.Body = c.Uid
 		return resp, nil
 	}
 
@@ -406,7 +406,7 @@ func (c *client) handleConnectCommand(cmd *connectClientCommand) (*response, err
 		token = ""
 	}
 
-	project, exists := c.app.getProjectByKey(projectKey)
+	project, exists := c.app.projByKey(projectKey)
 	if !exists {
 		return nil, ErrProjectNotFound
 	}
@@ -430,13 +430,13 @@ func (c *client) handleConnectCommand(cmd *connectClientCommand) (*response, err
 		c.timestamp = time.Now().Unix()
 	}
 
-	c.user = user
-	c.project = projectKey
+	c.User = user
+	c.Project = projectKey
 
 	var ttl interface{}
 	var timeToExpire int64 = 0
 	ttl = nil
-	connectionLifetime := project.ConnectionLifetime
+	connectionLifetime := project.Lifetime
 	if connectionLifetime > 0 && !c.app.config.insecure {
 		ttl = connectionLifetime
 		timeToExpire := c.timestamp + connectionLifetime - time.Now().Unix()
@@ -451,14 +451,14 @@ func (c *client) handleConnectCommand(cmd *connectClientCommand) (*response, err
 		}
 	}
 
-	c.isAuthenticated = true
-	c.info = []byte(info)
-	c.channels = map[string]bool{}
+	c.authenticated = true
+	c.Info = []byte(info)
+	c.Channels = map[string]bool{}
 	c.channelInfo = map[string][]byte{}
 
 	go c.presencePing()
 
-	err := c.app.addConnection(c)
+	err := c.app.addConn(c)
 	if err != nil {
 		logger.ERROR.Println(err)
 		return nil, ErrInternalServerError
@@ -470,7 +470,7 @@ func (c *client) handleConnectCommand(cmd *connectClientCommand) (*response, err
 	}
 
 	body := map[string]interface{}{
-		"client":  c.uid,
+		"client":  c.Uid,
 		"expired": false,
 		"ttl":     ttl,
 	}
@@ -478,9 +478,9 @@ func (c *client) handleConnectCommand(cmd *connectClientCommand) (*response, err
 	return resp, nil
 }
 
-// handleRefreshCommand handle refresh command to update connection with new
+// refreshCmd handle refresh command to update connection with new
 // timestamp - this is only required when connection lifetime project option set.
-func (c *client) handleRefreshCommand(cmd *refreshClientCommand) (*response, error) {
+func (c *client) refreshCmd(cmd *refreshClientCommand) (*response, error) {
 
 	resp := newResponse("refresh")
 
@@ -490,7 +490,7 @@ func (c *client) handleRefreshCommand(cmd *refreshClientCommand) (*response, err
 	timestamp := cmd.Timestamp
 	token := cmd.Token
 
-	project, exists := c.app.getProjectByKey(projectKey)
+	project, exists := c.app.projByKey(projectKey)
 	if !exists {
 		return nil, ErrProjectNotFound
 	}
@@ -509,7 +509,7 @@ func (c *client) handleRefreshCommand(cmd *refreshClientCommand) (*response, err
 
 	var ttl interface{}
 
-	connectionLifetime := project.ConnectionLifetime
+	connectionLifetime := project.Lifetime
 	if connectionLifetime <= 0 {
 		// connection check disabled
 		ttl = nil
@@ -518,7 +518,7 @@ func (c *client) handleRefreshCommand(cmd *refreshClientCommand) (*response, err
 		if timeToExpire > 0 {
 			// connection refreshed, update client timestamp and set new expiration timeout
 			c.timestamp = int64(ts)
-			c.info = []byte(info)
+			c.Info = []byte(info)
 			if c.expireTimer != nil {
 				c.expireTimer.Stop()
 			}
@@ -538,14 +538,14 @@ func (c *client) handleRefreshCommand(cmd *refreshClientCommand) (*response, err
 	return resp, nil
 }
 
-// handleSubscribeCommand handles subscribe command - clients send this when subscribe
+// subscribeCmd handles subscribe command - clients send this when subscribe
 // on channel, if channel if private then we must validate provided sign here before
 // actually subscribe client on channel
-func (c *client) handleSubscribeCommand(cmd *subscribeClientCommand) (*response, error) {
+func (c *client) subscribeCmd(cmd *subscribeClientCommand) (*response, error) {
 
 	resp := newResponse("subscribe")
 
-	project, exists := c.app.getProjectByKey(c.project)
+	project, exists := c.app.projByKey(c.Project)
 	if !exists {
 		return nil, ErrProjectNotFound
 	}
@@ -569,25 +569,25 @@ func (c *client) handleSubscribeCommand(cmd *subscribeClientCommand) (*response,
 	}
 	resp.Body = body
 
-	if !c.app.isUserAllowed(channel, c.user) {
+	if !c.app.userAllowed(channel, c.User) {
 		resp.Err(ErrPermissionDenied)
 		return resp, nil
 	}
 
-	chOpts := c.app.getChannelOptions(c.project, channel)
+	chOpts := c.app.channelOpts(c.Project, channel)
 	if chOpts == nil {
 		resp.Err(ErrNamespaceNotFound)
 		return resp, nil
 	}
 
-	if !chOpts.Anonymous && c.user == "" && !c.app.config.insecure {
+	if !chOpts.Anonymous && c.User == "" && !c.app.config.insecure {
 		resp.Err(ErrPermissionDenied)
 		return resp, nil
 	}
 
-	if c.app.isPrivateChannel(channel) {
+	if c.app.privateCh(channel) {
 		// private channel - subscription must be properly signed
-		if c.uid != cmd.Client {
+		if c.Uid != cmd.Client {
 			resp.Err(ErrPermissionDenied)
 			return resp, nil
 		}
@@ -599,18 +599,18 @@ func (c *client) handleSubscribeCommand(cmd *subscribeClientCommand) (*response,
 		c.channelInfo[channel] = []byte(cmd.Info)
 	}
 
-	err := c.app.addSubscription(c.project, channel, c)
+	err := c.app.addSub(c.Project, channel, c)
 	if err != nil {
 		logger.ERROR.Println(err)
 		return resp, ErrInternalServerError
 	}
 
-	c.channels[channel] = true
+	c.Channels[channel] = true
 
-	info := c.getInfo(channel)
+	info := c.info(channel)
 
 	if chOpts.Presence {
-		err = c.app.addPresence(c.project, channel, c.uid, info)
+		err = c.app.addPresence(c.Project, channel, c.Uid, info)
 		if err != nil {
 			logger.ERROR.Println(err)
 			return nil, ErrInternalServerError
@@ -618,7 +618,7 @@ func (c *client) handleSubscribeCommand(cmd *subscribeClientCommand) (*response,
 	}
 
 	if chOpts.JoinLeave {
-		err = c.app.publishJoinLeaveMessage(c.project, channel, "join", info)
+		err = c.app.pubJoinLeave(c.Project, channel, "join", info)
 		if err != nil {
 			logger.ERROR.Println(err)
 		}
@@ -627,9 +627,9 @@ func (c *client) handleSubscribeCommand(cmd *subscribeClientCommand) (*response,
 	return resp, nil
 }
 
-// handleUnsubscribeCommand handles unsubscribe command from client - it allows to
+// unsubscribeCmd handles unsubscribe command from client - it allows to
 // unsubscribe connection from channel
-func (c *client) handleUnsubscribeCommand(cmd *unsubscribeClientCommand) (*response, error) {
+func (c *client) unsubscribeCmd(cmd *unsubscribeClientCommand) (*response, error) {
 
 	resp := newResponse("unsubscribe")
 
@@ -643,30 +643,30 @@ func (c *client) handleUnsubscribeCommand(cmd *unsubscribeClientCommand) (*respo
 	}
 	resp.Body = body
 
-	chOpts := c.app.getChannelOptions(c.project, channel)
+	chOpts := c.app.channelOpts(c.Project, channel)
 	if chOpts == nil {
 		resp.Err(ErrNamespaceNotFound)
 		return resp, nil
 	}
 
-	err := c.app.removeSubscription(c.project, channel, c)
+	err := c.app.removeSub(c.Project, channel, c)
 	if err != nil {
 		logger.ERROR.Println(err)
 		return resp, ErrInternalServerError
 	}
 
-	_, ok := c.channels[channel]
+	_, ok := c.Channels[channel]
 	if ok {
 
-		delete(c.channels, channel)
+		delete(c.Channels, channel)
 
-		err = c.app.removePresence(c.project, channel, c.uid)
+		err = c.app.removePresence(c.Project, channel, c.Uid)
 		if err != nil {
 			logger.ERROR.Println(err)
 		}
 
 		if chOpts.JoinLeave {
-			err = c.app.publishJoinLeaveMessage(c.project, channel, "leave", c.getInfo(channel))
+			err = c.app.pubJoinLeave(c.Project, channel, "leave", c.info(channel))
 			if err != nil {
 				logger.ERROR.Println(err)
 			}
@@ -676,15 +676,15 @@ func (c *client) handleUnsubscribeCommand(cmd *unsubscribeClientCommand) (*respo
 	return resp, nil
 }
 
-// handlePublishCommand handles publish command - clients can publish messages into
+// publishCmd handles publish command - clients can publish messages into
 // channels themselves if `publish` allowed by channel options. In most cases clients not
 // allowed to publish into channels directly - web application publishes messages
 // itself via HTTP API or Redis.
-func (c *client) handlePublishCommand(cmd *publishClientCommand) (*response, error) {
+func (c *client) publishCmd(cmd *publishClientCommand) (*response, error) {
 
 	resp := newResponse("publish")
 
-	project, exists := c.app.getProjectByKey(c.project)
+	project, exists := c.app.projByKey(c.Project)
 	if !exists {
 		return nil, ErrProjectNotFound
 	}
@@ -703,12 +703,12 @@ func (c *client) handlePublishCommand(cmd *publishClientCommand) (*response, err
 	}
 	resp.Body = body
 
-	if _, ok := c.channels[channel]; !ok {
+	if _, ok := c.Channels[channel]; !ok {
 		resp.Err(ErrPermissionDenied)
 		return resp, nil
 	}
 
-	chOpts := c.app.getChannelOptions(c.project, channel)
+	chOpts := c.app.channelOpts(c.Project, channel)
 	if chOpts == nil {
 		resp.Err(ErrNamespaceNotFound)
 		return resp, nil
@@ -719,9 +719,9 @@ func (c *client) handlePublishCommand(cmd *publishClientCommand) (*response, err
 		return resp, nil
 	}
 
-	info := c.getInfo(channel)
+	info := c.info(channel)
 
-	err := c.app.publishClientMessage(project, channel, chOpts, data, &info)
+	err := c.app.pubClient(project, channel, chOpts, data, &info)
 	if err != nil {
 		logger.ERROR.Println(err)
 		resp.Err(ErrInternalServerError)
@@ -735,11 +735,11 @@ func (c *client) handlePublishCommand(cmd *publishClientCommand) (*response, err
 	return resp, nil
 }
 
-// handlePresenceCommand handles presence command - it shows which clients
+// presenceCmd handles presence command - it shows which clients
 // are subscribed on channel at this moment. This method also checks if
 // presence information turned on for channel (based on channel options
 // for namespace or project)
-func (c *client) handlePresenceCommand(cmd *presenceClientCommand) (*response, error) {
+func (c *client) presenceCmd(cmd *presenceClientCommand) (*response, error) {
 
 	resp := newResponse("presence")
 
@@ -756,7 +756,7 @@ func (c *client) handlePresenceCommand(cmd *presenceClientCommand) (*response, e
 
 	resp.Body = body
 
-	chOpts := c.app.getChannelOptions(c.project, channel)
+	chOpts := c.app.channelOpts(c.Project, channel)
 	if chOpts == nil {
 		resp.Err(ErrNamespaceNotFound)
 		return resp, nil
@@ -767,7 +767,7 @@ func (c *client) handlePresenceCommand(cmd *presenceClientCommand) (*response, e
 		return resp, nil
 	}
 
-	data, err := c.app.getPresence(c.project, channel)
+	data, err := c.app.presence(c.Project, channel)
 	if err != nil {
 		logger.ERROR.Println(err)
 		resp.Err(ErrInternalServerError)
@@ -781,11 +781,11 @@ func (c *client) handlePresenceCommand(cmd *presenceClientCommand) (*response, e
 	return resp, nil
 }
 
-// handleHistoryCommand handles history command - it shows last M messages published
+// historyCmd handles history command - it shows last M messages published
 // into channel. M is history size and can be configured for project or namespace
 // via channel options. Also this method checks that history available for channel
 // (also determined by channel options flag)
-func (c *client) handleHistoryCommand(cmd *historyClientCommand) (*response, error) {
+func (c *client) historyCmd(cmd *historyClientCommand) (*response, error) {
 
 	resp := newResponse("history")
 
@@ -802,7 +802,7 @@ func (c *client) handleHistoryCommand(cmd *historyClientCommand) (*response, err
 
 	resp.Body = body
 
-	chOpts := c.app.getChannelOptions(c.project, channel)
+	chOpts := c.app.channelOpts(c.Project, channel)
 	if chOpts == nil {
 		resp.Err(ErrNamespaceNotFound)
 		return resp, nil
@@ -813,7 +813,7 @@ func (c *client) handleHistoryCommand(cmd *historyClientCommand) (*response, err
 		return resp, nil
 	}
 
-	data, err := c.app.getHistory(c.project, channel)
+	data, err := c.app.history(c.Project, channel)
 	if err != nil {
 		resp.Err(ErrInternalServerError)
 		return resp, nil

--- a/libcentrifugo/config.go
+++ b/libcentrifugo/config.go
@@ -223,7 +223,7 @@ func getGlobalProject(v *viper.Viper) (*project, bool) {
 		}
 		p.Name = viper.GetString("project_name")
 		p.Secret = viper.GetString("project_secret")
-		p.ConnectionLifetime = int64(viper.GetInt("project_connection_lifetime"))
+		p.Lifetime = int64(viper.GetInt("project_connection_lifetime"))
 		p.Anonymous = viper.GetBool("project_anonymous")
 		p.Watch = viper.GetBool("project_watch")
 		p.Publish = viper.GetBool("project_publish")
@@ -237,7 +237,7 @@ func getGlobalProject(v *viper.Viper) (*project, bool) {
 		}
 		p.Name = v.GetString("project_name")
 		p.Secret = v.GetString("project_secret")
-		p.ConnectionLifetime = int64(v.GetInt("project_connection_lifetime"))
+		p.Lifetime = int64(v.GetInt("project_connection_lifetime"))
 		p.Anonymous = v.GetBool("project_anonymous")
 		p.Watch = v.GetBool("project_watch")
 		p.Publish = v.GetBool("project_publish")

--- a/libcentrifugo/config.go
+++ b/libcentrifugo/config.go
@@ -223,7 +223,7 @@ func getGlobalProject(v *viper.Viper) (*project, bool) {
 		}
 		p.Name = viper.GetString("project_name")
 		p.Secret = viper.GetString("project_secret")
-		p.Lifetime = int64(viper.GetInt("project_connection_lifetime"))
+		p.ConnLifetime = int64(viper.GetInt("project_connection_lifetime"))
 		p.Anonymous = viper.GetBool("project_anonymous")
 		p.Watch = viper.GetBool("project_watch")
 		p.Publish = viper.GetBool("project_publish")
@@ -237,7 +237,7 @@ func getGlobalProject(v *viper.Viper) (*project, bool) {
 		}
 		p.Name = v.GetString("project_name")
 		p.Secret = v.GetString("project_secret")
-		p.Lifetime = int64(v.GetInt("project_connection_lifetime"))
+		p.ConnLifetime = int64(v.GetInt("project_connection_lifetime"))
 		p.Anonymous = v.GetBool("project_anonymous")
 		p.Watch = v.GetBool("project_watch")
 		p.Publish = v.GetBool("project_publish")

--- a/libcentrifugo/connections.go
+++ b/libcentrifugo/connections.go
@@ -2,15 +2,15 @@ package libcentrifugo
 
 // clientConnection is an interface abstracting all methods used
 // by application to interact with client connection
-type clientConnection interface {
-	// getUid returns unique connection id
-	getUid() string
-	// getProject returns connection project key
-	getProject() string
-	// getUser return user ID associated with connection
-	getUser() string
-	// getChannels returns a slice of channels connection subscribed to
-	getChannels() []string
+type clientConn interface {
+	// uid returns unique connection id
+	uid() string
+	// project returns connection project key
+	project() string
+	// user return user ID associated with connection
+	user() string
+	// channels returns a slice of channels connection subscribed to
+	channels() []string
 	// send allows to send message to connection client
 	send(message string) error
 	// unsubscribe allows to unsubscribe connection from channel
@@ -21,9 +21,9 @@ type clientConnection interface {
 
 // adminConnection is an interface abstracting all methods used
 // by application to interact with admin connection
-type adminConnection interface {
-	// getUid returns unique admin connection id
-	getUid() string
+type adminConn interface {
+	// uid returns unique admin connection id
+	uid() string
 	// send allows to send message to admin
 	send(message string) error
 }

--- a/libcentrifugo/engine.go
+++ b/libcentrifugo/engine.go
@@ -5,7 +5,7 @@ package libcentrifugo
 // presence and history data
 type engine interface {
 	// getName returns a name of concrete engine implementation
-	getName() string
+	name() string
 
 	// initialize provides a way to make additional engine startup work
 	initialize() error
@@ -23,10 +23,10 @@ type engine interface {
 	// removePresence removes presence information for connection with uid
 	removePresence(channel, uid string) error
 	// getPresence returns actual presence information for channel
-	getPresence(channel string) (map[string]ClientInfo, error)
+	presence(channel string) (map[string]ClientInfo, error)
 
 	// addHistoryMessage adds message into channel history and takes care about history size
 	addHistoryMessage(channel string, message Message, size, lifetime int64) error
 	// getHistory returns history messages for channel
-	getHistory(channel string) ([]Message, error)
+	history(channel string) ([]Message, error)
 }

--- a/libcentrifugo/enginememory.go
+++ b/libcentrifugo/enginememory.go
@@ -25,7 +25,7 @@ func newMemoryEngine(app *application) *memoryEngine {
 	}
 }
 
-func (e *memoryEngine) getName() string {
+func (e *memoryEngine) name() string {
 	return "In memory – single node only"
 }
 
@@ -35,7 +35,7 @@ func (e *memoryEngine) initialize() error {
 }
 
 func (e *memoryEngine) publish(channel string, message []byte) error {
-	return e.app.handleMessage(channel, message)
+	return e.app.handleMsg(channel, message)
 }
 
 func (e *memoryEngine) subscribe(channel string) error {
@@ -54,7 +54,7 @@ func (e *memoryEngine) removePresence(channel, uid string) error {
 	return e.presenceHub.remove(channel, uid)
 }
 
-func (e *memoryEngine) getPresence(channel string) (map[string]ClientInfo, error) {
+func (e *memoryEngine) presence(channel string) (map[string]ClientInfo, error) {
 	return e.presenceHub.get(channel)
 }
 
@@ -62,7 +62,7 @@ func (e *memoryEngine) addHistoryMessage(channel string, message Message, size, 
 	return e.historyHub.add(channel, message, size, lifetime)
 }
 
-func (e *memoryEngine) getHistory(channel string) ([]Message, error) {
+func (e *memoryEngine) history(channel string) ([]Message, error) {
 	return e.historyHub.get(channel)
 }
 

--- a/libcentrifugo/engineredis.go
+++ b/libcentrifugo/engineredis.go
@@ -88,7 +88,7 @@ func newPool(server, password, db string) *redis.Pool {
 	}
 }
 
-func (e *redisEngine) getName() string {
+func (e *redisEngine) name() string {
 	return "Redis"
 }
 
@@ -147,14 +147,14 @@ func (e *redisEngine) initializeApi() {
 			logger.ERROR.Println(err)
 			continue
 		}
-		project, exists := e.app.getProjectByKey(req.Project)
+		project, exists := e.app.projByKey(req.Project)
 		if !exists {
 			logger.ERROR.Println("no project found with key", req.Project)
 			continue
 		}
 
 		for _, command := range req.Data {
-			_, err := e.app.handleApiCommand(project, command)
+			_, err := e.app.apiCmd(project, command)
 			if err != nil {
 				logger.ERROR.Println(err)
 			}
@@ -179,7 +179,7 @@ func (e *redisEngine) initializePubSub() {
 		e.psc.Close()
 		return
 	}
-	for _, channel := range e.app.clientSubscriptionHub.getChannels() {
+	for _, channel := range e.app.subs.channels() {
 		err = e.psc.Subscribe(channel)
 		if err != nil {
 			e.psc.Close()
@@ -189,7 +189,7 @@ func (e *redisEngine) initializePubSub() {
 	for {
 		switch n := e.psc.Receive().(type) {
 		case redis.Message:
-			e.app.handleMessage(n.Channel, n.Data)
+			e.app.handleMsg(n.Channel, n.Data)
 		case redis.Subscription:
 		case error:
 			logger.ERROR.Printf("error: %v\n", n)
@@ -300,7 +300,7 @@ func mapStringClientInfo(result interface{}, err error) (map[string]ClientInfo, 
 	return m, nil
 }
 
-func (e *redisEngine) getPresence(channel string) (map[string]ClientInfo, error) {
+func (e *redisEngine) presence(channel string) (map[string]ClientInfo, error) {
 	conn := e.pool.Get()
 	defer conn.Close()
 	now := time.Now().Unix()
@@ -371,7 +371,7 @@ func sliceOfMessages(result interface{}, err error) ([]Message, error) {
 	return msgs, nil
 }
 
-func (e *redisEngine) getHistory(channel string) ([]Message, error) {
+func (e *redisEngine) history(channel string) ([]Message, error) {
 	conn := e.pool.Get()
 	defer conn.Close()
 	historyKey := e.getHistoryKey(channel)

--- a/libcentrifugo/engineredis.go
+++ b/libcentrifugo/engineredis.go
@@ -147,7 +147,7 @@ func (e *redisEngine) initializeApi() {
 			logger.ERROR.Println(err)
 			continue
 		}
-		project, exists := e.app.projByKey(req.Project)
+		project, exists := e.app.projectByKey(req.Project)
 		if !exists {
 			logger.ERROR.Println("no project found with key", req.Project)
 			continue

--- a/libcentrifugo/handlers.go
+++ b/libcentrifugo/handlers.go
@@ -31,13 +31,13 @@ func (app *application) sockJSHandler(s sockjs.Session) {
 	defer func() {
 		c.clean()
 	}()
-	logger.INFO.Printf("new SockJS session established with uid %s\n", c.getUid())
+	logger.INFO.Printf("new SockJS session established with uid %s\n", c.uid())
 
 	go c.sendMessages()
 
 	for {
 		if msg, err := s.Recv(); err == nil {
-			err = c.handleMessage([]byte(msg))
+			err = c.message([]byte(msg))
 			if err != nil {
 				logger.ERROR.Println(err)
 				s.Close(3000, err.Error())
@@ -49,12 +49,12 @@ func (app *application) sockJSHandler(s sockjs.Session) {
 	}
 }
 
-type wsConnection struct {
+type wsConn struct {
 	ws        *websocket.Conn
 	writeChan chan []byte // buffered channel of outbound messages.
 }
 
-func (conn wsConnection) Send(message string) error {
+func (conn wsConn) Send(message string) error {
 
 	select {
 	case conn.writeChan <- []byte(message):
@@ -64,12 +64,12 @@ func (conn wsConnection) Send(message string) error {
 	return nil
 }
 
-func (conn wsConnection) Close(status uint32, reason string) error {
+func (conn wsConn) Close(status uint32, reason string) error {
 	return conn.ws.Close()
 }
 
 // writer reads from channel and sends received messages into connection
-func (conn *wsConnection) writer(closeChan chan struct{}) {
+func (conn *wsConn) writer(closeChan chan struct{}) {
 	for {
 		select {
 		case message := <-conn.writeChan:
@@ -95,7 +95,7 @@ func (app *application) rawWebsocketHandler(w http.ResponseWriter, r *http.Reque
 	}
 	defer ws.Close()
 
-	conn := wsConnection{
+	conn := wsConn{
 		ws:        ws,
 		writeChan: make(chan []byte, 256),
 	}
@@ -104,7 +104,7 @@ func (app *application) rawWebsocketHandler(w http.ResponseWriter, r *http.Reque
 	if err != nil {
 		return
 	}
-	logger.INFO.Printf("new raw Websocket session established with uid %s\n", c.getUid())
+	logger.INFO.Printf("new raw Websocket session established with uid %s\n", c.uid())
 	defer func() {
 		c.clean()
 	}()
@@ -118,7 +118,7 @@ func (app *application) rawWebsocketHandler(w http.ResponseWriter, r *http.Reque
 		if err != nil {
 			break
 		}
-		err = c.handleMessage(message)
+		err = c.message(message)
 		if err != nil {
 			logger.ERROR.Println(err)
 			conn.ws.Close()
@@ -132,7 +132,7 @@ var (
 	objectJsonPrefix byte = '{'
 )
 
-func getCommandsFromApiMessage(msgBytes []byte) ([]apiCommand, error) {
+func msgToCommands(msgBytes []byte) ([]apiCommand, error) {
 	var commands []apiCommand
 
 	firstByte := msgBytes[0]
@@ -201,7 +201,7 @@ func (app *application) apiHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	project, exists := app.getProjectByKey(projectKey)
+	project, exists := app.projByKey(projectKey)
 	if !exists {
 		logger.ERROR.Println("no project found with key", projectKey)
 		http.Error(w, "Project not found", http.StatusNotFound)
@@ -219,7 +219,7 @@ func (app *application) apiHandler(w http.ResponseWriter, r *http.Request) {
 
 	msgBytes := []byte(encodedData)
 
-	commands, err := getCommandsFromApiMessage(msgBytes)
+	commands, err := msgToCommands(msgBytes)
 	if err != nil {
 		logger.ERROR.Println(err)
 		http.Error(w, "Bad Request", http.StatusBadRequest)
@@ -229,7 +229,7 @@ func (app *application) apiHandler(w http.ResponseWriter, r *http.Request) {
 	var mr multiResponse
 
 	for _, command := range commands {
-		resp, err := app.handleApiCommand(project, command)
+		resp, err := app.apiCmd(project, command)
 		if err != nil {
 			logger.ERROR.Println(err)
 			http.Error(w, "Bad Request", http.StatusBadRequest)
@@ -308,14 +308,14 @@ func (app *application) Logged(h http.Handler) http.Handler {
 }
 
 func (app *application) infoHandler(w http.ResponseWriter, r *http.Request) {
-	app.nodesMutex.Lock()
-	defer app.nodesMutex.Unlock()
+	app.nodesMu.Lock()
+	defer app.nodesMu.Unlock()
 	app.RLock()
 	defer app.RUnlock()
 	info := map[string]interface{}{
 		"version":   VERSION,
 		"structure": app.structure.ProjectList,
-		"engine":    app.engine.getName(),
+		"engine":    app.engine.name(),
 		"node_name": app.config.name,
 		"nodes":     app.nodes,
 	}
@@ -327,7 +327,7 @@ func (app *application) actionHandler(w http.ResponseWriter, r *http.Request) {
 	projectKey := r.FormValue("project")
 	method := r.FormValue("method")
 
-	project, exists := app.getProjectByKey(projectKey)
+	project, exists := app.projByKey(projectKey)
 	if !exists {
 		http.Error(w, "Bad Request", http.StatusBadRequest)
 		return
@@ -348,7 +348,7 @@ func (app *application) actionHandler(w http.ResponseWriter, r *http.Request) {
 			Channel: channel,
 			Data:    []byte(data),
 		}
-		resp, err = app.handlePublishCommand(project, cmd)
+		resp, err = app.publishCmd(project, cmd)
 	case "unsubscribe":
 		channel := r.FormValue("channel")
 		user := r.FormValue("user")
@@ -356,25 +356,25 @@ func (app *application) actionHandler(w http.ResponseWriter, r *http.Request) {
 			Channel: channel,
 			User:    user,
 		}
-		resp, err = app.handleUnsubscribeCommand(project, cmd)
+		resp, err = app.unsubcribeCmd(project, cmd)
 	case "disconnect":
 		user := r.FormValue("user")
 		cmd := &disconnectApiCommand{
 			User: user,
 		}
-		resp, err = app.handleDisconnectCommand(project, cmd)
+		resp, err = app.disconnectCmd(project, cmd)
 	case "presence":
 		channel := r.FormValue("channel")
 		cmd := &presenceApiCommand{
 			Channel: channel,
 		}
-		resp, err = app.handlePresenceCommand(project, cmd)
+		resp, err = app.presenceCmd(project, cmd)
 	case "history":
 		channel := r.FormValue("channel")
 		cmd := &historyApiCommand{
 			Channel: channel,
 		}
-		resp, err = app.handleHistoryCommand(project, cmd)
+		resp, err = app.historyCmd(project, cmd)
 	}
 
 	if err != nil {
@@ -399,10 +399,10 @@ func (app *application) adminWebsocketHandler(w http.ResponseWriter, r *http.Req
 	if err != nil {
 		return
 	}
-	logger.INFO.Printf("new admin session established with uid %s\n", c.getUid())
+	logger.INFO.Printf("new admin session established with uid %s\n", c.uid())
 	defer func() {
 		close(c.closeChan)
-		err := app.removeAdminConnection(c)
+		err := app.removeAdminConn(c)
 		if err != nil {
 			logger.ERROR.Println(err)
 		}

--- a/libcentrifugo/handlers.go
+++ b/libcentrifugo/handlers.go
@@ -201,7 +201,7 @@ func (app *application) apiHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	project, exists := app.projByKey(projectKey)
+	project, exists := app.projectByKey(projectKey)
 	if !exists {
 		logger.ERROR.Println("no project found with key", projectKey)
 		http.Error(w, "Project not found", http.StatusNotFound)
@@ -327,7 +327,7 @@ func (app *application) actionHandler(w http.ResponseWriter, r *http.Request) {
 	projectKey := r.FormValue("project")
 	method := r.FormValue("method")
 
-	project, exists := app.projByKey(projectKey)
+	project, exists := app.projectByKey(projectKey)
 	if !exists {
 		http.Error(w, "Bad Request", http.StatusBadRequest)
 		return

--- a/libcentrifugo/hubs_test.go
+++ b/libcentrifugo/hubs_test.go
@@ -8,19 +8,19 @@ import (
 
 type testClientConnection struct{}
 
-func (c *testClientConnection) getUid() string {
+func (c *testClientConnection) uid() string {
 	return "test uid"
 }
 
-func (c *testClientConnection) getProject() string {
+func (c *testClientConnection) project() string {
 	return "test project"
 }
 
-func (c *testClientConnection) getUser() string {
+func (c *testClientConnection) user() string {
 	return "test user"
 }
 
-func (c *testClientConnection) getChannels() []string {
+func (c *testClientConnection) channels() []string {
 	return []string{"test"}
 }
 
@@ -37,21 +37,21 @@ func (c *testClientConnection) close(reason string) error {
 }
 
 func TestClientConnectionHub(t *testing.T) {
-	h := newClientConnectionHub()
+	h := newClientHub()
 	c := &testClientConnection{}
 	h.add(c)
 	assert.Equal(t, len(h.connections), 1)
-	conns := h.getUserConnections("test project", "test user")
+	conns := h.userConnections("test project", "test user")
 	assert.Equal(t, 1, len(conns))
-	assert.Equal(t, 1, h.getClientsCount())
-	assert.Equal(t, 1, h.getUniqueClientsCount())
+	assert.Equal(t, 1, h.nClients())
+	assert.Equal(t, 1, h.nUniqueClients())
 	h.remove(c)
 	assert.Equal(t, len(h.connections), 0)
 	assert.Equal(t, 1, len(conns))
 }
 
-func getTestClientSubscriptionHub() *clientSubscriptionHub {
-	return newClientSubscriptionHub()
+func getTestClientSubscriptionHub() *subHub {
+	return newSubHub()
 }
 
 func TestClientSubscriptionHub(t *testing.T) {
@@ -59,8 +59,8 @@ func TestClientSubscriptionHub(t *testing.T) {
 	c := &testClientConnection{}
 	h.add("test1", c)
 	h.add("test2", c)
-	assert.Equal(t, 2, h.getChannelsCount())
-	channels := h.getChannels()
+	assert.Equal(t, 2, h.nChannels())
+	channels := h.channels()
 	assert.Equal(t, stringInSlice("test1", channels), true)
 	assert.Equal(t, stringInSlice("test2", channels), true)
 	err := h.broadcast("test1", "message")

--- a/libcentrifugo/structure.go
+++ b/libcentrifugo/structure.go
@@ -42,7 +42,7 @@ type project struct {
 	Secret string `json:"secret"`
 
 	// ConnectionLifetime determines time until connection expire, 0 means no connection expire at all
-	ConnectionLifetime int64 `mapstructure:"connection_lifetime" json:"connection_lifetime"`
+	Lifetime int64 `mapstructure:"connection_lifetime" json:"connection_lifetime"`
 
 	// Namespaces - list of namespaces for project for custom channel options
 	Namespaces []namespace `json:"namespaces"`
@@ -135,7 +135,7 @@ func (s *structure) validate() error {
 }
 
 // getProjectByKey searches for a project with specified key in structure
-func (s *structure) getProjectByKey(projectKey string) (*project, bool) {
+func (s *structure) projByKey(projectKey string) (*project, bool) {
 	project, ok := s.ProjectMap[projectKey]
 	if !ok {
 		return nil, false
@@ -144,8 +144,8 @@ func (s *structure) getProjectByKey(projectKey string) (*project, bool) {
 }
 
 // getChannelOptions searches for channel options for specified project and namespace
-func (s *structure) getChannelOptions(projectKey, namespaceName string) *ChannelOptions {
-	project, exists := s.getProjectByKey(projectKey)
+func (s *structure) channelOpts(projectKey, namespaceName string) *ChannelOptions {
+	project, exists := s.projByKey(projectKey)
 	if !exists {
 		return nil
 	}

--- a/libcentrifugo/structure.go
+++ b/libcentrifugo/structure.go
@@ -41,8 +41,8 @@ type project struct {
 	// Secret is a secret key for project, used to sign API requests and client connection tokens
 	Secret string `json:"secret"`
 
-	// ConnectionLifetime determines time until connection expire, 0 means no connection expire at all
-	Lifetime int64 `mapstructure:"connection_lifetime" json:"connection_lifetime"`
+	// ConnLifetime determines time until connection expire, 0 means no connection expire at all
+	ConnLifetime int64 `mapstructure:"connection_lifetime" json:"connection_lifetime"`
 
 	// Namespaces - list of namespaces for project for custom channel options
 	Namespaces []namespace `json:"namespaces"`

--- a/libcentrifugo/structure_test.go
+++ b/libcentrifugo/structure_test.go
@@ -53,11 +53,11 @@ func TestStructureInitialize(t *testing.T) {
 func TestGetProjectByKey(t *testing.T) {
 	s := getTestStructure()
 	s.initialize()
-	_, found := s.getProjectByKey("test3")
+	_, found := s.projByKey("test3")
 	if found {
 		t.Error("found project that does not exist")
 	}
-	_, found = s.getProjectByKey("test2")
+	_, found = s.projByKey("test2")
 	if !found {
 		t.Error("project not found")
 	}
@@ -66,15 +66,15 @@ func TestGetProjectByKey(t *testing.T) {
 func TestGetChannelOptions(t *testing.T) {
 	s := getTestStructure()
 	s.initialize()
-	options := s.getChannelOptions("test1", "test")
+	options := s.channelOpts("test1", "test")
 	if options == nil {
 		t.Error("namespace channel options not found")
 	}
-	options = s.getChannelOptions("test1", "")
+	options = s.channelOpts("test1", "")
 	if options == nil {
 		t.Error("project channel options not found")
 	}
-	options = s.getChannelOptions("test1", "notexist")
+	options = s.channelOpts("test1", "notexist")
 	if options != nil {
 		t.Error("found channel options for namespace that does not exist")
 	}


### PR DESCRIPTION
I have gone through the project, and changed many of the names to a more go idiomatic form.

See for instance [What's in a name?](http://talks.golang.org/2014/names.slide#1). I guess a lot comes from the python heritage.

Most of what I have changed:
* Avoid 'get', 'set', 'handle' prefixes where it makes sense.
* Shorten a few types `Connection` -> `Conn`, `Command` -> `Cmd`, 
* Change some member variables to shorter versions.

I haven't done anything to local variables or exported functions.

I can see it no longer merges, but i can of course re-base if you don't object to the idea.
