### PR TITLE
Implement sharded publish queues for redis engine to improve throughput. Refs #52

### DIFF
--- a/libcentrifugo/engineredis_test.go
+++ b/libcentrifugo/engineredis_test.go
@@ -16,13 +16,13 @@ type testRedisConn struct {
 }
 
 const (
-	testRedisHost          = "127.0.0.1"
-	testRedisPort          = "6379"
-	testRedisPassword      = ""
-	testRedisDB            = "9"
-	testRedisURL           = "redis://:@127.0.0.1:6379/9"
-	testRedisPoolSize      = 5
-	testRedisNPubApiShards = 4
+	testRedisHost         = "127.0.0.1"
+	testRedisPort         = "6379"
+	testRedisPassword     = ""
+	testRedisDB           = "9"
+	testRedisURL          = "redis://:@127.0.0.1:6379/9"
+	testRedisPoolSize     = 5
+	testRedisNumAPIShards = 4
 )
 
 func (t testRedisConn) close() error {
@@ -67,7 +67,17 @@ func dial() testRedisConn {
 }
 
 func testRedisEngine(app *Application) *RedisEngine {
-	e := NewRedisEngine(app, testRedisHost, testRedisPort, testRedisPassword, testRedisDB, testRedisURL, true, testRedisPoolSize, testRedisNPubApiShards)
+	redisConf := &RedisEngineConfig{
+		Host:         testRedisHost,
+		Port:         testRedisPort,
+		Password:     testRedisPassword,
+		DB:           testRedisDB,
+		URL:          testRedisURL,
+		PoolSize:     testRedisPoolSize,
+		API:          true,
+		NumAPIShards: testRedisNumAPIShards,
+	}
+	e := NewRedisEngine(app, redisConf)
 	return e
 }
 
@@ -151,9 +161,9 @@ func TestRedisEngine(t *testing.T) {
 	_, err = c.Conn.Do("LPUSH", apiKey, []byte("{}"))
 	assert.Equal(t, nil, err)
 
-	// test Publish API
-	for i := 0; i < testRedisNPubApiShards; i++ {
-		queueKey := fmt.Sprintf("%s.pub.%d", apiKey, i)
+	// test API shards
+	for i := 0; i < testRedisNumAPIShards; i++ {
+		queueKey := fmt.Sprintf("%s.%d", apiKey, i)
 		_, err = c.Conn.Do("LPUSH", queueKey, []byte("{}"))
 		assert.Equal(t, nil, err)
 	}

--- a/main.go
+++ b/main.go
@@ -208,7 +208,7 @@ func Main() {
 			viper.BindPFlag("redis_url", cmd.Flags().Lookup("redis_url"))
 			viper.BindPFlag("redis_api", cmd.Flags().Lookup("redis_api"))
 			viper.BindPFlag("redis_pool", cmd.Flags().Lookup("redis_pool"))
-			viper.BindPFlag("redis_api_num_pub_shards", cmd.Flags().Lookup("redis_api_num_pub_shards"))
+			viper.BindPFlag("redis_api_num_shards", cmd.Flags().Lookup("redis_api_num_shards"))
 
 			viper.SetConfigFile(configFile)
 
@@ -269,17 +269,17 @@ func Main() {
 			case "memory":
 				e = libcentrifugo.NewMemoryEngine(app)
 			case "redis":
-				e = libcentrifugo.NewRedisEngine(
-					app,
-					viper.GetString("redis_host"),
-					viper.GetString("redis_port"),
-					viper.GetString("redis_password"),
-					viper.GetString("redis_db"),
-					viper.GetString("redis_url"),
-					viper.GetBool("redis_api"),
-					viper.GetInt("redis_pool"),
-					viper.GetInt("redis_api_num_pub_shards"),
-				)
+				redisConf := &libcentrifugo.RedisEngineConfig{
+					Host:         viper.GetString("redis_host"),
+					Port:         viper.GetString("redis_port"),
+					Password:     viper.GetString("redis_password"),
+					DB:           viper.GetString("redis_db"),
+					URL:          viper.GetString("redis_url"),
+					PoolSize:     viper.GetInt("redis_pool"),
+					API:          viper.GetBool("redis_api"),
+					NumAPIShards: viper.GetInt("redis_api_num_shards"),
+				}
+				e = libcentrifugo.NewRedisEngine(app, redisConf)
 			default:
 				logger.FATAL.Fatalln("Unknown engine: " + viper.GetString("engine"))
 			}
@@ -398,7 +398,7 @@ func Main() {
 	rootCmd.Flags().StringVarP(&redisURL, "redis_url", "", "", "redis connection URL (Redis engine)")
 	rootCmd.Flags().BoolVarP(&redisAPI, "redis_api", "", false, "enable Redis API listener (Redis engine)")
 	rootCmd.Flags().IntVarP(&redisPool, "redis_pool", "", 256, "Redis pool size (Redis engine)")
-	rootCmd.Flags().IntVarP(&redisPool, "redis_api_num_pub_shards", "", 0, "Number of shards for redis publish queue (Redis engine)")
+	rootCmd.Flags().IntVarP(&redisPool, "redis_api_num_shards", "", 0, "Number of shards for redis API queue (Redis engine)")
 
 	var versionCmd = &cobra.Command{
 		Use:   "version",

--- a/main.go
+++ b/main.go
@@ -208,6 +208,7 @@ func Main() {
 			viper.BindPFlag("redis_url", cmd.Flags().Lookup("redis_url"))
 			viper.BindPFlag("redis_api", cmd.Flags().Lookup("redis_api"))
 			viper.BindPFlag("redis_pool", cmd.Flags().Lookup("redis_pool"))
+			viper.BindPFlag("redis_api_num_pub_shards", cmd.Flags().Lookup("redis_api_num_pub_shards"))
 
 			viper.SetConfigFile(configFile)
 
@@ -277,6 +278,7 @@ func Main() {
 					viper.GetString("redis_url"),
 					viper.GetBool("redis_api"),
 					viper.GetInt("redis_pool"),
+					viper.GetInt("redis_api_num_pub_shards"),
 				)
 			default:
 				logger.FATAL.Fatalln("Unknown engine: " + viper.GetString("engine"))
@@ -396,6 +398,7 @@ func Main() {
 	rootCmd.Flags().StringVarP(&redisURL, "redis_url", "", "", "redis connection URL (Redis engine)")
 	rootCmd.Flags().BoolVarP(&redisAPI, "redis_api", "", false, "enable Redis API listener (Redis engine)")
 	rootCmd.Flags().IntVarP(&redisPool, "redis_pool", "", 256, "Redis pool size (Redis engine)")
+	rootCmd.Flags().IntVarP(&redisPool, "redis_api_num_pub_shards", "", 0, "Number of shards for redis publish queue (Redis engine)")
 
 	var versionCmd = &cobra.Command{
 		Use:   "version",


### PR DESCRIPTION
As always, I'm not in love with many of the names I choose. I've opted to balance clarity and previty with shortened words but being clear about the semantics... but I'm open to suggestions.

I have this branch running now with ~5k messages a second being published and no queue backlog (with 16 shards).

Obviously we will need to document all these new features in the book once we prepare 1.3 release - @FZambia how do you normally do that? Wait until 1.3 features are final and then update it?

I also considered making the new publish more separate from the "old" api, and also considered only supporting publish/broadcast methods on it with simpler syntax but it ened up just being a lot more code complication for not much benefit.

Finally, I'm not really very pleased with the test suite for the API - I followed what was there and just push something into redis but without any assertion that it was delivered it's really not testing anything.

I may have time later to improve those tests but I needed to get something delivered for a tight deadline.