### PR TITLE
Fix dependence on Mutex implementation for alignment of atomics

### DIFF
--- a/libcentrifugo/metrics.go
+++ b/libcentrifugo/metrics.go
@@ -101,7 +101,7 @@ type metricCounter struct {
 	lastIntervalDelta int64
 	// Prevent false-sharing of consecutive counters in the parent registry
 	// run go test -test.cpu 1,2,4,8 -test.bench=Atomic -test.run XXX
-	// On my machine (quad core/8HT macbook) this is consistently ~40% faster with 8 threads.
+	// On my machine (quad core/8HT macbook) this is consistently ~60% faster with 8 threads.
 	_padding [5]int64
 }
 


### PR DESCRIPTION
Also cleans up cruft from recent back and forth on metrics code.

Adds comments to hopefully ensure we don't screw up counter alignment again...

## Test Plan

 - new benchmark added to proove value of padding to cache line
 - all test pass again
 - Metrics remains backwards compatible for `gocent` and JSON output
 - built with `-race` and ran 100 concurrent API requests for 30 seconds several times, no races
 - left running past several `NodeMetricsInterval`s and no races on Update
 - `go vet` doesn't complain about anything related to this change (minor complaints can be dealt with in another diff).

## Benchmark results on my machine

I realised last night that I also ignored false-sharing issues with atomics - since we pack `metricsCounter` into contiguous memory, and each is only 24 bytes, up to 3 `value` fields will be in each 64byte cache line. That means separate cores attempting to increment _different_ counters that happen to be in same cache line cause the caches to thrash unnecessarily.

```
$ go test -test.cpu 1,2,4,8 -test.bench=Atomic -test.run XXX
PASS
BenchmarkAtomicCounterNoPad    	100000000	        15.3 ns/op
BenchmarkAtomicCounterNoPad-2  	20000000	        78.3 ns/op
BenchmarkAtomicCounterNoPad-4  	10000000	       195 ns/op
BenchmarkAtomicCounterNoPad-8  	 5000000	       395 ns/op
BenchmarkAtomicCounterWithPad  	100000000	        15.7 ns/op
BenchmarkAtomicCounterWithPad-2	30000000	        56.9 ns/op
BenchmarkAtomicCounterWithPad-4	10000000	       150 ns/op
BenchmarkAtomicCounterWithPad-8	 5000000	       257 ns/op
ok  	github.com/centrifugal/centrifugo/libcentrifugo	14.263s
```

My machine is 4 cores (8 Hyper Threads). With all 8 logical threads are running this benchmark you can see that false-sharing causes about ~54% decrease in performance of counters vs the padded version (for the benchmark access pattern).

Saving hundreds of ns is probably not a big deal in centrifugo terms, but principle remains, and the fix is simple and cheap (and with measurements to demonstrate it helps). The overhead also grows significantly with number of cores so the performance improvement will be bigger on big servers with 32+ hardware threads, especially once multiple processor sockets are involved. Note that this benchmark workload could only ever improve by a modest amount since the threads are legitimately sharing both counters.

Just to see, I ran a slightly modified version where each thread got it's own `metricsCounter` from the consecutive array, in that case the difference for 8 threads goes from 90ns/op to 15ns/op which is an 83% increase in performance from eliminating the sharing.