### PR TITLE
Add TLS support. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+v0.2.2  (unreleased)
+======
+
+* Add TLS support. New flags are:
+  * `--ssl`                   - accept SSL connections. This requires an X509 certificate and a key file.
+  * `--ssl_cert="file.cert"`  - path to X509 certificate file.
+  * `--ssl_key="file.key"`    - path to X509 certificate key.
+
 v0.2.1
 ======
 


### PR DESCRIPTION
New flags:
```
 --ssl                   - indicates ssl should be used.
 --ssl_cert="file.cert"  - path to X509 certificate file.
 --ssl_key="file.key"    - path to X509 certificate key.
```

For #27 