### PR TITLE
Only store active (Fixes #50)

### DIFF
--- a/config.go
+++ b/config.go
@@ -59,7 +59,7 @@ func newConfig() *libcentrifugo.Config {
 	cfg.JoinLeave = viper.GetBool("join_leave")
 	cfg.HistorySize = viper.GetInt("history_size")
 	cfg.HistoryLifetime = viper.GetInt("history_lifetime")
-	cfg.OnlySaveIfActive = viper.GetBool("only_save_if_active")
+	cfg.OnlySaveIfActive = viper.GetBool("history_drop_inactive")
 	cfg.Recover = viper.GetBool("recover")
 	cfg.Namespaces = namespacesFromConfig(nil)
 

--- a/config.go
+++ b/config.go
@@ -59,6 +59,7 @@ func newConfig() *libcentrifugo.Config {
 	cfg.JoinLeave = viper.GetBool("join_leave")
 	cfg.HistorySize = viper.GetInt("history_size")
 	cfg.HistoryLifetime = viper.GetInt("history_lifetime")
+	cfg.OnlySaveIfActive = viper.GetInt("only_save_if_active")
 	cfg.Recover = viper.GetBool("recover")
 	cfg.Namespaces = namespacesFromConfig(nil)
 

--- a/config.go
+++ b/config.go
@@ -59,7 +59,7 @@ func newConfig() *libcentrifugo.Config {
 	cfg.JoinLeave = viper.GetBool("join_leave")
 	cfg.HistorySize = viper.GetInt("history_size")
 	cfg.HistoryLifetime = viper.GetInt("history_lifetime")
-	cfg.OnlySaveIfActive = viper.GetInt("only_save_if_active")
+	cfg.OnlySaveIfActive = viper.GetBool("only_save_if_active")
 	cfg.Recover = viper.GetBool("recover")
 	cfg.Namespaces = namespacesFromConfig(nil)
 

--- a/libcentrifugo/application.go
+++ b/libcentrifugo/application.go
@@ -430,7 +430,6 @@ func (app *Application) publish(ch Channel, data []byte, client ConnID, info *Cl
 // pubClient publishes message into channel so all running nodes
 // will receive it and will send to all clients on node subscribed on channel.
 func (app *Application) pubClient(ch Channel, chOpts ChannelOptions, data []byte, client ConnID, info *ClientInfo) error {
-
 	message, err := newMessage(ch, data, client, info)
 	if err != nil {
 		return err
@@ -462,15 +461,16 @@ func (app *Application) pubClient(ch Channel, chOpts ChannelOptions, data []byte
 		return err
 	}
 
-	_, err = app.engine.publish(chID, byteMessage)
+	hasCurrentSubscribers, err := app.engine.publish(chID, byteMessage)
 	if err != nil {
 		return err
 	}
 
 	if chOpts.HistorySize > 0 && chOpts.HistoryLifetime > 0 {
 		histOpts := addHistoryOpts{
-			Size:     chOpts.HistorySize,
-			Lifetime: chOpts.HistoryLifetime,
+			Size:             chOpts.HistorySize,
+			Lifetime:         chOpts.HistoryLifetime,
+			OnlySaveIfActive: (chOpts.OnlySaveIfActive && !hasCurrentSubscribers),
 		}
 		err = app.addHistory(ch, message, histOpts)
 		if err != nil {

--- a/libcentrifugo/application.go
+++ b/libcentrifugo/application.go
@@ -353,7 +353,8 @@ func (app *Application) pubControl(method string, params []byte) error {
 
 	app.RLock()
 	defer app.RUnlock()
-	return app.engine.publish(app.config.ControlChannel, messageBytes)
+	_, err = app.engine.publish(app.config.ControlChannel, messageBytes)
+	return err
 }
 
 // pubAdmin publishes message into admin channel so all running
@@ -361,7 +362,8 @@ func (app *Application) pubControl(method string, params []byte) error {
 func (app *Application) pubAdmin(message []byte) error {
 	app.RLock()
 	defer app.RUnlock()
-	return app.engine.publish(app.config.AdminChannel, message)
+	_, err := app.engine.publish(app.config.AdminChannel, message)
+	return err
 }
 
 // Publish sends a message to all clients subscribed on channel with provided data, client and ClientInfo.
@@ -460,7 +462,7 @@ func (app *Application) pubClient(ch Channel, chOpts ChannelOptions, data []byte
 		return err
 	}
 
-	err = app.engine.publish(chID, byteMessage)
+	_, err = app.engine.publish(chID, byteMessage)
 	if err != nil {
 		return err
 	}
@@ -494,7 +496,8 @@ func (app *Application) pubJoinLeave(ch Channel, method string, info ClientInfo)
 	if err != nil {
 		return err
 	}
-	return app.engine.publish(chID, byteMessage)
+	_, err = app.engine.publish(chID, byteMessage)
+	return err
 }
 
 // pubPing sends control ping message to all nodes - this message

--- a/libcentrifugo/application_test.go
+++ b/libcentrifugo/application_test.go
@@ -55,8 +55,15 @@ func testApp() *Application {
 }
 
 func testMemoryApp() *Application {
-	c := newTestConfig()
-	app, _ := NewApplication(&c)
+	return testMemoryAppWithConfig(nil)
+}
+
+func testMemoryAppWithConfig(c *Config) *Application {
+	if c == nil {
+		conf := newTestConfig()
+		c = &conf
+	}
+	app, _ := NewApplication(c)
 	app.SetEngine(NewMemoryEngine(app))
 	return app
 }
@@ -271,11 +278,33 @@ func testWrongControlCmd(uid string) []byte {
 }
 
 func TestPublish(t *testing.T) {
-	app := testMemoryApp()
+	// Custom config
+	c := newTestConfig()
+
+	// Set custom options for default namespace
+	c.ChannelOptions.HistoryLifetime = 10
+	c.ChannelOptions.HistorySize = 2
+	c.ChannelOptions.OnlySaveIfActive = true
+
+	app := testMemoryAppWithConfig(&c)
 	createTestClients(app, 10, 1)
 	data, _ := json.Marshal(map[string]string{"test": "publish"})
 	err := app.Publish(Channel("channel-0"), data, ConnID(""), nil)
-	assert.Equal(t, nil, err)
+	assert.Nil(t, err)
+
+	// Check publish to subscribed channels did result in saved history
+	hist, err := app.History(Channel("channel-0"))
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(hist))
+
+	// Publishing to a channel no one is subscribed to should be a no-op
+	err = app.Publish(Channel("some-other-channel"), data, ConnID(""), nil)
+	assert.Nil(t, err)
+
+	hist, err = app.History(Channel("some-other-channel"))
+	assert.Nil(t, err)
+	assert.Equal(t, 0, len(hist))
+
 }
 
 func TestPublishJoinLeave(t *testing.T) {

--- a/libcentrifugo/config.go
+++ b/libcentrifugo/config.go
@@ -53,7 +53,7 @@ type ChannelOptions struct {
 	// OnlySaveIfActive enables an optimization where history is only saved for channels that have at
 	// least one active subscriber. This can give a huge memory saving, with only minor edgecases that are
 	// different from without it as noted on https://github.com/centrifugal/centrifugo/issues/50.
-	OnlySaveIfActive bool `json:"only_save_if_active"`
+	OnlySaveIfActive bool `mapstructure:"only_save_if_active" json:"only_save_if_active"`
 }
 
 // NamespaceKey is a name of namespace unique for project.

--- a/libcentrifugo/config.go
+++ b/libcentrifugo/config.go
@@ -53,7 +53,7 @@ type ChannelOptions struct {
 	// OnlySaveIfActive enables an optimization where history is only saved for channels that have at
 	// least one active subscriber. This can give a huge memory saving, with only minor edgecases that are
 	// different from without it as noted on https://github.com/centrifugal/centrifugo/issues/50.
-	OnlySaveIfActive bool `mapstructure:"only_save_if_active" json:"only_save_if_active"`
+	OnlySaveIfActive bool `mapstructure:"history_drop_inactive" json:"history_drop_inactive"`
 }
 
 // NamespaceKey is a name of namespace unique for project.

--- a/libcentrifugo/config.go
+++ b/libcentrifugo/config.go
@@ -49,6 +49,11 @@ type ChannelOptions struct {
 	// from history and must be used with reasonable HistorySize and HistoryLifetime
 	// configuration.
 	Recover bool `json:"recover"`
+
+	// OnlySaveIfActive enables an optimization where history is only saved for channels that have at
+	// least one active subscriber. This can give a huge memory saving, with only minor edgecases that are
+	// different from without it as noted on https://github.com/centrifugal/centrifugo/issues/50.
+	OnlySaveIfActive bool `json:"only_save_if_active"`
 }
 
 // NamespaceKey is a name of namespace unique for project.

--- a/libcentrifugo/engine.go
+++ b/libcentrifugo/engine.go
@@ -12,6 +12,10 @@ type addHistoryOpts struct {
 	// Lifetime is maximum amount of seconds history messages should exist
 	// before expiring and most probably being deleted (to prevent memory leaks).
 	Lifetime int
+	// OnlySaveIfActive hints to the engine that there were no actual subscribers
+	// connected when message was published, and that it can skip saving if there is
+	// no unexpired history for the channel (i.e. no subscribers active within history_lifetime)
+	OnlySaveIfActive bool
 }
 
 // Engine is an interface with all methods that can be used by client or
@@ -25,7 +29,10 @@ type Engine interface {
 	run() error
 
 	// publish allows to send message into channel.
-	publish(chID ChannelID, message []byte) error
+	// Returns whether or not it sent to any active subscribers with `true` indicating
+	// at least one subscriber was published to.
+	// If engine has no efficient way to know that, it should always return true.
+	publish(chID ChannelID, message []byte) (bool, error)
 
 	// subscribe on channel.
 	subscribe(chID ChannelID) error

--- a/libcentrifugo/engine_test.go
+++ b/libcentrifugo/engine_test.go
@@ -14,8 +14,8 @@ func (e *testEngine) run() error {
 	return nil
 }
 
-func (e *testEngine) publish(chID ChannelID, message []byte) error {
-	return nil
+func (e *testEngine) publish(chID ChannelID, message []byte) (bool, error) {
+	return true, nil
 }
 
 func (e *testEngine) subscribe(chID ChannelID) error {

--- a/libcentrifugo/enginememory.go
+++ b/libcentrifugo/enginememory.go
@@ -36,8 +36,11 @@ func (e *MemoryEngine) run() error {
 	return nil
 }
 
-func (e *MemoryEngine) publish(chID ChannelID, message []byte) error {
-	return e.app.handleMsg(chID, message)
+func (e *MemoryEngine) publish(chID ChannelID, message []byte) (bool, error) {
+	if !e.app.clients.hasSubscribers(chID) {
+		return false, nil
+	}
+	return true, e.app.handleMsg(chID, message)
 }
 
 func (e *MemoryEngine) subscribe(chID ChannelID) error {

--- a/libcentrifugo/enginememory.go
+++ b/libcentrifugo/enginememory.go
@@ -203,6 +203,11 @@ func (h *memoryHistoryHub) add(chID ChannelID, message Message, opts addHistoryO
 
 	_, ok := h.history[chID]
 
+	if opts.OnlySaveIfActive && !ok {
+		// No active history for this channel so don't bother storing at all
+		return nil
+	}
+
 	expireAt := time.Now().Unix() + int64(opts.Lifetime)
 	heap.Push(&h.queue, &priority.Item{Value: string(chID), Priority: expireAt})
 	if !ok {

--- a/libcentrifugo/enginememory_test.go
+++ b/libcentrifugo/enginememory_test.go
@@ -128,7 +128,7 @@ func TestMemoryHistoryHub(t *testing.T) {
 	h.add(ch1, Message{}, addHistoryOpts{1, 1, false})
 	h.add(ch1, Message{}, addHistoryOpts{1, 1, false})
 	h.add(ch2, Message{}, addHistoryOpts{2, 1, false})
-	h.add(ch2, Message{}, addHistoryOpts{2, 1, false})
+	h.add(ch2, Message{}, addHistoryOpts{2, 1, true}) // Test that adding only if active works when it's active
 	hist, err := h.get(ch1)
 	assert.Equal(t, nil, err)
 	assert.Equal(t, 1, len(hist))
@@ -157,6 +157,12 @@ func TestMemoryHistoryHub(t *testing.T) {
 	h.add(ch1, Message{}, addHistoryOpts{1, 1})
 	hist, err = h.get(ch1, historyOpts{Limit: 2})
 	assert.Equal(t, 1, len(hist))
+
+	// Now test adding history for inactive channel is a no-op if OnlySaveIfActvie is true
+	h.add(ch2, Message{}, addHistoryOpts{2, 10, true})
+	assert.Equal(t, 0, len(h.history))
+	hist, err = h.get(ch2)
+	assert.Equal(t, 0, len(hist))
 }
 
 func TestMemoryChannels(t *testing.T) {

--- a/libcentrifugo/enginememory_test.go
+++ b/libcentrifugo/enginememory_test.go
@@ -81,7 +81,7 @@ func TestMemoryEngine(t *testing.T) {
 	assert.Equal(t, nil, err)
 	assert.Equal(t, 1, len(p))
 	assert.Equal(t, nil, e.addHistory(ChannelID("channel"), Message{}, addHistoryOpts{1, 1, false}))
-	h, err := e.history(ChannelID("channel"))
+	h, err := e.history(ChannelID("channel"), historyOpts{})
 	assert.Equal(t, nil, err)
 	assert.Equal(t, 1, len(h))
 	err = e.removePresence(ChannelID("channel"), "uid")
@@ -129,7 +129,7 @@ func TestMemoryHistoryHub(t *testing.T) {
 	h.add(ch1, Message{}, addHistoryOpts{1, 1, false})
 	h.add(ch2, Message{}, addHistoryOpts{2, 1, false})
 	h.add(ch2, Message{}, addHistoryOpts{2, 1, true}) // Test that adding only if active works when it's active
-	hist, err := h.get(ch1)
+	hist, err := h.get(ch1, historyOpts{})
 	assert.Equal(t, nil, err)
 	assert.Equal(t, 1, len(hist))
 	hist, err = h.get(ch2, historyOpts{})
@@ -142,27 +142,27 @@ func TestMemoryHistoryHub(t *testing.T) {
 	hist, err = h.get(ch1, historyOpts{})
 	assert.Equal(t, 0, len(hist))
 
+	// Now test adding history for inactive channel is a no-op if OnlySaveIfActvie is true
+	h.add(ch2, Message{}, addHistoryOpts{2, 10, true})
+	assert.Equal(t, 0, len(h.history))
+	hist, err = h.get(ch2, historyOpts{})
+	assert.Equal(t, 0, len(hist))
+
 	// test history messages limit
-	h.add(ch1, Message{}, addHistoryOpts{10, 1})
-	h.add(ch1, Message{}, addHistoryOpts{10, 1})
-	h.add(ch1, Message{}, addHistoryOpts{10, 1})
-	h.add(ch1, Message{}, addHistoryOpts{10, 1})
+	h.add(ch1, Message{}, addHistoryOpts{10, 1, false})
+	h.add(ch1, Message{}, addHistoryOpts{10, 1, false})
+	h.add(ch1, Message{}, addHistoryOpts{10, 1, false})
+	h.add(ch1, Message{}, addHistoryOpts{10, 1, false})
 	hist, err = h.get(ch1, historyOpts{})
 	assert.Equal(t, 4, len(hist))
 	hist, err = h.get(ch1, historyOpts{Limit: 1})
 	assert.Equal(t, 1, len(hist))
 
 	// test history limit greater than history size
-	h.add(ch1, Message{}, addHistoryOpts{1, 1})
-	h.add(ch1, Message{}, addHistoryOpts{1, 1})
+	h.add(ch1, Message{}, addHistoryOpts{1, 1, false})
+	h.add(ch1, Message{}, addHistoryOpts{1, 1, false})
 	hist, err = h.get(ch1, historyOpts{Limit: 2})
 	assert.Equal(t, 1, len(hist))
-
-	// Now test adding history for inactive channel is a no-op if OnlySaveIfActvie is true
-	h.add(ch2, Message{}, addHistoryOpts{2, 10, true})
-	assert.Equal(t, 0, len(h.history))
-	hist, err = h.get(ch2)
-	assert.Equal(t, 0, len(hist))
 }
 
 func TestMemoryChannels(t *testing.T) {

--- a/libcentrifugo/engineredis.go
+++ b/libcentrifugo/engineredis.go
@@ -250,11 +250,11 @@ func (e *RedisEngine) initializePubSub() {
 	}
 }
 
-func (e *RedisEngine) publish(chID ChannelID, message []byte) error {
+func (e *RedisEngine) publish(chID ChannelID, message []byte) (bool, error) {
 	conn := e.pool.Get()
 	defer conn.Close()
-	_, err := conn.Do("PUBLISH", chID, message)
-	return err
+	numSubscribers, err := redis.Int(conn.Do("PUBLISH", chID, message))
+	return numSubscribers > 0, err
 }
 
 func (e *RedisEngine) subscribe(chID ChannelID) error {

--- a/libcentrifugo/engineredis_test.go
+++ b/libcentrifugo/engineredis_test.go
@@ -105,42 +105,42 @@ func TestRedisEngine(t *testing.T) {
 	assert.Equal(t, nil, err)
 
 	// test adding history
-	assert.Equal(t, nil, e.addHistory(ChannelID("channel"), Message{}, addHistoryOpts{4, 1}))
+	assert.Equal(t, nil, e.addHistory(ChannelID("channel"), Message{}, addHistoryOpts{4, 1, false}))
 	h, err := e.history(ChannelID("channel"), historyOpts{})
 	assert.Equal(t, nil, err)
 	assert.Equal(t, 1, len(h))
 
 	// test history limit
-	assert.Equal(t, nil, e.addHistory(ChannelID("channel"), Message{}, addHistoryOpts{4, 1}))
-	assert.Equal(t, nil, e.addHistory(ChannelID("channel"), Message{}, addHistoryOpts{4, 1}))
-	assert.Equal(t, nil, e.addHistory(ChannelID("channel"), Message{}, addHistoryOpts{4, 1}))
+	assert.Equal(t, nil, e.addHistory(ChannelID("channel"), Message{}, addHistoryOpts{4, 1, false}))
+	assert.Equal(t, nil, e.addHistory(ChannelID("channel"), Message{}, addHistoryOpts{4, 1, false}))
+	assert.Equal(t, nil, e.addHistory(ChannelID("channel"), Message{}, addHistoryOpts{4, 1, false}))
 	h, err = e.history(ChannelID("channel"), historyOpts{Limit: 2})
 	assert.Equal(t, nil, err)
 	assert.Equal(t, 2, len(h))
 
 	// test history limit greater than history size
-	assert.Equal(t, nil, e.addHistory(ChannelID("channel"), Message{}, addHistoryOpts{1, 1}))
-	assert.Equal(t, nil, e.addHistory(ChannelID("channel"), Message{}, addHistoryOpts{1, 1}))
-	assert.Equal(t, nil, e.addHistory(ChannelID("channel"), Message{}, addHistoryOpts{1, 1}))
+	assert.Equal(t, nil, e.addHistory(ChannelID("channel"), Message{}, addHistoryOpts{1, 1, false}))
+	assert.Equal(t, nil, e.addHistory(ChannelID("channel"), Message{}, addHistoryOpts{1, 1, false}))
+	assert.Equal(t, nil, e.addHistory(ChannelID("channel"), Message{}, addHistoryOpts{1, 1, false}))
 	h, err = e.history(ChannelID("channel"), historyOpts{Limit: 2})
 
-	// OnlySaveIfActive tests
+	// OnlySaveIfActive tests - new channel to avoid conflicts with test above
 	// 1. add history with OnlySaveIfActive = true should be a no-op if history is empty
-	assert.Equal(t, nil, e.addHistory(ChannelID("channel"), Message{}, addHistoryOpts{2, 5, true}))
-	h, err = e.history(ChannelID("channel"))
+	assert.Equal(t, nil, e.addHistory(ChannelID("channel-2"), Message{}, addHistoryOpts{2, 5, true}))
+	h, err = e.history(ChannelID("channel-2"), historyOpts{})
 	assert.Equal(t, nil, err)
 	assert.Equal(t, 0, len(h))
 
 	// 2. add history with OnlySaveIfActive = false should always work
-	assert.Equal(t, nil, e.addHistory(ChannelID("channel"), Message{}, addHistoryOpts{2, 5, false}))
-	h, err = e.history(ChannelID("channel"))
+	assert.Equal(t, nil, e.addHistory(ChannelID("channel-2"), Message{}, addHistoryOpts{2, 5, false}))
+	h, err = e.history(ChannelID("channel-2"), historyOpts{})
 	assert.Equal(t, nil, err)
 	assert.Equal(t, 1, len(h))
 
 	// 3. add with OnlySaveIfActive = true should work immediately since there should be something in history
 	// for 5 seconds from above
-	assert.Equal(t, nil, e.addHistory(ChannelID("channel"), Message{}, addHistoryOpts{2, 5, true}))
-	h, err = e.history(ChannelID("channel"))
+	assert.Equal(t, nil, e.addHistory(ChannelID("channel-2"), Message{}, addHistoryOpts{2, 5, true}))
+	h, err = e.history(ChannelID("channel-2"), historyOpts{})
 	assert.Equal(t, nil, err)
 	assert.Equal(t, 2, len(h))
 

--- a/libcentrifugo/engineredis_test.go
+++ b/libcentrifugo/engineredis_test.go
@@ -79,9 +79,13 @@ func TestRedisEngine(t *testing.T) {
 	app.SetEngine(e)
 	assert.Equal(t, e.name(), "Redis")
 
-	// test pub/sub operations
-	assert.Equal(t, nil, e.publish(ChannelID("channel"), []byte("{}")))
+	hasActiveSubscribers, err := e.publish(ChannelID("channel"), []byte("{}"))
+	assert.False(t, hasActiveSubscribers)
+	assert.Equal(t, nil, err)
 	assert.Equal(t, nil, e.subscribe(ChannelID("channel")))
+	// Now we've subscribed...
+	hasActiveSubscribers, err = e.publish(ChannelID("channel"), []byte("{}"))
+	assert.True(t, hasActiveSubscribers)
 	assert.Equal(t, nil, e.unsubscribe(ChannelID("channel")))
 
 	// test adding presence

--- a/libcentrifugo/hubs.go
+++ b/libcentrifugo/hubs.go
@@ -235,6 +235,17 @@ func (h *clientHub) channels() []ChannelID {
 	return channels
 }
 
+// hasSubscribers returns whether or not there are any subscribers for a given channel.
+func (h *clientHub) hasSubscribers(chID ChannelID) bool {
+	h.RLock()
+	defer h.RUnlock()
+	conns, ok := h.subs[chID]
+	if !ok {
+		return false
+	}
+	return len(conns) > 0
+}
+
 // adminHub manages admin connections from web interface.
 type adminHub struct {
 	sync.RWMutex

--- a/libcentrifugo/hubs_test.go
+++ b/libcentrifugo/hubs_test.go
@@ -104,11 +104,15 @@ func TestSubHub(t *testing.T) {
 	}
 	assert.Equal(t, stringInSlice("test1", channels), true)
 	assert.Equal(t, stringInSlice("test2", channels), true)
+	assert.True(t, h.hasSubscribers(ChannelID("test1")))
+	assert.True(t, h.hasSubscribers(ChannelID("test2")))
 	err := h.broadcast("test1", []byte("message"))
 	assert.Equal(t, err, nil)
 	h.removeSub("test1", c)
 	h.removeSub("test2", c)
 	assert.Equal(t, len(h.subs), 0)
+	assert.False(t, h.hasSubscribers(ChannelID("test1")))
+	assert.False(t, h.hasSubscribers(ChannelID("test2")))
 }
 
 func TestAdminHub(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -160,6 +160,7 @@ func Main() {
 			viper.SetDefault("history_size", 0)
 			viper.SetDefault("history_lifetime", 0)
 			viper.SetDefault("recover", false)
+			viper.SetDefault("only_save_if_active", false)
 			viper.SetDefault("namespaces", "")
 
 			viper.SetEnvPrefix("centrifugo")
@@ -181,6 +182,7 @@ func Main() {
 			viper.BindEnv("recover")
 			viper.BindEnv("history_size")
 			viper.BindEnv("history_lifetime")
+			viper.BindEnv("only_save_if_active")
 
 			viper.BindPFlag("port", cmd.Flags().Lookup("port"))
 			viper.BindPFlag("api_port", cmd.Flags().Lookup("api_port"))

--- a/main.go
+++ b/main.go
@@ -160,7 +160,7 @@ func Main() {
 			viper.SetDefault("history_size", 0)
 			viper.SetDefault("history_lifetime", 0)
 			viper.SetDefault("recover", false)
-			viper.SetDefault("only_save_if_active", false)
+			viper.SetDefault("history_drop_inactive", false)
 			viper.SetDefault("namespaces", "")
 
 			viper.SetEnvPrefix("centrifugo")
@@ -182,7 +182,7 @@ func Main() {
 			viper.BindEnv("recover")
 			viper.BindEnv("history_size")
 			viper.BindEnv("history_lifetime")
-			viper.BindEnv("only_save_if_active")
+			viper.BindEnv("history_drop_inactive")
 
 			viper.BindPFlag("port", cmd.Flags().Lookup("port"))
 			viper.BindPFlag("api_port", cmd.Flags().Lookup("api_port"))

--- a/main.go
+++ b/main.go
@@ -22,7 +22,7 @@ import (
 
 const (
 	// VERSION determines version of Centrifugo server.
-	VERSION = "1.2.0"
+	VERSION = "1.2.1"
 )
 
 func setupLogging() {


### PR DESCRIPTION
See design discussion on #50 for details.

This is tested to match the guarantees documented there.

Note this is optional and opt-in only.

I've tested the config changes locally and tested that you can opt in on a namespace and have the desired behaviour.