### PR TITLE
Proposal for handling shutdowns.

### DIFF
--- a/libcentrifugo/admin.go
+++ b/libcentrifugo/admin.go
@@ -65,6 +65,11 @@ func (c *adminClient) writer() {
 	}
 }
 
+// TODO: Implement
+func (c *adminClient) flush() {
+	return
+}
+
 // handleMessage handles message received from admin connection
 func (c *adminClient) handleMessage(msg []byte) (*response, error) {
 

--- a/libcentrifugo/api.go
+++ b/libcentrifugo/api.go
@@ -170,8 +170,8 @@ func (app *application) presenceCmd(p *project, cmd *presenceApiCommand) (*respo
 		return nil, ErrInvalidApiMessage
 	}
 
-	body := map[string]interface{}{
-		"channel": channel,
+	body := &presenceBody{
+		Channel: channel,
 	}
 
 	resp.Body = body
@@ -193,10 +193,8 @@ func (app *application) presenceCmd(p *project, cmd *presenceApiCommand) (*respo
 		return resp, nil
 	}
 
-	resp.Body = map[string]interface{}{
-		"channel": channel,
-		"data":    presence,
-	}
+	body.Data = presence
+
 	return resp, nil
 }
 
@@ -212,8 +210,8 @@ func (app *application) historyCmd(p *project, cmd *historyApiCommand) (*respons
 		return nil, ErrInvalidApiMessage
 	}
 
-	body := map[string]interface{}{
-		"channel": channel,
+	body := &historyBody{
+		Channel: channel,
 	}
 
 	resp.Body = body
@@ -235,9 +233,7 @@ func (app *application) historyCmd(p *project, cmd *historyApiCommand) (*respons
 		return resp, nil
 	}
 
-	resp.Body = map[string]interface{}{
-		"channel": channel,
-		"data":    history,
-	}
+	body.Data = history
+
 	return resp, nil
 }

--- a/libcentrifugo/api.go
+++ b/libcentrifugo/api.go
@@ -115,13 +115,13 @@ func (app *application) unsubcribeCmd(p *project, cmd *unsubscribeApiCommand) (*
 		}
 	}
 
-	err := app.unsubUser(p.Name, user, channel)
+	err := app.unsubscribeUser(p.Name, user, channel)
 	if err != nil {
 		resp.Err(ErrInternalServerError)
 		return resp, nil
 	}
 
-	err = app.pubUnsub(p.Name, user, channel)
+	err = app.pubUnsubscribe(p.Name, user, channel)
 	if err != nil {
 		resp.Err(ErrInternalServerError)
 		return resp, nil

--- a/libcentrifugo/application.go
+++ b/libcentrifugo/application.go
@@ -270,9 +270,9 @@ func (app *application) pubClient(p *project, ch Channel, chOpts ChannelOptions,
 
 	if chOpts.Watch {
 		resp := newResponse("message")
-		resp.Body = map[string]interface{}{
-			"project": p.Name,
-			"message": message,
+		resp.Body = &adminMessageBody{
+			Project: p.Name,
+			Message: message,
 		}
 		messageBytes, err := json.Marshal(resp)
 		if err != nil {
@@ -315,9 +315,9 @@ func (app *application) pubClient(p *project, ch Channel, chOpts ChannelOptions,
 func (app *application) pubJoinLeave(pk ProjectKey, ch Channel, method string, info ClientInfo) error {
 	chID := app.channelID(pk, ch)
 	resp := newResponse(method)
-	resp.Body = map[string]interface{}{
-		"channel": ch,
-		"data":    info,
+	resp.Body = &joinLeaveBody{
+		Channel: ch,
+		Data:    info,
 	}
 	byteMessage, err := json.Marshal(resp)
 	if err != nil {

--- a/libcentrifugo/application_test.go
+++ b/libcentrifugo/application_test.go
@@ -29,8 +29,6 @@ func (app *application) newTestHandler(b *testing.B, s *testSession) *client {
 	if err != nil {
 		b.Fatal(err)
 	}
-	go c.sendMessages()
-
 	return c
 }
 

--- a/libcentrifugo/application_test.go
+++ b/libcentrifugo/application_test.go
@@ -49,3 +49,11 @@ func TestUserAllowed(t *testing.T) {
 	assert.Equal(t, true, app.userAllowed("channel#1,2", "2"))
 	assert.Equal(t, false, app.userAllowed("channel#1,2", "3"))
 }
+
+func TestNamespaceKey(t *testing.T) {
+	app := testApp()
+	assert.Equal(t, NamespaceKey("ns"), app.namespaceKey("ns:channel"))
+	assert.Equal(t, NamespaceKey(""), app.namespaceKey("channel"))
+	assert.Equal(t, NamespaceKey("ns"), app.namespaceKey("ns:channel:opa"))
+	assert.Equal(t, NamespaceKey("ns"), app.namespaceKey("ns::channel"))
+}

--- a/libcentrifugo/body.go
+++ b/libcentrifugo/body.go
@@ -21,9 +21,9 @@ type joinLeaveBody struct {
 }
 
 type connectBody struct {
-	Client  ConnID `json:"client"`
-	Expired bool   `json:"expired"`
-	TTL     *int64 `json:"ttl"`
+	Client  *ConnID `json:"client"`
+	Expired bool    `json:"expired"`
+	TTL     *int64  `json:"ttl"`
 }
 
 type refreshBody struct {

--- a/libcentrifugo/body.go
+++ b/libcentrifugo/body.go
@@ -1,0 +1,44 @@
+package libcentrifugo
+
+type presenceBody struct {
+	Channel Channel               `json:"channel"`
+	Data    map[ConnID]ClientInfo `json:"data"`
+}
+
+type historyBody struct {
+	Channel Channel   `json:"channel"`
+	Data    []Message `json:"data"`
+}
+
+type adminMessageBody struct {
+	Project ProjectKey `json:"project"`
+	Message Message    `json:"message"`
+}
+
+type joinLeaveBody struct {
+	Channel Channel    `json:"channel"`
+	Data    ClientInfo `json:"data"`
+}
+
+type connectBody struct {
+	Client  ConnID `json:"client"`
+	Expired bool   `json:"expired"`
+	TTL     *int64 `json:"ttl"`
+}
+
+type refreshBody struct {
+	TTL *int64 `json:"ttl"`
+}
+
+type subscribeBody struct {
+	Channel Channel `json:"channel"`
+}
+
+type unsubscribeBody struct {
+	Channel Channel `json:"channel"`
+}
+
+type publishBody struct {
+	Channel Channel `json:"channel"`
+	Status  bool    `json:"status"`
+}

--- a/libcentrifugo/centrifugo.go
+++ b/libcentrifugo/centrifugo.go
@@ -91,7 +91,7 @@ func Main() {
 			viper.SetDefault("max_channel_length", 255)
 			viper.SetDefault("channel_prefix", "centrifugo")
 			viper.SetDefault("node_ping_interval", 5)
-			viper.SetDefault("message_send_timeout", 10)
+			viper.SetDefault("message_send_timeout", 60)
 			viper.SetDefault("expired_connection_close_delay", 10)
 			viper.SetDefault("presence_ping_interval", 25)
 			viper.SetDefault("presence_expire_interval", 60)

--- a/libcentrifugo/centrifugo.go
+++ b/libcentrifugo/centrifugo.go
@@ -210,10 +210,10 @@ func Main() {
 			go handleSignals(app)
 
 			// register raw Websocket endpoint
-			http.Handle("/connection/websocket", app.Logged(shutdown.WrapHandler(http.HandlerFunc(app.rawWebsocketHandler))))
+			http.Handle("/connection/websocket", app.Logged(http.HandlerFunc(app.rawWebsocketHandler)))
 
 			// register SockJS endpoints
-			http.Handle("/connection/", app.Logged(shutdown.WrapHandler(newSockJSHandler(app, viper.GetString("sockjs_url")))))
+			http.Handle("/connection/", app.Logged(newSockJSHandler(app, viper.GetString("sockjs_url"))))
 
 			// register HTTP API endpoint
 			http.Handle("/api/", app.Logged(shutdown.WrapHandler(http.HandlerFunc(app.apiHandler))))

--- a/libcentrifugo/centrifugo.go
+++ b/libcentrifugo/centrifugo.go
@@ -10,6 +10,7 @@ import (
 	"syscall"
 
 	"github.com/centrifugal/centrifugo/libcentrifugo/logger"
+	"github.com/klauspost/shutdown"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -205,27 +206,28 @@ func Main() {
 
 			app.run()
 
+			shutdown.OnSignal(0, os.Interrupt, syscall.SIGTERM)
 			go handleSignals(app)
 
 			// register raw Websocket endpoint
-			http.Handle("/connection/websocket", app.Logged(http.HandlerFunc(app.rawWebsocketHandler)))
+			http.Handle("/connection/websocket", app.Logged(shutdown.WrapHandler(http.HandlerFunc(app.rawWebsocketHandler))))
 
 			// register SockJS endpoints
-			http.Handle("/connection/", app.Logged(newSockJSHandler(app, viper.GetString("sockjs_url"))))
+			http.Handle("/connection/", app.Logged(shutdown.WrapHandler(newSockJSHandler(app, viper.GetString("sockjs_url")))))
 
 			// register HTTP API endpoint
-			http.Handle("/api/", app.Logged(http.HandlerFunc(app.apiHandler)))
+			http.Handle("/api/", app.Logged(shutdown.WrapHandler(http.HandlerFunc(app.apiHandler))))
 
 			// register admin web interface API endpoints
-			http.Handle("/auth/", app.Logged(http.HandlerFunc(app.authHandler)))
-			http.Handle("/info/", app.Logged(app.Authenticated(http.HandlerFunc(app.infoHandler))))
-			http.Handle("/action/", app.Logged(app.Authenticated(http.HandlerFunc(app.actionHandler))))
-			http.Handle("/socket", app.Logged(http.HandlerFunc(app.adminWebsocketHandler)))
+			http.Handle("/auth/", app.Logged(shutdown.WrapHandler(http.HandlerFunc(app.authHandler))))
+			http.Handle("/info/", app.Logged(shutdown.WrapHandler(app.Authenticated(http.HandlerFunc(app.infoHandler)))))
+			http.Handle("/action/", app.Logged(shutdown.WrapHandler(app.Authenticated(http.HandlerFunc(app.actionHandler)))))
+			http.Handle("/socket", app.Logged(shutdown.WrapHandler(http.HandlerFunc(app.adminWebsocketHandler))))
 
 			// optionally serve admin web interface application
 			webDir := viper.GetString("web")
 			if webDir != "" {
-				http.Handle("/", http.FileServer(http.Dir(webDir)))
+				http.Handle("/", shutdown.WrapHandler(http.FileServer(http.Dir(webDir))))
 			}
 
 			addr := viper.GetString("address") + ":" + viper.GetString("port")

--- a/libcentrifugo/client.go
+++ b/libcentrifugo/client.go
@@ -18,7 +18,7 @@ const (
 // client represents clien connection to Centrifugo - at moment this can be Websocket
 // or SockJS connection.
 type client struct {
-	sync.Mutex
+	sync.RWMutex
 	app           *application
 	sess          session
 	Uid           ConnID
@@ -123,12 +123,14 @@ func (c *client) user() UserID {
 }
 
 func (c *client) channels() []Channel {
+	c.RLock()
 	keys := make([]Channel, len(c.Channels))
 	i := 0
 	for k := range c.Channels {
 		keys[i] = k
 		i += 1
 	}
+	c.RUnlock()
 	return keys
 }
 

--- a/libcentrifugo/client.go
+++ b/libcentrifugo/client.go
@@ -75,6 +75,7 @@ func (c *client) sendMessages() {
 		}
 		err := c.sendMsgTimeout(msg)
 		if err != nil {
+			logger.INFO.Println("error sending to", c.uid(), err.Error())
 			c.sess.Close(CloseStatus, "error sending message")
 		}
 	}

--- a/libcentrifugo/client.go
+++ b/libcentrifugo/client.go
@@ -51,14 +51,16 @@ func newClient(app *application, s session) (*client, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &client{
+	c := client{
 		Uid:         ConnID(uid.String()),
 		app:         app,
 		sess:        s,
 		messages:    stringqueue.New(),
 		closeChan:   make(chan struct{}),
 		sendTimeout: time.Second * 10,
-	}, nil
+	}
+	go c.sendMessages()
+	return &c, nil
 }
 
 // sendMessages waits for messages from messageChan and sends them to client

--- a/libcentrifugo/client.go
+++ b/libcentrifugo/client.go
@@ -11,6 +11,10 @@ import (
 	"github.com/nu7hatch/gouuid"
 )
 
+const (
+	CloseStatus = 3000
+)
+
 // client represents clien connection to Centrifugo - at moment this can be Websocket
 // or SockJS connection.
 type client struct {
@@ -61,7 +65,7 @@ func (c *client) sendMessages() {
 		case message := <-c.messageChan:
 			err := c.sess.Send(message)
 			if err != nil {
-				c.sess.Close(3000, "error sending message")
+				c.sess.Close(CloseStatus, "error sending message")
 			}
 		case <-c.closeChan:
 			return
@@ -149,13 +153,13 @@ func (c *client) send(message string) error {
 	case c.messageChan <- message:
 		return nil
 	default:
-		c.sess.Close(3000, "error sending message")
+		c.sess.Close(CloseStatus, "error sending message")
 		return ErrInternalServerError
 	}
 }
 
 func (c *client) close(reason string) error {
-	return c.sess.Close(3000, reason)
+	return c.sess.Close(CloseStatus, reason)
 }
 
 // clean called when connection was closed to make different clean up

--- a/libcentrifugo/client.go
+++ b/libcentrifugo/client.go
@@ -88,8 +88,8 @@ func (c *client) updateChannelPresence(ch Channel) {
 
 // updatePresence updates presence info for all client channels
 func (c *client) updatePresence() {
-	c.Lock()
-	defer c.Unlock()
+	c.RLock()
+	defer c.RUnlock()
 	for _, channel := range c.channels() {
 		c.updateChannelPresence(channel)
 	}

--- a/libcentrifugo/client.go
+++ b/libcentrifugo/client.go
@@ -300,7 +300,7 @@ func (c *client) handleCommands(commands []clientCommand) error {
 	if err != nil {
 		return err
 	}
-	err = c.sess.Send(string(jsonResp))
+	err = c.send(string(jsonResp))
 	return err
 }
 

--- a/libcentrifugo/client.go
+++ b/libcentrifugo/client.go
@@ -388,8 +388,8 @@ func (c *client) connectCmd(cmd *connectClientCommand) (*response, error) {
 	resp := newResponse("connect")
 
 	if c.authenticated {
-		resp.Body = c.Uid
-		return resp, nil
+		logger.ERROR.Println("wrong connect message: client already authenticated")
+		return nil, ErrInvalidClientMessage
 	}
 
 	pk := cmd.Project

--- a/libcentrifugo/client.go
+++ b/libcentrifugo/client.go
@@ -99,6 +99,11 @@ func (c *client) sendMsgTimeout(msg string) error {
 	return nil
 }
 
+// TODO: Implement
+func (c *client) flush() {
+	return
+}
+
 // updateChannelPresence updates client presence info for channel so it
 // won't expire until client disconnect
 func (c *client) updateChannelPresence(ch Channel) {

--- a/libcentrifugo/client.go
+++ b/libcentrifugo/client.go
@@ -76,7 +76,6 @@ func (c *client) sendMessages() {
 			}
 			continue
 		}
-		//time.Sleep(time.Millisecond * 100)
 		err := c.sendMsgTimeout(msg)
 		if err != nil {
 			logger.INFO.Println("error sending to", c.uid(), err.Error())
@@ -107,7 +106,7 @@ func (c *client) sendMsgTimeout(msg string) error {
 // flush any remaining messages on the queue
 func (c *client) flush() {
 	if c.messages.Closed() {
-		logger.INFO.Println("client was already closed")
+		return
 	}
 	// Close and get remaining
 	msgs := c.messages.CloseRemaining()
@@ -118,8 +117,6 @@ func (c *client) flush() {
 	for _, msg := range msgs {
 		err := c.sendMsgTimeout(msg)
 		if err != nil {
-			logger.INFO.Println("error sending to", c.uid(), err.Error())
-			c.sess.Close(CloseStatus, "error sending message")
 			return
 		}
 	}

--- a/libcentrifugo/commands.go
+++ b/libcentrifugo/commands.go
@@ -24,7 +24,7 @@ type controlCommand struct {
 	Uid string
 
 	Method string
-	Params json.RawMessage
+	Params *json.RawMessage
 }
 
 // connectClientCommand is a command to authorize connection - it contains project key

--- a/libcentrifugo/connections.go
+++ b/libcentrifugo/connections.go
@@ -17,6 +17,8 @@ type clientConn interface {
 	unsubscribe(ch Channel) error
 	// close closes client's connection
 	close(reason string) error
+	// flushes outgoing messages
+	flush()
 }
 
 // adminConnection is an interface abstracting all methods used
@@ -26,4 +28,6 @@ type adminConn interface {
 	uid() ConnID
 	// send allows to send message to admin
 	send(message string) error
+	// flushes outgoing messages
+	flush()
 }

--- a/libcentrifugo/handlers.go
+++ b/libcentrifugo/handlers.go
@@ -33,8 +33,6 @@ func (app *application) sockJSHandler(s sockjs.Session) {
 	}()
 	logger.INFO.Printf("new SockJS session established with uid %s\n", c.uid())
 
-	go c.sendMessages()
-
 	for {
 		if msg, err := s.Recv(); err == nil {
 			err = c.message([]byte(msg))

--- a/libcentrifugo/handlers.go
+++ b/libcentrifugo/handlers.go
@@ -40,7 +40,7 @@ func (app *application) sockJSHandler(s sockjs.Session) {
 			err = c.message([]byte(msg))
 			if err != nil {
 				logger.ERROR.Println(err)
-				s.Close(3000, err.Error())
+				s.Close(CloseStatus, "error receiving message")
 				break
 			}
 			continue

--- a/libcentrifugo/hubs.go
+++ b/libcentrifugo/hubs.go
@@ -32,9 +32,6 @@ func newClientHub() *clientHub {
 				for _, cc := range user {
 					go func(cc clientConn) {
 						cc.flush()
-						for _, ch := range cc.channels() {
-							cc.unsubscribe(ch)
-						}
 						cc.close("shutting down")
 						wg.Done()
 					}(cc)

--- a/libcentrifugo/hubs.go
+++ b/libcentrifugo/hubs.go
@@ -279,7 +279,7 @@ type adminHub struct {
 func newAdminHub() *adminHub {
 	h := adminHub{connections: make(map[ConnID]adminConn)}
 	// Send shutdown message to all admins
-	shutdown.FirstFunc(func(interface{}) {
+	shutdown.SecondFunc(func(interface{}) {
 		var wg sync.WaitGroup
 		h.RLock()
 		wg.Add(len(h.connections))

--- a/libcentrifugo/hubs.go
+++ b/libcentrifugo/hubs.go
@@ -4,6 +4,7 @@ import (
 	"sync"
 
 	"github.com/centrifugal/centrifugo/libcentrifugo/logger"
+	"github.com/klauspost/shutdown"
 )
 
 // clientHub manages client connections
@@ -17,9 +18,34 @@ type clientHub struct {
 
 // newClientHub initializes connectionHub
 func newClientHub() *clientHub {
-	return &clientHub{
+	h := clientHub{
 		connections: make(map[ProjectKey]map[UserID]map[ConnID]clientConn),
 	}
+	// Flush all connections on shutdown stage 1.
+	// Also removes presence for all users
+	shutdown.FirstFunc(func(interface{}) {
+		var wg sync.WaitGroup
+		h.RLock()
+		for _, uc := range h.connections {
+			for _, user := range uc {
+				wg.Add(len(user))
+				for _, cc := range user {
+					go func(cc clientConn) {
+						cc.flush()
+						for _, ch := range cc.channels() {
+							cc.unsubscribe(ch)
+						}
+						cc.close("shutting down")
+						wg.Done()
+					}(cc)
+				}
+			}
+		}
+		h.RUnlock()
+		wg.Wait()
+	}, nil)
+
+	return &h
 }
 
 // nClients returns total number of client connections
@@ -136,9 +162,10 @@ type subHub struct {
 
 // newSubHub initializes subscriptionHub
 func newSubHub() *subHub {
-	return &subHub{
+	h := &subHub{
 		subs: make(map[ChannelID]map[ConnID]clientConn),
 	}
+	return h
 }
 
 // nChannels returns a total number of different channels
@@ -234,9 +261,23 @@ type adminHub struct {
 
 // newAdminHub initializes new adminHub
 func newAdminHub() *adminHub {
-	return &adminHub{
-		connections: make(map[ConnID]adminConn),
-	}
+	h := adminHub{connections: make(map[ConnID]adminConn)}
+	// Send shutdown message to all admins
+	shutdown.FirstFunc(func(interface{}) {
+		var wg sync.WaitGroup
+		h.RLock()
+		wg.Add(len(h.connections))
+		for _, conn := range h.connections {
+			go func(ac adminConn) {
+				ac.send("shutting down")
+				ac.flush()
+				wg.Done()
+			}(conn)
+		}
+		h.RUnlock()
+		wg.Wait()
+	}, nil)
+	return &h
 }
 
 // add adds connection to adminConnectionHub connections registry

--- a/libcentrifugo/hubs_test.go
+++ b/libcentrifugo/hubs_test.go
@@ -66,6 +66,10 @@ func (c *testClientConn) close(reason string) error {
 	return nil
 }
 
+func (c *testClientConn) flush() {
+	return
+}
+
 type testAdminConn struct{}
 
 func (c *testAdminConn) uid() ConnID {
@@ -74,6 +78,10 @@ func (c *testAdminConn) uid() ConnID {
 
 func (c *testAdminConn) send(message string) error {
 	return nil
+}
+
+func (c *testAdminConn) flush() {
+	return
 }
 
 func TestClientHub(t *testing.T) {

--- a/libcentrifugo/stringqueue/stringqueue.go
+++ b/libcentrifugo/stringqueue/stringqueue.go
@@ -22,6 +22,10 @@ type StringQueue interface {
 	// all goroutines in wait() will return
 	Close()
 
+	// CloseRemaining will close the queue and return all entried in the queue.
+	// All goroutines in wait() will return
+	CloseRemaining() []string
+
 	// Closed returns true if the queue has been closed
 	// The call cannot guarantee that the queue hasn't been
 	// closed while the function returns, so only "true" has a definite meaning.
@@ -96,8 +100,8 @@ func (q *stringQueue) Add(i string) bool {
 	return true
 }
 
-// Close the queue and discard all entried in the queue
-// all goroutines in wait() will return
+// Close the queue and discard all entried in the queue.
+// All goroutines in wait() will return
 func (q *stringQueue) Close() {
 	q.mu.Lock()
 	defer q.mu.Unlock()
@@ -105,6 +109,27 @@ func (q *stringQueue) Close() {
 	q.cnt = 0
 	q.nodes = nil
 	q.cond.Broadcast()
+}
+
+// CloseRemaining will close the queue and return all entried in the queue.
+// All goroutines in wait() will return
+func (q *stringQueue) CloseRemaining() []string {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if q.isClosed {
+		return []string{}
+	}
+	rem := make([]string, 0, q.cnt)
+	for q.cnt > 0 {
+		i := q.nodes[q.head]
+		q.head = (q.head + 1) % len(q.nodes)
+		q.cnt--
+		rem = append(rem, i)
+	}
+	q.isClosed = true
+	q.nodes = nil
+	q.cond.Broadcast()
+	return rem
 }
 
 // Closed returns true if the queue has been closed


### PR DESCRIPTION
Proposal for discussion for #18 

Right now it handles:
* Reject all incoming requests once shutdown has been initiated
* Finish all incoming requests (in pre-shutdown)
* Send "shutting down" to all admins.
* Flush all outgoing messages and unsubscribe users (stage 1).

TODO: Implement flush in clients.