### PR TITLE
Channels command

### DIFF
--- a/libcentrifugo/api.go
+++ b/libcentrifugo/api.go
@@ -56,6 +56,8 @@ func (app *Application) apiCmd(p Project, command apiCommand) (*response, error)
 			return nil, ErrInvalidMessage
 		}
 		resp, err = app.historyCmd(p, &cmd)
+	case "channels":
+		resp, err = app.channelsCmd(p)
 	default:
 		return nil, ErrMethodNotFound
 	}
@@ -70,100 +72,89 @@ func (app *Application) apiCmd(p Project, command apiCommand) (*response, error)
 
 // publishCmd publishes data into channel
 func (app *Application) publishCmd(p Project, cmd *publishApiCommand) (*response, error) {
-
 	resp := newResponse("publish")
-
 	channel := cmd.Channel
 	data := cmd.Data
-
 	err := app.publish(p.Name, channel, data, cmd.Client, nil, false)
 	if err != nil {
 		resp.Err(err)
 		return resp, nil
 	}
-
 	return resp, nil
 }
 
 // unsubscribeCmd unsubscribes project's user from channel and sends
 // unsubscribe control message to other nodes
 func (app *Application) unsubcribeCmd(p Project, cmd *unsubscribeApiCommand) (*response, error) {
-
 	resp := newResponse("unsubscribe")
-
 	channel := cmd.Channel
 	user := cmd.User
-
 	err := app.Unsubscribe(p.Name, user, channel)
 	if err != nil {
 		resp.Err(err)
 		return resp, nil
 	}
-
 	return resp, nil
 }
 
 // disconnectCmd disconnects project's user and sends disconnect
 // control message to other nodes
 func (app *Application) disconnectCmd(p Project, cmd *disconnectApiCommand) (*response, error) {
-
 	resp := newResponse("disconnect")
-
 	user := cmd.User
-
 	err := app.Disconnect(p.Name, user)
 	if err != nil {
 		resp.Err(err)
 		return resp, nil
 	}
-
 	return resp, nil
 }
 
 // presenceCmd returns response with presense information for project channel
 func (app *Application) presenceCmd(p Project, cmd *presenceApiCommand) (*response, error) {
-
 	resp := newResponse("presence")
-
 	channel := cmd.Channel
-
 	body := &PresenceBody{
 		Channel: channel,
 	}
-
 	resp.Body = body
-
 	presence, err := app.Presence(p.Name, channel)
 	if err != nil {
 		resp.Err(err)
 		return resp, nil
 	}
-
 	body.Data = presence
-
 	return resp, nil
 }
 
 // historyCmd returns response with history information for project channel
 func (app *Application) historyCmd(p Project, cmd *historyApiCommand) (*response, error) {
-
 	resp := newResponse("history")
-
 	channel := cmd.Channel
-
 	body := &HistoryBody{
 		Channel: channel,
 	}
-
 	resp.Body = body
-
 	history, err := app.History(p.Name, channel)
 	if err != nil {
+		resp.Err(err)
+		return resp, nil
+	}
+	body.Data = history
+	return resp, nil
+}
+
+// channelsCmd returns active channels for project.
+func (app *Application) channelsCmd(p Project) (*response, error) {
+	resp := newResponse("channels")
+	body := &ChannelsBody{}
+	resp.Body = body
+	channels, err := app.engine.channels(p.Name)
+	if err != nil {
+		logger.ERROR.Println(err)
 		resp.Err(ErrInternalServerError)
 		return resp, nil
 	}
-
-	body.Data = history
-
+	body.Data = channels
 	return resp, nil
 }

--- a/libcentrifugo/application.go
+++ b/libcentrifugo/application.go
@@ -510,14 +510,18 @@ func (app *Application) pingCmd(cmd *pingControlCommand) error {
 	return nil
 }
 
+func (app *Application) channelIDPrefix(pk ProjectKey) string {
+	app.RLock()
+	defer app.RUnlock()
+	return app.config.ChannelPrefix + "." + string(pk) + "."
+}
+
 // channelID returns internal name of channel ChannelID - as
 // every project can have channels with the same name we should distinguish
 // between them. This also prevents collapses with admin and control
 // channel names
 func (app *Application) channelID(pk ProjectKey, ch Channel) ChannelID {
-	app.RLock()
-	defer app.RUnlock()
-	return ChannelID(app.config.ChannelPrefix + "." + string(pk) + "." + string(ch))
+	return ChannelID(app.channelIDPrefix(pk) + string(ch))
 }
 
 // addConn registers authenticated connection in clientConnectionHub

--- a/libcentrifugo/application_test.go
+++ b/libcentrifugo/application_test.go
@@ -53,6 +53,14 @@ func testMemoryApp() *Application {
 	return app
 }
 
+func testRedisApp() *Application {
+	c := newTestConfig()
+	app, _ := NewApplication(&c)
+	app.SetEngine(testRedisEngine(app))
+	app.SetStructure(getTestStructure())
+	return app
+}
+
 func newTestClient(app *Application) *client {
 	s := &testSession{}
 	c, _ := newClient(app, s)

--- a/libcentrifugo/body.go
+++ b/libcentrifugo/body.go
@@ -10,6 +10,10 @@ type HistoryBody struct {
 	Data    []Message `json:"data"`
 }
 
+type ChannelsBody struct {
+	Data []Channel `json:"data"`
+}
+
 type adminMessageBody struct {
 	Project ProjectKey `json:"project"`
 	Message Message    `json:"message"`

--- a/libcentrifugo/engine.go
+++ b/libcentrifugo/engine.go
@@ -26,4 +26,7 @@ type Engine interface {
 	addHistory(chID ChannelID, message Message, size, lifetime int64) error
 	// history returns a slice of history messages for channel
 	history(chID ChannelID) ([]Message, error)
+
+	// channels returns slice of currently acrtive channels for project.
+	channels(pk ProjectKey) ([]Channel, error)
 }

--- a/libcentrifugo/engine.go
+++ b/libcentrifugo/engine.go
@@ -27,6 +27,6 @@ type Engine interface {
 	// history returns a slice of history messages for channel
 	history(chID ChannelID) ([]Message, error)
 
-	// channels returns slice of currently acrtive channels for project.
+	// channels returns slice of currently active channels for project.
 	channels(pk ProjectKey) ([]Channel, error)
 }

--- a/libcentrifugo/engine_test.go
+++ b/libcentrifugo/engine_test.go
@@ -41,3 +41,7 @@ func (e *testEngine) addHistory(chID ChannelID, message Message, size, lifetime 
 func (e *testEngine) history(chID ChannelID) ([]Message, error) {
 	return []Message{}, nil
 }
+
+func (e *testEngine) channels(pk ProjectKey) ([]Channel, error) {
+	return []Channel{}, nil
+}

--- a/libcentrifugo/enginememory.go
+++ b/libcentrifugo/enginememory.go
@@ -67,9 +67,7 @@ func (e *MemoryEngine) history(chID ChannelID) ([]Message, error) {
 
 func (e *MemoryEngine) channels(pk ProjectKey) ([]Channel, error) {
 	chIDs := e.app.clients.channels()
-	e.app.RLock()
-	prefix := e.app.config.ChannelPrefix + "." + string(pk) + "."
-	e.app.RUnlock()
+	prefix := e.app.channelIDPrefix(pk)
 	channels := []Channel{}
 	for _, chID := range chIDs {
 		if strings.HasPrefix(string(chID), prefix) {

--- a/libcentrifugo/enginememory.go
+++ b/libcentrifugo/enginememory.go
@@ -2,6 +2,7 @@ package libcentrifugo
 
 import (
 	"container/heap"
+	"strings"
 	"sync"
 	"time"
 
@@ -62,6 +63,20 @@ func (e *MemoryEngine) addHistory(chID ChannelID, message Message, size, lifetim
 
 func (e *MemoryEngine) history(chID ChannelID) ([]Message, error) {
 	return e.historyHub.get(chID)
+}
+
+func (e *MemoryEngine) channels(pk ProjectKey) ([]Channel, error) {
+	chIDs := e.app.clients.channels()
+	e.app.RLock()
+	prefix := e.app.config.ChannelPrefix + "." + string(pk) + "."
+	e.app.RUnlock()
+	channels := []Channel{}
+	for _, chID := range chIDs {
+		if strings.HasPrefix(string(chID), prefix) {
+			channels = append(channels, Channel(string(chID)[len(prefix):]))
+		}
+	}
+	return channels, nil
 }
 
 type memoryPresenceHub struct {

--- a/libcentrifugo/enginememory_test.go
+++ b/libcentrifugo/enginememory_test.go
@@ -88,3 +88,14 @@ func TestMemoryHistoryHub(t *testing.T) {
 	hist, err = h.get(ch1)
 	assert.Equal(t, 0, len(hist))
 }
+
+func TestMemoryChannels(t *testing.T) {
+	app := testMemoryApp()
+	channels, err := app.engine.channels(ProjectKey("test1"))
+	assert.Equal(t, nil, err)
+	assert.Equal(t, 0, len(channels))
+	createTestClients(app, 10, 1)
+	channels, err = app.engine.channels(ProjectKey("test1"))
+	assert.Equal(t, nil, err)
+	assert.Equal(t, 10, len(channels))
+}

--- a/libcentrifugo/engineredis.go
+++ b/libcentrifugo/engineredis.go
@@ -418,6 +418,39 @@ func (e *RedisEngine) history(chID ChannelID) ([]Message, error) {
 	if err != nil {
 		return nil, err
 	}
-	history, err := sliceOfMessages(reply, nil)
-	return history, err
+	return sliceOfMessages(reply, nil)
+}
+
+func sliceOfChannels(result interface{}, prefix string, err error) ([]Channel, error) {
+	values, err := redis.Values(result, err)
+	if err != nil {
+		return nil, err
+	}
+	channels := make([]Channel, len(values))
+	for i := 0; i < len(values); i += 1 {
+		value, okValue := values[i].([]byte)
+		if !okValue {
+			return nil, errors.New("error getting ChannelID value")
+		}
+		chID := string(value)
+		if len(chID) <= len(prefix) {
+			return nil, errors.New("malformed ChannelID returned from Redis")
+		}
+		channel := chID[len(prefix):]
+		channels[i] = Channel(channel)
+	}
+	return channels, nil
+}
+
+// Requires Redis >= 2.8.0 (http://redis.io/commands/pubsub)
+func (e *RedisEngine) channels(pk ProjectKey) ([]Channel, error) {
+	conn := e.pool.Get()
+	defer conn.Close()
+	prefix := e.app.channelIDPrefix(pk)
+	reply, err := conn.Do("PUBSUB", "CHANNELS", prefix+"*")
+	if err != nil {
+		println(err.Error())
+		return nil, err
+	}
+	return sliceOfChannels(reply, prefix, nil)
 }

--- a/libcentrifugo/handlers.go
+++ b/libcentrifugo/handlers.go
@@ -401,6 +401,8 @@ func (app *Application) ActionHandler(w http.ResponseWriter, r *http.Request) {
 			Channel: channel,
 		}
 		resp, err = app.historyCmd(project, cmd)
+	case "channels":
+		resp, err = app.channelsCmd(project)
 	default:
 		http.Error(w, "Bad Request", http.StatusBadRequest)
 		return


### PR DESCRIPTION
New server API command implemented here. It's called `channels` and returns all active (with one or more subscribers) channels in project at moment. It's not available for client, just for API calls.

This change required to add new method to `Engine` interface.

It works with Memory and Redis engines. But for Redis Engine it requires Redis >= 2.8.0 (http://redis.io/commands/pubsub)