### PR TITLE
Fix unintentional shadowing

### DIFF
--- a/libcentrifugo/api.go
+++ b/libcentrifugo/api.go
@@ -18,7 +18,7 @@ func (app *application) apiCmd(p *project, command apiCommand) (*response, error
 	switch method {
 	case "publish":
 		var cmd publishApiCommand
-		err := json.Unmarshal(params, &cmd)
+		err = json.Unmarshal(params, &cmd)
 		if err != nil {
 			logger.ERROR.Println(err)
 			return nil, ErrInvalidApiMessage
@@ -26,7 +26,7 @@ func (app *application) apiCmd(p *project, command apiCommand) (*response, error
 		resp, err = app.publishCmd(p, &cmd)
 	case "unsubscribe":
 		var cmd unsubscribeApiCommand
-		err := json.Unmarshal(params, &cmd)
+		err = json.Unmarshal(params, &cmd)
 		if err != nil {
 			logger.ERROR.Println(err)
 			return nil, ErrInvalidApiMessage
@@ -34,7 +34,7 @@ func (app *application) apiCmd(p *project, command apiCommand) (*response, error
 		resp, err = app.unsubcribeCmd(p, &cmd)
 	case "disconnect":
 		var cmd disconnectApiCommand
-		err := json.Unmarshal(params, &cmd)
+		err = json.Unmarshal(params, &cmd)
 		if err != nil {
 			logger.ERROR.Println(err)
 			return nil, ErrInvalidApiMessage
@@ -42,7 +42,7 @@ func (app *application) apiCmd(p *project, command apiCommand) (*response, error
 		resp, err = app.disconnectCmd(p, &cmd)
 	case "presence":
 		var cmd presenceApiCommand
-		err := json.Unmarshal(params, &cmd)
+		err = json.Unmarshal(params, &cmd)
 		if err != nil {
 			logger.ERROR.Println(err)
 			return nil, ErrInvalidApiMessage
@@ -50,7 +50,7 @@ func (app *application) apiCmd(p *project, command apiCommand) (*response, error
 		resp, err = app.presenceCmd(p, &cmd)
 	case "history":
 		var cmd historyApiCommand
-		err := json.Unmarshal(params, &cmd)
+		err = json.Unmarshal(params, &cmd)
 		if err != nil {
 			logger.ERROR.Println(err)
 			return nil, ErrInvalidApiMessage

--- a/libcentrifugo/api_test.go
+++ b/libcentrifugo/api_test.go
@@ -12,42 +12,42 @@ func TestAPICmd(t *testing.T) {
 
 	cmd := apiCommand{
 		Method: "nonexistent",
-		Params: []byte{},
+		Params: []byte("{}"),
 	}
 	_, err := app.apiCmd(p, cmd)
 	assert.Equal(t, err, ErrMethodNotFound)
 
 	cmd = apiCommand{
 		Method: "publish",
-		Params: []byte{},
+		Params: []byte("{}"),
 	}
 	_, err = app.apiCmd(p, cmd)
 	assert.Equal(t, err, ErrInvalidApiMessage)
 
 	cmd = apiCommand{
 		Method: "unsubscribe",
-		Params: []byte{},
+		Params: []byte("{}"),
 	}
 	_, err = app.apiCmd(p, cmd)
 	assert.Equal(t, err, ErrInvalidApiMessage)
 
 	cmd = apiCommand{
 		Method: "disconnect",
-		Params: []byte{},
+		Params: []byte("{}"),
 	}
 	_, err = app.apiCmd(p, cmd)
 	assert.Equal(t, err, ErrInvalidApiMessage)
 
 	cmd = apiCommand{
 		Method: "presence",
-		Params: []byte{},
+		Params: []byte("{}"),
 	}
 	_, err = app.apiCmd(p, cmd)
 	assert.Equal(t, err, ErrInvalidApiMessage)
 
 	cmd = apiCommand{
 		Method: "history",
-		Params: []byte{},
+		Params: []byte("{}"),
 	}
 	_, err = app.apiCmd(p, cmd)
 	assert.Equal(t, err, ErrInvalidApiMessage)


### PR DESCRIPTION
Fix 'err' being shadowed, so the error returned from the API command was being ignored.

Also add empty params to test, so Unmarshal doesn't fail.