### PR TITLE
Support for client side ping

### DIFF
--- a/libcentrifugo/centrifugo/main.go
+++ b/libcentrifugo/centrifugo/main.go
@@ -122,6 +122,7 @@ func Main(version string) {
 				"node_metrics_interval":          60,
 				"stale_connection_close_delay":   25,
 				"expired_connection_close_delay": 25,
+				"client_max_idle_timeout":        60,
 				"client_channel_limit":           100,
 				"client_request_max_size":        65536,    // 64KB
 				"client_queue_max_size":          10485760, // 10MB

--- a/libcentrifugo/conns/clientconn/conn_test.go
+++ b/libcentrifugo/conns/clientconn/conn_test.go
@@ -635,6 +635,29 @@ func TestClientPing(t *testing.T) {
 	assert.Equal(t, nil, resp.(*proto.ClientPingResponse).ResponseError.Err)
 }
 
+func TestClientIsIdle(t *testing.T) {
+	app := NewTestNode()
+	conf := app.Config()
+	conf.ClientMaxIdleTimeout = time.Second
+	app.SetConfig(&conf)
+	c, err := New(app, NewTestSession())
+	assert.Equal(t, nil, err)
+
+	timestamp := strconv.FormatInt(time.Now().Unix(), 10)
+	cmds := []proto.ClientCommand{testConnectCmd(timestamp)}
+	cmdBytes, _ := json.Marshal(cmds)
+	err = c.(*client).Handle(cmdBytes)
+	assert.Equal(t, nil, err)
+
+	isIdle := c.(*client).isIdle()
+	assert.Equal(t, false, isIdle)
+
+	time.Sleep(2 * time.Second)
+
+	isIdle = c.(*client).isIdle()
+	assert.Equal(t, true, isIdle)
+}
+
 func testSubscribeRecoverCmd(channel string, last string, rec bool) proto.ClientCommand {
 	subscribeCmd := proto.SubscribeClientCommand{
 		Channel: string(channel),

--- a/libcentrifugo/node/config.go
+++ b/libcentrifugo/node/config.go
@@ -105,6 +105,11 @@ type Config struct {
 	// ClientChannelLimit sets upper limit of channels each client can subscribe to.
 	ClientChannelLimit int `json:"client_channel_limit"`
 
+	// ClientMaxIdleTimeout sets a time how long client considered alive if there was
+	// no any message activity. It only used when client sets ping: true when connecting
+	// to Centrifugo - i.e. explicitly said that it going to send periodic pings to server.
+	ClientMaxIdleTimeout time.Duration `json:"client_max_idle_timeout"`
+
 	// UserConnectionLimit limits number of connections from user with the same ID.
 	UserConnectionLimit int `json:"user_connection_limit"`
 
@@ -210,6 +215,7 @@ var DefaultConfig = &Config{
 	ClientQueueMaxSize:          10485760, // 10MB by default
 	ClientQueueInitialCapacity:  2,
 	ClientChannelLimit:          100,
+	ClientMaxIdleTimeout:        60 * time.Second,
 	Insecure:                    false,
 }
 
@@ -242,6 +248,7 @@ func NewConfig(v config.Getter) *Config {
 	cfg.ClientQueueMaxSize = v.GetInt("client_queue_max_size")
 	cfg.ClientQueueInitialCapacity = v.GetInt("client_queue_initial_capacity")
 	cfg.ClientChannelLimit = v.GetInt("client_channel_limit")
+	cfg.ClientMaxIdleTimeout = time.Duration(v.GetInt("client_max_idle_timeout")) * time.Second
 	cfg.UserConnectionLimit = v.GetInt("user_connection_limit")
 	cfg.Insecure = v.GetBool("insecure")
 	cfg.InsecureAPI = v.GetBool("insecure_api")

--- a/libcentrifugo/proto/commands.go
+++ b/libcentrifugo/proto/commands.go
@@ -119,6 +119,7 @@ type ConnectClientCommand struct {
 	Timestamp string `json:"timestamp"`
 	Info      string `json:"info"`
 	Token     string `json:"token"`
+	Ping      bool   `json:"ping"`
 }
 
 // RefreshClientCommand is used to prolong connection lifetime when connection check

--- a/libcentrifugo/proto/response.go
+++ b/libcentrifugo/proto/response.go
@@ -202,7 +202,7 @@ type DisconnectBody struct {
 
 // PingBody represents body of response in case of successful ping command.
 type PingBody struct {
-	Data string `json:"data"`
+	Data string `json:"data,omitempty"`
 }
 
 // StatsBody represents body of response in case of successful stats command.
@@ -376,10 +376,10 @@ func NewClientPublishResponse(body PublishBody) *ClientPublishResponse {
 
 type ClientPingResponse struct {
 	clientResponse
-	Body PingBody `json:"body"`
+	Body *PingBody `json:"body,omitempty"`
 }
 
-func NewClientPingResponse(body PingBody) *ClientPingResponse {
+func NewClientPingResponse(body *PingBody) *ClientPingResponse {
 	return &ClientPingResponse{
 		clientResponse: clientResponse{
 			Method: "ping",

--- a/libcentrifugo/server/httpserver/handlers.go
+++ b/libcentrifugo/server/httpserver/handlers.go
@@ -279,8 +279,6 @@ func (s *HTTPServer) sockJSHandler(sess sockjs.Session) {
 		if msg, err := sess.Recv(); err == nil {
 			err = c.Handle([]byte(msg))
 			if err != nil {
-				logger.ERROR.Println(err)
-				c.Close(&conns.DisconnectAdvice{Reason: "error handling message", Reconnect: true})
 				return
 			}
 			continue
@@ -326,12 +324,11 @@ func (s *HTTPServer) RawWebsocketHandler(w http.ResponseWriter, r *http.Request)
 	for {
 		_, message, err := ws.ReadMessage()
 		if err != nil {
-			break
+			return
 		}
 		err = c.Handle(message)
 		if err != nil {
-			c.Close(&conns.DisconnectAdvice{Reason: err.Error(), Reconnect: true})
-			break
+			return
 		}
 	}
 }


### PR DESCRIPTION
As we are going to send automatic pings from clients to server here are some simple changes to close idle clients. At moment client must explicitly set `"ping": true` in `connect` command to enable idle check.

Also this pr includes several changes to make client--server protocol more readable and a bit more compact.