### PR TITLE
latencies for http api responses and client api responses

### DIFF
--- a/libcentrifugo/application.go
+++ b/libcentrifugo/application.go
@@ -66,7 +66,7 @@ func NewApplication(config *Config) (*Application, error) {
 		admins:     newAdminHub(),
 		nodes:      make(map[string]nodeInfo),
 		started:    time.Now().Unix(),
-		metrics:    &metricsRegistry{},
+		metrics:    newMetricsRegistry(),
 		shutdownCh: make(chan struct{}),
 	}
 	return app, nil

--- a/libcentrifugo/client.go
+++ b/libcentrifugo/client.go
@@ -306,6 +306,10 @@ func cmdFromClientMsg(msgBytes []byte) ([]clientCommand, error) {
 }
 
 func (c *client) message(msg []byte) error {
+	started := time.Now()
+	defer func() {
+		c.app.metrics.histograms.RecordMicroseconds("client_api", time.Now().Sub(started))
+	}()
 	c.app.metrics.NumClientRequests.Inc()
 	c.app.metrics.BytesClientIn.Add(int64(len(msg)))
 

--- a/libcentrifugo/handlers.go
+++ b/libcentrifugo/handlers.go
@@ -296,7 +296,10 @@ func (app *Application) processAPIData(data []byte) ([]byte, error) {
 
 // APIHandler is responsible for receiving API commands over HTTP.
 func (app *Application) APIHandler(w http.ResponseWriter, r *http.Request) {
-
+	started := time.Now()
+	defer func() {
+		app.metrics.histograms.RecordMicroseconds("http_api", time.Now().Sub(started))
+	}()
 	app.metrics.NumAPIRequests.Inc()
 
 	contentType := r.Header.Get("Content-Type")

--- a/libcentrifugo/hdrhistogram/hdrhistogram.go
+++ b/libcentrifugo/hdrhistogram/hdrhistogram.go
@@ -115,12 +115,24 @@ func (r *HDRHistogramRegistry) Rotate() {
 	}
 }
 
+func stringInSlice(a string, list []string) bool {
+	for _, b := range list {
+		if b == a {
+			return true
+		}
+	}
+	return false
+}
+
 // LoadValues allows to get union of metric values over all registered
 // histograms - both for current and merged over all buckets.
-func (r *HDRHistogramRegistry) LoadValues() map[string]int64 {
+func (r *HDRHistogramRegistry) LoadValues(names ...string) map[string]int64 {
 	values := make(map[string]int64)
 	for _, hist := range r.histograms {
 		name := hist.Name()
+		if len(names) > 0 && !stringInSlice(name, names) {
+			continue
+		}
 		nHistograms := strconv.Itoa(hist.NumHistograms())
 		currentSnapshot := hist.Snapshot()
 		mergedSnapshot := hist.MergedSnapshot()

--- a/libcentrifugo/hdrhistogram/hdrhistogram.go
+++ b/libcentrifugo/hdrhistogram/hdrhistogram.go
@@ -85,7 +85,7 @@ func (r *HDRHistogramRegistry) Register(h *HDRHistogram) {
 
 // RecordValue into histogram with provided name. Panics if name not registered.
 func (r *HDRHistogramRegistry) RecordValue(name string, value int64) error {
-	return r.histograms[name].hist.Current.RecordValue(value)
+	return r.histograms[name].RecordValue(value)
 }
 
 // RecordMicroseconds into histogram with provided name. Panics if name not registered.

--- a/libcentrifugo/hdrhistogram/hdrhistogram.go
+++ b/libcentrifugo/hdrhistogram/hdrhistogram.go
@@ -1,0 +1,107 @@
+package hdrhistogram
+
+import (
+	"strconv"
+	"sync"
+	"time"
+
+	hdr "github.com/codahale/hdrhistogram"
+)
+
+// HDRHistogram is a synchronized wrapper over github.com/codahale/hdrhistogram.WindowedHistogram
+type HDRHistogram struct {
+	mu         sync.Mutex
+	hist       *hdr.WindowedHistogram
+	name       string
+	numBuckets int
+	quantiles  []float64
+}
+
+func NewHDRHistogram(name string, numBuckets int, minValue, maxValue int64, sigfigs int, quantiles []float64) *HDRHistogram {
+	h := &HDRHistogram{
+		hist:       hdr.NewWindowed(numBuckets, minValue, maxValue, sigfigs),
+		name:       name,
+		quantiles:  quantiles,
+		numBuckets: numBuckets,
+	}
+	return h
+}
+
+func (h *HDRHistogram) Name() string {
+	return h.name
+}
+
+func (h *HDRHistogram) NumBuckets() int {
+	return h.numBuckets
+}
+
+func (h *HDRHistogram) RecordValue(value int64) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.hist.Current.RecordValue(value)
+}
+
+func (h *HDRHistogram) RecordMicroseconds(value time.Duration) error {
+	return h.RecordValue(int64(value) / 1000)
+}
+
+func (h *HDRHistogram) Rotate() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.hist.Rotate()
+}
+
+// HDRHistogramRegistry is a wrapper to deal with several HDRHistogram instances.
+// After it has been initialized you only can write values into histograms and extract
+// data - do not register histograms dinamically after initial setup.
+type HDRHistogramRegistry struct {
+	histograms map[string]*HDRHistogram
+}
+
+func NewHDRHistogramRegistry() *HDRHistogramRegistry {
+	return &HDRHistogramRegistry{
+		histograms: make(map[string]*HDRHistogram),
+	}
+}
+
+func (r *HDRHistogramRegistry) Register(h *HDRHistogram) {
+	r.histograms[h.Name()] = h
+}
+
+func (r *HDRHistogramRegistry) RecordValue(name string, value int64) error {
+	return r.histograms[name].hist.Current.RecordValue(value)
+}
+
+func (r *HDRHistogramRegistry) RecordMicroseconds(name string, value time.Duration) error {
+	return r.RecordValue(name, int64(value)/1000)
+}
+
+func (r *HDRHistogramRegistry) Rotate() {
+	for _, hist := range r.histograms {
+		hist.hist.Rotate()
+	}
+}
+
+func (r *HDRHistogramRegistry) LoadLatencies() map[string]int64 {
+	latencies := make(map[string]int64)
+	for _, hist := range r.histograms {
+		name := hist.Name()
+		numBuckets := strconv.Itoa(hist.NumBuckets())
+		latencies[name+"_1_count"] = int64(hist.hist.Current.TotalCount())
+		latencies[name+"_1_max"] = int64(hist.hist.Current.Max())
+		latencies[name+"_1_min"] = int64(hist.hist.Current.Min())
+		latencies[name+"_1_mean"] = int64(hist.hist.Current.Mean())
+		for _, q := range hist.quantiles {
+			latencies[name+"_1_"+strconv.FormatFloat(q, 'f', -1, 64)+"%ile"] = int64(hist.hist.Current.ValueAtQuantile(q))
+		}
+		merged := hist.hist.Merge()
+		latencies[name+"_"+numBuckets+"_count"] = int64(merged.TotalCount())
+		latencies[name+"_"+numBuckets+"_max"] = int64(merged.Max())
+		latencies[name+"_"+numBuckets+"_min"] = int64(merged.Min())
+		latencies[name+"_"+numBuckets+"_mean"] = int64(merged.Mean())
+		for _, q := range hist.quantiles {
+			latencies[name+"_"+numBuckets+"_"+strconv.FormatFloat(q, 'f', -1, 64)+"%ile"] = int64(merged.ValueAtQuantile(q))
+		}
+	}
+	return latencies
+}

--- a/libcentrifugo/hdrhistogram/hdrhistogram_test.go
+++ b/libcentrifugo/hdrhistogram/hdrhistogram_test.go
@@ -1,19 +1,52 @@
 package hdrhistogram
 
 import (
-	"strconv"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func TestHDRHistogram(t *testing.T) {
-
+func TestRegistryValueRecording(t *testing.T) {
+	registry := NewHDRHistogramRegistry()
+	hist := NewHDRHistogram("test", 3, 1, 1000, 3, []float64{50.0})
+	registry.Register(hist)
+	err := registry.RecordValue("test", 100)
+	assert.Equal(t, nil, err)
+	err = registry.RecordValue("test", 1000000)
+	assert.NotEqual(t, nil, err, "out of range should return error")
+	err = registry.RecordMicroseconds("test", time.Duration(1000))
+	assert.Equal(t, nil, err)
+	err = registry.RecordMicroseconds("test", time.Duration(10000000))
+	assert.NotEqual(t, nil, err, "out of range should return error")
 }
 
-func BenchmarkHDRHistogram(b *testing.B) {
+func BenchmarkRegistryRecording(b *testing.B) {
+	registry := NewHDRHistogramRegistry()
+	hist := NewHDRHistogram("test", 3, 1, 1000, 3, []float64{50.0})
+	registry.Register(hist)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		println(1)
+		err := registry.RecordValue("test", int64(i%1000))
+		if err != nil {
+			panic(err)
+		}
 	}
+}
+
+func BenchmarkRegistryRecordingParallel(b *testing.B) {
+	registry := NewHDRHistogramRegistry()
+	hist := NewHDRHistogram("test", 3, 1, 1000, 3, []float64{50.0})
+	registry.Register(hist)
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		i := 0
+		for pb.Next() {
+			err := registry.RecordValue("test", int64(i%1000))
+			if err != nil {
+				panic(err)
+			}
+			i++
+		}
+	})
 }

--- a/libcentrifugo/hdrhistogram/hdrhistogram_test.go
+++ b/libcentrifugo/hdrhistogram/hdrhistogram_test.go
@@ -1,0 +1,19 @@
+package hdrhistogram
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHDRHistogram(t *testing.T) {
+
+}
+
+func BenchmarkHDRHistogram(b *testing.B) {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		println(1)
+	}
+}

--- a/libcentrifugo/hdrhistogram/hdrhistogram_test.go
+++ b/libcentrifugo/hdrhistogram/hdrhistogram_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestHDRHistogram(t *testing.T) {
-	hist := NewHDRHistogram("test", 3, 1, 1000, 3, []float64{50.0})
+	hist := NewHDRHistogram("test", 3, 1, 1000, 3, []float64{50.0}, "")
 	err := hist.RecordValue(100)
 	assert.Equal(t, nil, err)
 	err = hist.RecordValue(1000000)
@@ -21,14 +21,14 @@ func TestHDRHistogram(t *testing.T) {
 
 func TestRegistryRegister(t *testing.T) {
 	registry := NewHDRHistogramRegistry()
-	hist := NewHDRHistogram("test", 3, 1, 1000, 3, []float64{50.0})
+	hist := NewHDRHistogram("test", 3, 1, 1000, 3, []float64{50.0}, "")
 	registry.Register(hist)
 	assert.Equal(t, 1, len(registry.histograms))
 }
 
 func TestRegistryValueRecording(t *testing.T) {
 	registry := NewHDRHistogramRegistry()
-	hist := NewHDRHistogram("test", 3, 1, 1000, 3, []float64{50.0})
+	hist := NewHDRHistogram("test", 3, 1, 1000, 3, []float64{50.0}, "")
 	registry.Register(hist)
 	err := registry.RecordValue("test", 100)
 	assert.Equal(t, nil, err)
@@ -42,8 +42,8 @@ func TestRegistryValueRecording(t *testing.T) {
 
 func TestRegistryRotate(t *testing.T) {
 	registry := NewHDRHistogramRegistry()
-	hist1 := NewHDRHistogram("test1", 3, 1, 1000, 3, []float64{50.0})
-	hist2 := NewHDRHistogram("test2", 3, 1, 1000, 3, []float64{50.0})
+	hist1 := NewHDRHistogram("test1", 3, 1, 1000, 3, []float64{50.0}, "")
+	hist2 := NewHDRHistogram("test2", 3, 1, 1000, 3, []float64{50.0}, "")
 	registry.Register(hist1)
 	registry.Register(hist2)
 	registry.RecordValue("test1", 100)
@@ -57,8 +57,8 @@ func TestRegistryRotate(t *testing.T) {
 
 func TestRegistryLoadValues(t *testing.T) {
 	registry := NewHDRHistogramRegistry()
-	hist1 := NewHDRHistogram("test1", 3, 1, 1000, 3, []float64{50.0})
-	hist2 := NewHDRHistogram("test2", 3, 1, 1000, 3, []float64{50.0})
+	hist1 := NewHDRHistogram("test1", 3, 1, 1000, 3, []float64{50.0}, "")
+	hist2 := NewHDRHistogram("test2", 3, 1, 1000, 3, []float64{50.0}, "")
 	registry.Register(hist1)
 	registry.Register(hist2)
 	registry.RecordValue("test1", 100)
@@ -92,8 +92,8 @@ func TestRegistryLoadValues(t *testing.T) {
 
 func TestRegistryLoadValuesCustomOnly(t *testing.T) {
 	registry := NewHDRHistogramRegistry()
-	hist1 := NewHDRHistogram("test1", 3, 1, 1000, 3, []float64{50.0})
-	hist2 := NewHDRHistogram("test2", 3, 1, 1000, 3, []float64{50.0})
+	hist1 := NewHDRHistogram("test1", 3, 1, 1000, 3, []float64{50.0}, "")
+	hist2 := NewHDRHistogram("test2", 3, 1, 1000, 3, []float64{50.0}, "")
 	registry.Register(hist1)
 	registry.Register(hist2)
 	values := registry.LoadValues("test2")
@@ -103,9 +103,18 @@ func TestRegistryLoadValuesCustomOnly(t *testing.T) {
 	assert.False(t, ok)
 }
 
+func TestRegistryLoadValueCustomQuantity(t *testing.T) {
+	registry := NewHDRHistogramRegistry()
+	hist := NewHDRHistogram("test", 3, 1, 1000, 3, []float64{50.0}, "microseconds")
+	registry.Register(hist)
+	values := registry.LoadValues("test")
+	_, ok := values["test_1_microseconds_mean"]
+	assert.True(t, ok)
+}
+
 func BenchmarkRegistryRecording(b *testing.B) {
 	registry := NewHDRHistogramRegistry()
-	hist := NewHDRHistogram("test", 3, 1, 1000, 3, []float64{50.0})
+	hist := NewHDRHistogram("test", 3, 1, 1000, 3, []float64{50.0}, "")
 	registry.Register(hist)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -118,7 +127,7 @@ func BenchmarkRegistryRecording(b *testing.B) {
 
 func BenchmarkRegistryRecordingParallel(b *testing.B) {
 	registry := NewHDRHistogramRegistry()
-	hist := NewHDRHistogram("test", 3, 1, 1000, 3, []float64{50.0})
+	hist := NewHDRHistogram("test", 3, 1, 1000, 3, []float64{50.0}, "")
 	registry.Register(hist)
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {

--- a/libcentrifugo/hdrhistogram/hdrhistogram_test.go
+++ b/libcentrifugo/hdrhistogram/hdrhistogram_test.go
@@ -7,6 +7,25 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestHDRHistogram(t *testing.T) {
+	hist := NewHDRHistogram("test", 3, 1, 1000, 3, []float64{50.0})
+	err := hist.RecordValue(100)
+	assert.Equal(t, nil, err)
+	err = hist.RecordValue(1000000)
+	assert.NotEqual(t, nil, err, "out of range should return error")
+	err = hist.RecordMicroseconds(time.Duration(1000))
+	assert.Equal(t, nil, err)
+	err = hist.RecordMicroseconds(time.Duration(10000000))
+	assert.NotEqual(t, nil, err, "out of range should return error")
+}
+
+func TestRegistryRegister(t *testing.T) {
+	registry := NewHDRHistogramRegistry()
+	hist := NewHDRHistogram("test", 3, 1, 1000, 3, []float64{50.0})
+	registry.Register(hist)
+	assert.Equal(t, 1, len(registry.histograms))
+}
+
 func TestRegistryValueRecording(t *testing.T) {
 	registry := NewHDRHistogramRegistry()
 	hist := NewHDRHistogram("test", 3, 1, 1000, 3, []float64{50.0})
@@ -19,6 +38,69 @@ func TestRegistryValueRecording(t *testing.T) {
 	assert.Equal(t, nil, err)
 	err = registry.RecordMicroseconds("test", time.Duration(10000000))
 	assert.NotEqual(t, nil, err, "out of range should return error")
+}
+
+func TestRegistryRotate(t *testing.T) {
+	registry := NewHDRHistogramRegistry()
+	hist1 := NewHDRHistogram("test1", 3, 1, 1000, 3, []float64{50.0})
+	hist2 := NewHDRHistogram("test2", 3, 1, 1000, 3, []float64{50.0})
+	registry.Register(hist1)
+	registry.Register(hist2)
+	registry.RecordValue("test1", 100)
+	registry.RecordValue("test2", 200)
+	assert.Equal(t, registry.histograms["test1"].hist.Current.Max(), int64(100))
+	assert.Equal(t, registry.histograms["test2"].hist.Current.Max(), int64(200))
+	registry.Rotate()
+	assert.Equal(t, registry.histograms["test1"].hist.Current.Max(), int64(0))
+	assert.Equal(t, registry.histograms["test2"].hist.Current.Max(), int64(0))
+}
+
+func TestRegistryLoadValues(t *testing.T) {
+	registry := NewHDRHistogramRegistry()
+	hist1 := NewHDRHistogram("test1", 3, 1, 1000, 3, []float64{50.0})
+	hist2 := NewHDRHistogram("test2", 3, 1, 1000, 3, []float64{50.0})
+	registry.Register(hist1)
+	registry.Register(hist2)
+	registry.RecordValue("test1", 100)
+	registry.RecordValue("test2", 200)
+	registry.RecordValue("test1", 200)
+	registry.RecordValue("test2", 100)
+	values := registry.LoadValues()
+	assert.Equal(t, int64(150), values["test1_3_mean"])
+	assert.Equal(t, int64(150), values["test1_1_mean"])
+	assert.Equal(t, int64(150), values["test2_3_mean"])
+	assert.Equal(t, int64(150), values["test2_1_mean"])
+	assert.Equal(t, int64(200), values["test1_3_max"])
+	assert.Equal(t, int64(200), values["test1_1_max"])
+	assert.Equal(t, int64(200), values["test2_3_max"])
+	assert.Equal(t, int64(200), values["test2_1_max"])
+	registry.Rotate()
+	registry.RecordValue("test1", 200)
+	registry.RecordValue("test2", 300)
+	registry.RecordValue("test1", 300)
+	registry.RecordValue("test2", 200)
+	values = registry.LoadValues()
+	assert.Equal(t, int64(200), values["test1_3_mean"])
+	assert.Equal(t, int64(250), values["test1_1_mean"])
+	assert.Equal(t, int64(200), values["test2_3_mean"])
+	assert.Equal(t, int64(250), values["test2_1_mean"])
+	assert.Equal(t, int64(300), values["test1_3_max"])
+	assert.Equal(t, int64(300), values["test1_1_max"])
+	assert.Equal(t, int64(300), values["test2_3_max"])
+	assert.Equal(t, int64(300), values["test2_1_max"])
+}
+
+func TestRegistryLoadValuesCustomOnly(t *testing.T) {
+	registry := NewHDRHistogramRegistry()
+	hist1 := NewHDRHistogram("test1", 3, 1, 1000, 3, []float64{50.0})
+	hist2 := NewHDRHistogram("test2", 3, 1, 1000, 3, []float64{50.0})
+	registry.Register(hist1)
+	registry.Register(hist2)
+	values := registry.LoadValues("test2")
+	_, ok := values["test2_3_mean"]
+	assert.True(t, ok)
+	_, ok = values["test1_3_mean"]
+	assert.False(t, ok)
 }
 
 func BenchmarkRegistryRecording(b *testing.B) {

--- a/libcentrifugo/metrics.go
+++ b/libcentrifugo/metrics.go
@@ -12,6 +12,7 @@ import (
 	"sync/atomic"
 
 	"github.com/FZambia/go-logger"
+	"github.com/centrifugal/centrifugo/libcentrifugo/hdrhistogram"
 )
 
 // serverStats contains state and metrics information from running Centrifugo nodes.
@@ -71,6 +72,11 @@ type metrics struct {
 	// TimeClientMax shows maximum response time to client request. DEPRECATED!
 	TimeClientMax int64 `json:"time_client_max"`
 
+	// Latencies is a map of latency distributions. Currently it includes latency distribution
+	// of HTTP API response times and client response times. Every type includes distribution
+	// over short time period N (by default 1min) and 15*N period (by default 15min).
+	Latencies map[string]int64 `json:"latencies"`
+
 	// MemSys shows system memory usage in bytes.
 	MemSys int64 `json:"memory_sys"`
 
@@ -96,10 +102,7 @@ type metricsRegistry struct {
 	NumClientRequests metricCounter
 	BytesClientIn     metricCounter
 	BytesClientOut    metricCounter
-	TimeAPIMean       int64 // Deprecated
-	TimeClientMean    int64 // Deprecated
-	TimeAPIMax        int64 // Deprecated
-	TimeClientMax     int64 // Deprecated
+	histograms        *hdrhistogram.HDRHistogramRegistry
 	MemSys            int64
 	CPU               int64
 
@@ -107,6 +110,24 @@ type metricsRegistry struct {
 	// but raw counters may still increment atomically while held so it's not a strict
 	// point-in-time snapshot of all values.
 	mu sync.Mutex
+}
+
+func newMetricsHistogramRegistry() *hdrhistogram.HDRHistogramRegistry {
+	quantiles := []float64{50, 90, 99, 99.99}
+	var minValue int64 = 1        // as we record latencies in microseconds, min resolution 1mks
+	var maxValue int64 = 10000000 // as we record latencies in microseconds, max resolution 10s
+	numBuckets := 15              // histograms will be rotated every time we call UpdateSnapshot from outside.
+	sigfigs := 3
+	registry := hdrhistogram.NewHDRHistogramRegistry()
+	registry.Register(hdrhistogram.NewHDRHistogram("http_api", numBuckets, minValue, maxValue, sigfigs, quantiles))
+	registry.Register(hdrhistogram.NewHDRHistogram("client_api", numBuckets, minValue, maxValue, sigfigs, quantiles))
+	return registry
+}
+
+func newMetricsRegistry() *metricsRegistry {
+	registry := &metricsRegistry{}
+	registry.histograms = newMetricsHistogramRegistry()
+	return registry
 }
 
 // metricCounter is a wrapper around a set of int64s that count things.
@@ -182,6 +203,8 @@ func (m *metricsRegistry) UpdateSnapshot() {
 	m.NumClientRequests.updateDelta()
 	m.BytesClientIn.updateDelta()
 	m.BytesClientOut.updateDelta()
+
+	m.histograms.Rotate()
 }
 
 // GetRawMetrics returns a read-only copy of the raw counter values.
@@ -199,6 +222,7 @@ func (m *metricsRegistry) GetRawMetrics() *metrics {
 		BytesClientOut:    m.BytesClientOut.LoadRaw(),
 		MemSys:            atomic.LoadInt64(&m.MemSys),
 		CPU:               atomic.LoadInt64(&m.CPU),
+		Latencies:         m.histograms.LoadLatencies(),
 	}
 }
 
@@ -218,6 +242,7 @@ func (m *metricsRegistry) GetSnapshotMetrics() *metrics {
 		BytesClientOut:    m.BytesClientOut.LastIn(),
 		MemSys:            atomic.LoadInt64(&m.MemSys),
 		CPU:               atomic.LoadInt64(&m.CPU),
+		Latencies:         m.histograms.LoadLatencies(),
 	}
 }
 

--- a/libcentrifugo/metrics.go
+++ b/libcentrifugo/metrics.go
@@ -115,7 +115,7 @@ type metricsRegistry struct {
 func newMetricsHistogramRegistry() *hdrhistogram.HDRHistogramRegistry {
 	quantiles := []float64{50, 90, 99, 99.99}
 	var minValue int64 = 1        // as we record latencies in microseconds, min resolution 1mks
-	var maxValue int64 = 10000000 // as we record latencies in microseconds, max resolution 10s
+	var maxValue int64 = 60000000 // as we record latencies in microseconds, max resolution 60s
 	numBuckets := 15              // histograms will be rotated every time we call UpdateSnapshot from outside.
 	sigfigs := 3
 	registry := hdrhistogram.NewHDRHistogramRegistry()

--- a/libcentrifugo/metrics.go
+++ b/libcentrifugo/metrics.go
@@ -222,7 +222,7 @@ func (m *metricsRegistry) GetRawMetrics() *metrics {
 		BytesClientOut:    m.BytesClientOut.LoadRaw(),
 		MemSys:            atomic.LoadInt64(&m.MemSys),
 		CPU:               atomic.LoadInt64(&m.CPU),
-		Latencies:         m.histograms.LoadLatencies(),
+		Latencies:         m.histograms.LoadValues(),
 	}
 }
 
@@ -242,7 +242,7 @@ func (m *metricsRegistry) GetSnapshotMetrics() *metrics {
 		BytesClientOut:    m.BytesClientOut.LastIn(),
 		MemSys:            atomic.LoadInt64(&m.MemSys),
 		CPU:               atomic.LoadInt64(&m.CPU),
-		Latencies:         m.histograms.LoadLatencies(),
+		Latencies:         m.histograms.LoadValues(),
 	}
 }
 

--- a/libcentrifugo/metrics.go
+++ b/libcentrifugo/metrics.go
@@ -119,8 +119,8 @@ func newMetricsHistogramRegistry() *hdrhistogram.HDRHistogramRegistry {
 	numBuckets := 15              // histograms will be rotated every time we call UpdateSnapshot from outside.
 	sigfigs := 3
 	registry := hdrhistogram.NewHDRHistogramRegistry()
-	registry.Register(hdrhistogram.NewHDRHistogram("http_api", numBuckets, minValue, maxValue, sigfigs, quantiles))
-	registry.Register(hdrhistogram.NewHDRHistogram("client_api", numBuckets, minValue, maxValue, sigfigs, quantiles))
+	registry.Register(hdrhistogram.NewHDRHistogram("http_api", numBuckets, minValue, maxValue, sigfigs, quantiles, "microseconds"))
+	registry.Register(hdrhistogram.NewHDRHistogram("client_api", numBuckets, minValue, maxValue, sigfigs, quantiles, "microseconds"))
 	return registry
 }
 

--- a/vendor/github.com/codahale/hdrhistogram/LICENSE
+++ b/vendor/github.com/codahale/hdrhistogram/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 Coda Hale
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/vendor/github.com/codahale/hdrhistogram/README.md
+++ b/vendor/github.com/codahale/hdrhistogram/README.md
@@ -1,0 +1,15 @@
+hdrhistogram
+============
+
+[![Build Status](https://travis-ci.org/codahale/hdrhistogram.png?branch=master)](https://travis-ci.org/codahale/hdrhistogram)
+
+A pure Go implementation of the [HDR Histogram](https://github.com/HdrHistogram/HdrHistogram).
+
+> A Histogram that supports recording and analyzing sampled data value counts
+> across a configurable integer value range with configurable value precision
+> within the range. Value precision is expressed as the number of significant
+> digits in the value recording, and provides control over value quantization
+> behavior across the value range and the subsequent value resolution at any
+> given level.
+
+For documentation, check [godoc](http://godoc.org/github.com/codahale/hdrhistogram).

--- a/vendor/github.com/codahale/hdrhistogram/hdr.go
+++ b/vendor/github.com/codahale/hdrhistogram/hdr.go
@@ -1,0 +1,563 @@
+// Package hdrhistogram provides an implementation of Gil Tene's HDR Histogram
+// data structure. The HDR Histogram allows for fast and accurate analysis of
+// the extreme ranges of data with non-normal distributions, like latency.
+package hdrhistogram
+
+import (
+	"fmt"
+	"math"
+)
+
+// A Bracket is a part of a cumulative distribution.
+type Bracket struct {
+	Quantile       float64
+	Count, ValueAt int64
+}
+
+// A Snapshot is an exported view of a Histogram, useful for serializing them.
+// A Histogram can be constructed from it by passing it to Import.
+type Snapshot struct {
+	LowestTrackableValue  int64
+	HighestTrackableValue int64
+	SignificantFigures    int64
+	Counts                []int64
+}
+
+// A Histogram is a lossy data structure used to record the distribution of
+// non-normally distributed data (like latency) with a high degree of accuracy
+// and a bounded degree of precision.
+type Histogram struct {
+	lowestTrackableValue        int64
+	highestTrackableValue       int64
+	unitMagnitude               int64
+	significantFigures          int64
+	subBucketHalfCountMagnitude int32
+	subBucketHalfCount          int32
+	subBucketMask               int64
+	subBucketCount              int32
+	bucketCount                 int32
+	countsLen                   int32
+	totalCount                  int64
+	counts                      []int64
+}
+
+// New returns a new Histogram instance capable of tracking values in the given
+// range and with the given amount of precision.
+func New(minValue, maxValue int64, sigfigs int) *Histogram {
+	if sigfigs < 1 || 5 < sigfigs {
+		panic(fmt.Errorf("sigfigs must be [1,5] (was %d)", sigfigs))
+	}
+
+	largestValueWithSingleUnitResolution := 2 * math.Pow10(sigfigs)
+	subBucketCountMagnitude := int32(math.Ceil(math.Log2(float64(largestValueWithSingleUnitResolution))))
+
+	subBucketHalfCountMagnitude := subBucketCountMagnitude
+	if subBucketHalfCountMagnitude < 1 {
+		subBucketHalfCountMagnitude = 1
+	}
+	subBucketHalfCountMagnitude--
+
+	unitMagnitude := int32(math.Floor(math.Log2(float64(minValue))))
+	if unitMagnitude < 0 {
+		unitMagnitude = 0
+	}
+
+	subBucketCount := int32(math.Pow(2, float64(subBucketHalfCountMagnitude)+1))
+
+	subBucketHalfCount := subBucketCount / 2
+	subBucketMask := int64(subBucketCount-1) << uint(unitMagnitude)
+
+	// determine exponent range needed to support the trackable value with no
+	// overflow:
+	smallestUntrackableValue := int64(subBucketCount) << uint(unitMagnitude)
+	bucketsNeeded := int32(1)
+	for smallestUntrackableValue < maxValue {
+		smallestUntrackableValue <<= 1
+		bucketsNeeded++
+	}
+
+	bucketCount := bucketsNeeded
+	countsLen := (bucketCount + 1) * (subBucketCount / 2)
+
+	return &Histogram{
+		lowestTrackableValue:        minValue,
+		highestTrackableValue:       maxValue,
+		unitMagnitude:               int64(unitMagnitude),
+		significantFigures:          int64(sigfigs),
+		subBucketHalfCountMagnitude: subBucketHalfCountMagnitude,
+		subBucketHalfCount:          subBucketHalfCount,
+		subBucketMask:               subBucketMask,
+		subBucketCount:              subBucketCount,
+		bucketCount:                 bucketCount,
+		countsLen:                   countsLen,
+		totalCount:                  0,
+		counts:                      make([]int64, countsLen),
+	}
+}
+
+// ByteSize returns an estimate of the amount of memory allocated to the
+// histogram in bytes.
+//
+// N.B.: This does not take into account the overhead for slices, which are
+// small, constant, and specific to the compiler version.
+func (h *Histogram) ByteSize() int {
+	return 6*8 + 5*4 + len(h.counts)*8
+}
+
+// Merge merges the data stored in the given histogram with the receiver,
+// returning the number of recorded values which had to be dropped.
+func (h *Histogram) Merge(from *Histogram) (dropped int64) {
+	i := from.rIterator()
+	for i.next() {
+		v := i.valueFromIdx
+		c := i.countAtIdx
+
+		if h.RecordValues(v, c) != nil {
+			dropped += c
+		}
+	}
+
+	return
+}
+
+// TotalCount returns total number of values recorded.
+func (h *Histogram) TotalCount() int64 {
+	return h.totalCount
+}
+
+// Max returns the approximate maximum recorded value.
+func (h *Histogram) Max() int64 {
+	var max int64
+	i := h.iterator()
+	for i.next() {
+		if i.countAtIdx != 0 {
+			max = i.highestEquivalentValue
+		}
+	}
+	return h.highestEquivalentValue(max)
+}
+
+// Min returns the approximate minimum recorded value.
+func (h *Histogram) Min() int64 {
+	var min int64
+	i := h.iterator()
+	for i.next() {
+		if i.countAtIdx != 0 && min == 0 {
+			min = i.highestEquivalentValue
+			break
+		}
+	}
+	return h.lowestEquivalentValue(min)
+}
+
+// Mean returns the approximate arithmetic mean of the recorded values.
+func (h *Histogram) Mean() float64 {
+	if h.totalCount == 0 {
+		return 0
+	}
+	var total int64
+	i := h.iterator()
+	for i.next() {
+		if i.countAtIdx != 0 {
+			total += i.countAtIdx * h.medianEquivalentValue(i.valueFromIdx)
+		}
+	}
+	return float64(total) / float64(h.totalCount)
+}
+
+// StdDev returns the approximate standard deviation of the recorded values.
+func (h *Histogram) StdDev() float64 {
+	if h.totalCount == 0 {
+		return 0
+	}
+
+	mean := h.Mean()
+	geometricDevTotal := 0.0
+
+	i := h.iterator()
+	for i.next() {
+		if i.countAtIdx != 0 {
+			dev := float64(h.medianEquivalentValue(i.valueFromIdx)) - mean
+			geometricDevTotal += (dev * dev) * float64(i.countAtIdx)
+		}
+	}
+
+	return math.Sqrt(geometricDevTotal / float64(h.totalCount))
+}
+
+// Reset deletes all recorded values and restores the histogram to its original
+// state.
+func (h *Histogram) Reset() {
+	h.totalCount = 0
+	for i := range h.counts {
+		h.counts[i] = 0
+	}
+}
+
+// RecordValue records the given value, returning an error if the value is out
+// of range.
+func (h *Histogram) RecordValue(v int64) error {
+	return h.RecordValues(v, 1)
+}
+
+// RecordCorrectedValue records the given value, correcting for stalls in the
+// recording process. This only works for processes which are recording values
+// at an expected interval (e.g., doing jitter analysis). Processes which are
+// recording ad-hoc values (e.g., latency for incoming requests) can't take
+// advantage of this.
+func (h *Histogram) RecordCorrectedValue(v, expectedInterval int64) error {
+	if err := h.RecordValue(v); err != nil {
+		return err
+	}
+
+	if expectedInterval <= 0 || v <= expectedInterval {
+		return nil
+	}
+
+	missingValue := v - expectedInterval
+	for missingValue >= expectedInterval {
+		if err := h.RecordValue(missingValue); err != nil {
+			return err
+		}
+		missingValue -= expectedInterval
+	}
+
+	return nil
+}
+
+// RecordValues records n occurrences of the given value, returning an error if
+// the value is out of range.
+func (h *Histogram) RecordValues(v, n int64) error {
+	idx := h.countsIndexFor(v)
+	if idx < 0 || int(h.countsLen) <= idx {
+		return fmt.Errorf("value %d is too large to be recorded", v)
+	}
+	h.counts[idx] += n
+	h.totalCount += n
+
+	return nil
+}
+
+// ValueAtQuantile returns the recorded value at the given quantile (0..100).
+func (h *Histogram) ValueAtQuantile(q float64) int64 {
+	if q > 100 {
+		q = 100
+	}
+
+	total := int64(0)
+	countAtPercentile := int64(((q / 100) * float64(h.totalCount)) + 0.5)
+
+	i := h.iterator()
+	for i.next() {
+		total += i.countAtIdx
+		if total >= countAtPercentile {
+			return h.highestEquivalentValue(i.valueFromIdx)
+		}
+	}
+
+	return 0
+}
+
+// CumulativeDistribution returns an ordered list of brackets of the
+// distribution of recorded values.
+func (h *Histogram) CumulativeDistribution() []Bracket {
+	var result []Bracket
+
+	i := h.pIterator(1)
+	for i.next() {
+		result = append(result, Bracket{
+			Quantile: i.percentile,
+			Count:    i.countToIdx,
+			ValueAt:  i.highestEquivalentValue,
+		})
+	}
+
+	return result
+}
+
+// SignificantFigures returns the significant figures used to create the
+// histogram
+func (h *Histogram) SignificantFigures() int64 {
+	return h.significantFigures
+}
+
+// LowestTrackableValue returns the lower bound on values that will be added
+// to the histogram
+func (h *Histogram) LowestTrackableValue() int64 {
+	return h.lowestTrackableValue
+}
+
+// HighestTrackableValue returns the upper bound on values that will be added
+// to the histogram
+func (h *Histogram) HighestTrackableValue() int64 {
+	return h.highestTrackableValue
+}
+
+// Histogram bar for plotting
+type Bar struct {
+	From, To, Count int64
+}
+
+// Pretty print as csv for easy plotting
+func (b Bar) String() string {
+	return fmt.Sprintf("%v, %v, %v\n", b.From, b.To, b.Count)
+}
+
+// Distribution returns an ordered list of bars of the
+// distribution of recorded values, counts can be normalized to a probability
+func (h *Histogram) Distribution() (result []Bar) {
+	i := h.iterator()
+	for i.next() {
+		result = append(result, Bar{
+			Count: i.countAtIdx,
+			From:  h.lowestEquivalentValue(i.valueFromIdx),
+			To:    i.highestEquivalentValue,
+		})
+	}
+
+	return result
+}
+
+// Equals returns true if the two Histograms are equivalent, false if not.
+func (h *Histogram) Equals(other *Histogram) bool {
+	switch {
+	case
+		h.lowestTrackableValue != other.lowestTrackableValue,
+		h.highestTrackableValue != other.highestTrackableValue,
+		h.unitMagnitude != other.unitMagnitude,
+		h.significantFigures != other.significantFigures,
+		h.subBucketHalfCountMagnitude != other.subBucketHalfCountMagnitude,
+		h.subBucketHalfCount != other.subBucketHalfCount,
+		h.subBucketMask != other.subBucketMask,
+		h.subBucketCount != other.subBucketCount,
+		h.bucketCount != other.bucketCount,
+		h.countsLen != other.countsLen,
+		h.totalCount != other.totalCount:
+		return false
+	default:
+		for i, c := range h.counts {
+			if c != other.counts[i] {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// Export returns a snapshot view of the Histogram. This can be later passed to
+// Import to construct a new Histogram with the same state.
+func (h *Histogram) Export() *Snapshot {
+	return &Snapshot{
+		LowestTrackableValue:  h.lowestTrackableValue,
+		HighestTrackableValue: h.highestTrackableValue,
+		SignificantFigures:    h.significantFigures,
+		Counts:                h.counts,
+	}
+}
+
+// Import returns a new Histogram populated from the Snapshot data.
+func Import(s *Snapshot) *Histogram {
+	h := New(s.LowestTrackableValue, s.HighestTrackableValue, int(s.SignificantFigures))
+	h.counts = s.Counts
+	totalCount := int64(0)
+	for i := int32(0); i < h.countsLen; i++ {
+		countAtIndex := h.counts[i]
+		if countAtIndex > 0 {
+			totalCount += countAtIndex
+		}
+	}
+	h.totalCount = totalCount
+	return h
+}
+
+func (h *Histogram) iterator() *iterator {
+	return &iterator{
+		h:            h,
+		subBucketIdx: -1,
+	}
+}
+
+func (h *Histogram) rIterator() *rIterator {
+	return &rIterator{
+		iterator: iterator{
+			h:            h,
+			subBucketIdx: -1,
+		},
+	}
+}
+
+func (h *Histogram) pIterator(ticksPerHalfDistance int32) *pIterator {
+	return &pIterator{
+		iterator: iterator{
+			h:            h,
+			subBucketIdx: -1,
+		},
+		ticksPerHalfDistance: ticksPerHalfDistance,
+	}
+}
+
+func (h *Histogram) sizeOfEquivalentValueRange(v int64) int64 {
+	bucketIdx := h.getBucketIndex(v)
+	subBucketIdx := h.getSubBucketIdx(v, bucketIdx)
+	adjustedBucket := bucketIdx
+	if subBucketIdx >= h.subBucketCount {
+		adjustedBucket++
+	}
+	return int64(1) << uint(h.unitMagnitude+int64(adjustedBucket))
+}
+
+func (h *Histogram) valueFromIndex(bucketIdx, subBucketIdx int32) int64 {
+	return int64(subBucketIdx) << uint(int64(bucketIdx)+h.unitMagnitude)
+}
+
+func (h *Histogram) lowestEquivalentValue(v int64) int64 {
+	bucketIdx := h.getBucketIndex(v)
+	subBucketIdx := h.getSubBucketIdx(v, bucketIdx)
+	return h.valueFromIndex(bucketIdx, subBucketIdx)
+}
+
+func (h *Histogram) nextNonEquivalentValue(v int64) int64 {
+	return h.lowestEquivalentValue(v) + h.sizeOfEquivalentValueRange(v)
+}
+
+func (h *Histogram) highestEquivalentValue(v int64) int64 {
+	return h.nextNonEquivalentValue(v) - 1
+}
+
+func (h *Histogram) medianEquivalentValue(v int64) int64 {
+	return h.lowestEquivalentValue(v) + (h.sizeOfEquivalentValueRange(v) >> 1)
+}
+
+func (h *Histogram) getCountAtIndex(bucketIdx, subBucketIdx int32) int64 {
+	return h.counts[h.countsIndex(bucketIdx, subBucketIdx)]
+}
+
+func (h *Histogram) countsIndex(bucketIdx, subBucketIdx int32) int32 {
+	bucketBaseIdx := (bucketIdx + 1) << uint(h.subBucketHalfCountMagnitude)
+	offsetInBucket := subBucketIdx - h.subBucketHalfCount
+	return bucketBaseIdx + offsetInBucket
+}
+
+func (h *Histogram) getBucketIndex(v int64) int32 {
+	pow2Ceiling := bitLen(v | h.subBucketMask)
+	return int32(pow2Ceiling - int64(h.unitMagnitude) -
+		int64(h.subBucketHalfCountMagnitude+1))
+}
+
+func (h *Histogram) getSubBucketIdx(v int64, idx int32) int32 {
+	return int32(v >> uint(int64(idx)+int64(h.unitMagnitude)))
+}
+
+func (h *Histogram) countsIndexFor(v int64) int {
+	bucketIdx := h.getBucketIndex(v)
+	subBucketIdx := h.getSubBucketIdx(v, bucketIdx)
+	return int(h.countsIndex(bucketIdx, subBucketIdx))
+}
+
+type iterator struct {
+	h                                    *Histogram
+	bucketIdx, subBucketIdx              int32
+	countAtIdx, countToIdx, valueFromIdx int64
+	highestEquivalentValue               int64
+}
+
+func (i *iterator) next() bool {
+	if i.countToIdx >= i.h.totalCount {
+		return false
+	}
+
+	// increment bucket
+	i.subBucketIdx++
+	if i.subBucketIdx >= i.h.subBucketCount {
+		i.subBucketIdx = i.h.subBucketHalfCount
+		i.bucketIdx++
+	}
+
+	if i.bucketIdx >= i.h.bucketCount {
+		return false
+	}
+
+	i.countAtIdx = i.h.getCountAtIndex(i.bucketIdx, i.subBucketIdx)
+	i.countToIdx += i.countAtIdx
+	i.valueFromIdx = i.h.valueFromIndex(i.bucketIdx, i.subBucketIdx)
+	i.highestEquivalentValue = i.h.highestEquivalentValue(i.valueFromIdx)
+
+	return true
+}
+
+type rIterator struct {
+	iterator
+	countAddedThisStep int64
+}
+
+func (r *rIterator) next() bool {
+	for r.iterator.next() {
+		if r.countAtIdx != 0 {
+			r.countAddedThisStep = r.countAtIdx
+			return true
+		}
+	}
+	return false
+}
+
+type pIterator struct {
+	iterator
+	seenLastValue          bool
+	ticksPerHalfDistance   int32
+	percentileToIteratorTo float64
+	percentile             float64
+}
+
+func (p *pIterator) next() bool {
+	if !(p.countToIdx < p.h.totalCount) {
+		if p.seenLastValue {
+			return false
+		}
+
+		p.seenLastValue = true
+		p.percentile = 100
+
+		return true
+	}
+
+	if p.subBucketIdx == -1 && !p.iterator.next() {
+		return false
+	}
+
+	var done = false
+	for !done {
+		currentPercentile := (100.0 * float64(p.countToIdx)) / float64(p.h.totalCount)
+		if p.countAtIdx != 0 && p.percentileToIteratorTo <= currentPercentile {
+			p.percentile = p.percentileToIteratorTo
+			halfDistance := math.Trunc(math.Pow(2, math.Trunc(math.Log2(100.0/(100.0-p.percentileToIteratorTo)))+1))
+			percentileReportingTicks := float64(p.ticksPerHalfDistance) * halfDistance
+			p.percentileToIteratorTo += 100.0 / percentileReportingTicks
+			return true
+		}
+		done = !p.iterator.next()
+	}
+
+	return true
+}
+
+func bitLen(x int64) (n int64) {
+	for ; x >= 0x8000; x >>= 16 {
+		n += 16
+	}
+	if x >= 0x80 {
+		x >>= 8
+		n += 8
+	}
+	if x >= 0x8 {
+		x >>= 4
+		n += 4
+	}
+	if x >= 0x2 {
+		x >>= 2
+		n += 2
+	}
+	if x >= 0x1 {
+		n++
+	}
+	return
+}

--- a/vendor/github.com/codahale/hdrhistogram/window.go
+++ b/vendor/github.com/codahale/hdrhistogram/window.go
@@ -1,0 +1,45 @@
+package hdrhistogram
+
+// A WindowedHistogram combines histograms to provide windowed statistics.
+type WindowedHistogram struct {
+	idx int
+	h   []Histogram
+	m   *Histogram
+
+	Current *Histogram
+}
+
+// NewWindowed creates a new WindowedHistogram with N underlying histograms with
+// the given parameters.
+func NewWindowed(n int, minValue, maxValue int64, sigfigs int) *WindowedHistogram {
+	w := WindowedHistogram{
+		idx: -1,
+		h:   make([]Histogram, n),
+		m:   New(minValue, maxValue, sigfigs),
+	}
+
+	for i := range w.h {
+		w.h[i] = *New(minValue, maxValue, sigfigs)
+	}
+	w.Rotate()
+
+	return &w
+}
+
+// Merge returns a histogram which includes the recorded values from all the
+// sections of the window.
+func (w *WindowedHistogram) Merge() *Histogram {
+	w.m.Reset()
+	for _, h := range w.h {
+		w.m.Merge(&h)
+	}
+	return w.m
+}
+
+// Rotate resets the oldest histogram and rotates it to be used as the current
+// histogram.
+func (w *WindowedHistogram) Rotate() {
+	w.idx++
+	w.Current = &w.h[w.idx%len(w.h)]
+	w.Current.Reset()
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -262,6 +262,12 @@
 			"revisionTime": "2015-01-07T20:56:47Z"
 		},
 		{
+			"checksumSHA1": "W7DNxQwdGQ2YO3PR3jARJg6Iqsw=",
+			"path": "github.com/codahale/hdrhistogram",
+			"revision": "f8ad88b59a584afeee9d334eff879b104439117b",
+			"revisionTime": "2016-04-25T23:15:03Z"
+		},
+		{
 			"checksumSHA1": "+Qd5km5Hgsg8P3LXL8xX6YTZVvs=",
 			"path": "github.com/coreos/go-etcd/etcd",
 			"revision": "73a8ef737e8ea002281a28b4cb92a1de121ad4c6",


### PR DESCRIPTION
Here is first (without tests yet) implementation of latencies for HTTP API response times and client API response times. I am planning to finish this soon - here just showing first concept.

There are some caveats - for example we include latencies for different types of methods (publish, broadcast, presence etc) into one histogram. It's rather hard to separate these all into different histograms. Maybe if we had different API handlers for all methods it would be more logical. But anyway those resulting numbers can be useful for monitoring.

Also I should still think about proper synchronization.

Example of stats:

```json
{
    "uid": "2",
    "method": "stats",
    "error": null,
    "body": {
        "data": {
            "nodes": [
                {
                    "uid": "918600b0-69e8-4380-8d86-644e4eb9068b",
                    "name": "MacAir.local_8000",
                    "num_goroutine": 37,
                    "num_clients": 1,
                    "num_unique_clients": 1,
                    "num_channels": 4,
                    "started_at": 1469740187,
                    "gomaxprocs": 4,
                    "num_cpu": 4,
                    "num_msg_published": 0,
                    "num_msg_queued": 0,
                    "num_msg_sent": 0,
                    "num_api_requests": 0,
                    "num_client_requests": 0,
                    "bytes_client_in": 0,
                    "bytes_client_out": 0,
                    "time_api_mean": 0,
                    "time_client_mean": 0,
                    "time_api_max": 0,
                    "time_client_max": 0,
                    "latencies": {
                        "client_api_15_count": 22,
                        "client_api_15_microseconds_50%ile": 184,
                        "client_api_15_microseconds_90%ile": 1880,
                        "client_api_15_microseconds_99%ile": 3185,
                        "client_api_15_microseconds_99.99%ile": 3185,
                        "client_api_15_microseconds_max": 3185,
                        "client_api_15_microseconds_mean": 560,
                        "client_api_15_microseconds_min": 116,
                        "client_api_1_count": 22,
                        "client_api_1_microseconds_50%ile": 184,
                        "client_api_1_microseconds_90%ile": 1880,
                        "client_api_1_microseconds_99%ile": 3185,
                        "client_api_1_microseconds_99.99%ile": 3185,
                        "client_api_1_microseconds_max": 3185,
                        "client_api_1_microseconds_mean": 560,
                        "client_api_1_microseconds_min": 116,
                        "http_api_15_count": 484579,
                        "http_api_15_microseconds_50%ile": 52,
                        "http_api_15_microseconds_90%ile": 125,
                        "http_api_15_microseconds_99%ile": 1221,
                        "http_api_15_microseconds_99.99%ile": 51295,
                        "http_api_15_microseconds_max": 173567,
                        "http_api_15_microseconds_mean": 130,
                        "http_api_15_microseconds_min": 35,
                        "http_api_1_count": 484579,
                        "http_api_1_microseconds_50%ile": 52,
                        "http_api_1_microseconds_90%ile": 125,
                        "http_api_1_microseconds_99%ile": 1218,
                        "http_api_1_microseconds_99.99%ile": 46687,
                        "http_api_1_microseconds_max": 173567,
                        "http_api_1_microseconds_mean": 130,
                        "http_api_1_microseconds_min": 35
                    },
                    "memory_sys": 0,
                    "cpu_usage": 0
                }
            ],
            "metrics_interval": 60
        }
    }
}
```