### PR TITLE
Message trace logs

### DIFF
--- a/libcentrifugo/application.go
+++ b/libcentrifugo/application.go
@@ -221,6 +221,10 @@ func (app *Application) controlMsg(cmd *ControlMessage) error {
 	method := cmd.Method
 	params := cmd.Params
 
+	if logger.TRACE.Enabled() {
+		logger.TRACE.Printf("Control %s message from node: %s", cmd.Method, cmd.UID)
+	}
+
 	switch method {
 	case "ping":
 		var cmd pingControlCommand

--- a/libcentrifugo/application.go
+++ b/libcentrifugo/application.go
@@ -255,8 +255,12 @@ func (app *Application) controlMsg(cmd *ControlMessage) error {
 // adminMsg handlesadmin message broadcasting it to all admins connected to this node.
 func (app *Application) adminMsg(message *AdminMessage) error {
 	app.admins.RLock()
-	hasAdmins := len(app.admins.connections) > 0
+	numAdmins := len(app.admins.connections)
 	app.admins.RUnlock()
+	if logger.TRACE.Enabled() {
+		logger.TRACE.Printf("Admin message (%d admins): %s", numAdmins, message.Params)
+	}
+	hasAdmins := numAdmins > 0
 	if !hasAdmins {
 		return nil
 	}
@@ -273,6 +277,9 @@ func (app *Application) adminMsg(message *AdminMessage) error {
 // on channel.
 func (app *Application) clientMsg(ch Channel, message *Message) error {
 	numSubscribers := app.clients.numSubscribers(ch)
+	if logger.TRACE.Enabled() {
+		logger.TRACE.Printf("Client message into channel %s (%d subscribers): %s", message.Channel, numSubscribers, message.Data)
+	}
 	hasCurrentSubscribers := numSubscribers > 0
 	if !hasCurrentSubscribers {
 		return nil
@@ -394,7 +401,11 @@ func (app *Application) pubLeave(ch Channel, info ClientInfo) error {
 }
 
 func (app *Application) joinMsg(ch Channel, message *JoinMessage) error {
-	hasCurrentSubscribers := app.clients.numSubscribers(ch) > 0
+	numSubscribers := app.clients.numSubscribers(ch)
+	if logger.TRACE.Enabled() {
+		logger.TRACE.Printf("Join message into channel %s (%d subscribers): user %s", message.Channel, numSubscribers, message.Data.User)
+	}
+	hasCurrentSubscribers := numSubscribers > 0
 	if !hasCurrentSubscribers {
 		return nil
 	}
@@ -408,7 +419,11 @@ func (app *Application) joinMsg(ch Channel, message *JoinMessage) error {
 }
 
 func (app *Application) leaveMsg(ch Channel, message *LeaveMessage) error {
-	hasCurrentSubscribers := app.clients.numSubscribers(ch) > 0
+	numSubscribers := app.clients.numSubscribers(ch)
+	if logger.TRACE.Enabled() {
+		logger.TRACE.Printf("Leave message into channel %s (%d subscribers): user %s", message.Channel, numSubscribers, message.Data.User)
+	}
+	hasCurrentSubscribers := numSubscribers > 0
 	if !hasCurrentSubscribers {
 		return nil
 	}

--- a/vendor/github.com/FZambia/go-logger/LICENSE
+++ b/vendor/github.com/FZambia/go-logger/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Alexandr Emelin
+Copyright (c) 2016 Alexandr Emelin
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -19,4 +19,3 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-

--- a/vendor/github.com/FZambia/go-logger/README.md
+++ b/vendor/github.com/FZambia/go-logger/README.md
@@ -1,2 +1,23 @@
-# go-logger
-Logger for Go apps, this is an adapted code from Steve Francia's jWalterWeatherman library
+Go-logger
+=========
+
+Level-based logger for Go apps.
+
+Documentation
+-------------
+
+- [API Reference](http://godoc.org/github.com/FZambia/go-logger)
+
+Installation
+------------
+
+Install using the "go get" command:
+
+```
+go get -u github.com/FZambia/go-logger
+```
+
+License
+-------
+
+MIT license.

--- a/vendor/github.com/FZambia/go-logger/logger.go
+++ b/vendor/github.com/FZambia/go-logger/logger.go
@@ -1,6 +1,4 @@
-// Package logger provides a logger for Centrifugo server.
-// This is an adapted code from Steve Francia's jWalterWeatherman
-// library - see https://github.com/spf13/jWalterWeatherman
+// Package logger.
 package logger
 
 import (
@@ -8,16 +6,97 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"sync/atomic"
 )
 
 // Level describes the chosen log level
 type Level int
 
-type NotePad struct {
-	Handle io.Writer
-	Level  Level
-	Prefix string
-	Logger **log.Logger
+// LevelLogger represents levelled logger.
+type LevelLogger struct {
+	enabled int32
+	level   Level
+	prefix  string
+	Logger  *log.Logger
+}
+
+// Enabled exists to prevent calling underlying logger methods when not needed.
+// This can also called from library users before calling LevelLogger methods
+// to reduce allocations.
+func (n *LevelLogger) Enabled() bool {
+	return atomic.LoadInt32(&n.enabled) != 0
+}
+
+// Print calls underlying Logger Print func.
+func (n *LevelLogger) Print(v ...interface{}) {
+	if !n.Enabled() {
+		return
+	}
+	n.Logger.Print(v...)
+}
+
+// Printf calls underlying Logger Printf func.
+func (n *LevelLogger) Printf(format string, v ...interface{}) {
+	if !n.Enabled() {
+		return
+	}
+	n.Logger.Printf(format, v...)
+}
+
+// Println calls underlying Logger Println func.
+func (n *LevelLogger) Println(v ...interface{}) {
+	if !n.Enabled() {
+		return
+	}
+	n.Logger.Println(v...)
+}
+
+// Fatal calls underlying Logger Fatal func.
+func (n *LevelLogger) Fatal(v ...interface{}) {
+	if !n.Enabled() {
+		return
+	}
+	n.Logger.Fatal(v...)
+}
+
+// Fatalf calls underlying Logger Fatalf func.
+func (n *LevelLogger) Fatalf(format string, v ...interface{}) {
+	if !n.Enabled() {
+		return
+	}
+	n.Logger.Fatalf(format, v...)
+}
+
+// Fatalln calls underlying Logger Fatalln func.
+func (n *LevelLogger) Fatalln(v ...interface{}) {
+	if !n.Enabled() {
+		return
+	}
+	n.Logger.Fatalln(v...)
+}
+
+// Panic calls underlying Logger Panic func.
+func (n *LevelLogger) Panic(v ...interface{}) {
+	if !n.Enabled() {
+		return
+	}
+	n.Logger.Panic(v...)
+}
+
+// Panicf calls underlying Logger Panicf func.
+func (n *LevelLogger) Panicf(format string, v ...interface{}) {
+	if !n.Enabled() {
+		return
+	}
+	n.Logger.Panicf(format, v...)
+}
+
+// Panicln calls underlying Logger Panicln func.
+func (n *LevelLogger) Panicln(v ...interface{}) {
+	if !n.Enabled() {
+		return
+	}
+	n.Logger.Panicln(v...)
 }
 
 const (
@@ -35,13 +114,7 @@ const (
 )
 
 var (
-	TRACE    *log.Logger
-	DEBUG    *log.Logger
-	INFO     *log.Logger
-	WARN     *log.Logger
-	ERROR    *log.Logger
-	CRITICAL *log.Logger
-	FATAL    *log.Logger
+	logger *log.Logger
 
 	LogHandle  io.Writer = ioutil.Discard
 	OutHandle  io.Writer = os.Stdout
@@ -49,15 +122,15 @@ var (
 
 	Flag int = log.Ldate | log.Ltime
 
-	NotePads []*NotePad = []*NotePad{trace, debug, info, warn, err, critical, fatal}
+	TRACE    *LevelLogger = &LevelLogger{level: LevelTrace, Logger: logger, prefix: "[T]: "}
+	DEBUG    *LevelLogger = &LevelLogger{level: LevelDebug, Logger: logger, prefix: "[D]: "}
+	INFO     *LevelLogger = &LevelLogger{level: LevelInfo, Logger: logger, prefix: "[I]: "}
+	WARN     *LevelLogger = &LevelLogger{level: LevelWarn, Logger: logger, prefix: "[W]: "}
+	ERROR    *LevelLogger = &LevelLogger{level: LevelError, Logger: logger, prefix: "[E]: "}
+	CRITICAL *LevelLogger = &LevelLogger{level: LevelCritical, Logger: logger, prefix: "[C]: "}
+	FATAL    *LevelLogger = &LevelLogger{level: LevelFatal, Logger: logger, prefix: "[F]: "}
 
-	trace    *NotePad = &NotePad{Level: LevelTrace, Handle: os.Stdout, Logger: &TRACE, Prefix: "[T]: "}
-	debug    *NotePad = &NotePad{Level: LevelDebug, Handle: os.Stdout, Logger: &DEBUG, Prefix: "[D]: "}
-	info     *NotePad = &NotePad{Level: LevelInfo, Handle: os.Stdout, Logger: &INFO, Prefix: "[I]: "}
-	warn     *NotePad = &NotePad{Level: LevelWarn, Handle: os.Stdout, Logger: &WARN, Prefix: "[W]: "}
-	err      *NotePad = &NotePad{Level: LevelError, Handle: os.Stdout, Logger: &ERROR, Prefix: "[E]: "}
-	critical *NotePad = &NotePad{Level: LevelCritical, Handle: os.Stdout, Logger: &CRITICAL, Prefix: "[C]: "}
-	fatal    *NotePad = &NotePad{Level: LevelFatal, Handle: os.Stdout, Logger: &FATAL, Prefix: "[F]: "}
+	loggers []*LevelLogger = []*LevelLogger{TRACE, DEBUG, INFO, WARN, ERROR, CRITICAL, FATAL}
 
 	logThreshold    Level = DefaultLogThreshold
 	outputThreshold Level = DefaultStdoutThreshold
@@ -78,28 +151,35 @@ func init() {
 	initialize()
 }
 
-// initialize initializes loggers
+// initialize initializes loggers.
 func initialize() {
 	BothHandle = io.MultiWriter(LogHandle, OutHandle)
+	for _, l := range loggers {
 
-	for _, n := range NotePads {
-		if n.Level < outputThreshold && n.Level < logThreshold {
-			n.Handle = ioutil.Discard
-		} else if n.Level >= outputThreshold && n.Level >= logThreshold {
-			n.Handle = BothHandle
-		} else if n.Level >= outputThreshold && n.Level < logThreshold {
-			n.Handle = OutHandle
+		var handler io.Writer
+		var enabled int32
+
+		if l.level < outputThreshold && l.level < logThreshold {
+			enabled = 0
+			handler = ioutil.Discard
+		} else if l.level >= outputThreshold && l.level >= logThreshold {
+			enabled = 1
+			handler = BothHandle
+		} else if l.level >= outputThreshold && l.level < logThreshold {
+			enabled = 1
+			handler = OutHandle
 		} else {
-			n.Handle = LogHandle
+			enabled = 1
+			handler = LogHandle
 		}
-	}
 
-	for _, n := range NotePads {
-		*n.Logger = log.New(n.Handle, n.Prefix, Flag)
+		atomic.StoreInt32(&l.enabled, 0)
+		l.Logger = log.New(handler, l.prefix, Flag)
+		atomic.StoreInt32(&l.enabled, enabled)
 	}
 }
 
-// Ensures that the level provided is within the bounds of available levels
+// Ensures that the level provided is within the bounds of available levels.
 func levelCheck(level Level) Level {
 	switch {
 	case level <= LevelTrace:
@@ -111,24 +191,29 @@ func levelCheck(level Level) Level {
 	}
 }
 
-// Establishes a threshold where anything matching or above will be logged
+// SetLogThreshold establishes a threshold where anything matching or above will be logged.
 func SetLogThreshold(level Level) {
-	logThreshold = levelCheck(level)
-	initialize()
+	thresholdChanged := level != logThreshold
+	if thresholdChanged {
+		logThreshold = levelCheck(level)
+		initialize()
+	}
 }
 
-// Establishes a threshold where anything matching or above will be output
+// SetStdoutThreshold establishes a threshold where anything matching or above will be output.
 func SetStdoutThreshold(level Level) {
-	outputThreshold = levelCheck(level)
-	initialize()
+	thresholdChanged := level != outputThreshold
+	if thresholdChanged {
+		outputThreshold = levelCheck(level)
+		initialize()
+	}
 }
 
-// Conveniently Sets the Log Handle to a io.writer created for the file behind the given filepath
-// Will only append to this file
+// SetLogFile sets the LogHandle to a io.writer created for the file behind the given file path.
+// Will append to this file.
 func SetLogFile(path string) error {
 	file, err := os.OpenFile(path, os.O_RDWR|os.O_APPEND|os.O_CREATE, 0666)
 	if err != nil {
-		CRITICAL.Println("Failed to open log file:", path, err)
 		return err
 	}
 	LogHandle = file
@@ -136,7 +221,11 @@ func SetLogFile(path string) error {
 	return nil
 }
 
+// SetLogFlag sets global log flag used in package.
 func SetLogFlag(flag int) {
+	flagChanged := flag != Flag
 	Flag = flag
-	initialize()
+	if flagChanged {
+		initialize()
+	}
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -23,11 +23,10 @@
 			"revision": "056c9bc7be7190eaa7715723883caffa5f8fa3e4"
 		},
 		{
-			"checksumSHA1": "4abPaYSPssM6QNkIra92Lu2g2y8=",
-			"origin": "github.com/centrifugal/centrifugo/vendor/github.com/FZambia/go-logger",
+			"checksumSHA1": "6HiBVDBPrM6zWptYEwNhD3GqHuo=",
 			"path": "github.com/FZambia/go-logger",
-			"revision": "656c7347d91febe2e4f6132ff6d74a0213cbeebe",
-			"revisionTime": "2016-08-11T08:39:09Z"
+			"revision": "4052dbd19fe53cf9b5decf34e6c6f06366753259",
+			"revisionTime": "2016-09-06T15:03:52Z"
 		},
 		{
 			"path": "github.com/FZambia/go-sentinel",
@@ -326,7 +325,6 @@
 		},
 		{
 			"checksumSHA1": "SGSXlSU1TFtg5aTlVA9v4Ka86lU=",
-			"origin": "github.com/centrifugal/centrifugo/vendor/github.com/gorilla/securecookie",
 			"path": "github.com/gorilla/securecookie",
 			"revision": "e95799a481bbcc3d01c2ad5178524cb8bec9f370",
 			"revisionTime": "2015-08-20T08:29:58Z"
@@ -337,7 +335,6 @@
 		},
 		{
 			"checksumSHA1": "yc/AtS4YqKJrwaJTbHKmDYVrtVE=",
-			"origin": "github.com/centrifugal/centrifugo/vendor/github.com/gorilla/websocket",
 			"path": "github.com/gorilla/websocket",
 			"revision": "e2e3d8414d0fbae04004f151979f4e27c6747fe7",
 			"revisionTime": "2016-03-13T18:57:37Z"


### PR DESCRIPTION
Added TRACE logging of messages coming to node: admin, client message, join message, leave message. That was not so easy as TRACE logging allocated a lot even if the actual log level was higher. I updated logger library and now TRACE logging lines do not affect performance.