### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Centrifuge + Go = Centrifugo – harder, better, faster, stronger.
 
 Centrifugo is a real-time messaging server. This is a successor of 
-[Centrifuge](https://github.com/centrifugal/centrifuge). Please note that it can be used in conjuction with your application backend written in any language - Python, Ruby, Perl, PHP, Javascript, Java, Objective-C etc.
+[Centrifuge](https://github.com/centrifugal/centrifuge). Please note that it can be used in conjunction with your application backend written in any language - Python, Ruby, Perl, PHP, Javascript, Java, Objective-C etc.
 
 To understand what is it for and how it works – please, read 
 [documentation](http://fzambia.gitbooks.io/centrifugal/content/) of 


### PR DESCRIPTION
@centrifugal, I've corrected a typographical error in the documentation of the [centrifugo](https://github.com/centrifugal/centrifugo) project. Specifically, I've changed conjuction to conjunction. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.