### PR TITLE
Raw websocket compression support

### DIFF
--- a/libcentrifugo/server/httpserver/config.go
+++ b/libcentrifugo/server/httpserver/config.go
@@ -34,6 +34,20 @@ type Config struct {
 
 	// SockjsURL is a custom SockJS library url to use in iframe transports.
 	SockjsURL string `json:"sockjs_url"`
+
+	// WebsocketCompression allows to enable websocket permessage-deflate
+	// compression support for raw websocket connections. It does not guarantee
+	// that compression will be used - i.e. it only says that Centrifugo will
+	// try to negotiate it with client.
+	WebsocketCompression bool `json:"websocket_compression"`
+
+	// WebsocketReadBufferSize is a parameter that is used for raw websocket Upgrader.
+	// If set to zero reasonable default value will be used.
+	WebsocketReadBufferSize int `json:"websocket_read_buffer_size"`
+
+	// WebsocketWriteBufferSize is a parameter that is used for raw websocket Upgrader.
+	// If set to zero reasonable default value will be used.
+	WebsocketWriteBufferSize int `json:"websocket_write_buffer_size"`
 }
 
 // newConfig creates new libcentrifugo.Config using viper.
@@ -50,6 +64,9 @@ func newConfig(c config.Getter) *Config {
 	cfg.SSL = c.GetBool("ssl")
 	cfg.SSLCert = c.GetString("ssl_cert")
 	cfg.SSLKey = c.GetString("ssl_cert")
+	cfg.WebsocketCompression = c.GetBool("websocket_compression")
+	cfg.WebsocketReadBufferSize = c.GetInt("websocket_read_buffer_size")
+	cfg.WebsocketWriteBufferSize = c.GetInt("websocket_write_buffer_size")
 	return cfg
 }
 

--- a/libcentrifugo/server/httpserver/server.go
+++ b/libcentrifugo/server/httpserver/server.go
@@ -34,6 +34,9 @@ func HTTPServerConfigure(setter config.Setter) error {
 	setter.SetDefault("admin_password", "")
 	setter.SetDefault("admin_secret", "")
 	setter.SetDefault("sockjs_url", "//cdn.jsdelivr.net/sockjs/1.1/sockjs.min.js")
+	setter.SetDefault("websocket_compression", false)
+	setter.SetDefault("websocket_read_buffer_size", 4096)
+	setter.SetDefault("websocket_write_buffer_size", 4096)
 
 	setter.BoolFlag("web", "w", false, "serve admin web interface application (warning: automatically enables admin socket)")
 	setter.StringFlag("web_path", "", "", "optional path to custom web interface application")

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -77,8 +77,8 @@
 		{
 			"checksumSHA1": "SmBqqqR0T+1Ksx5zwCl295Vey0s=",
 			"path": "github.com/gorilla/websocket",
-			"revision": "9fbf129ff2a3cf2467f7d0021de2eb4d3aecc109",
-			"revisionTime": "2016-11-02T20:04:59Z"
+			"revision": "e8f0f8aaa98dfb6586cbdf2978d511e3199a960a",
+			"revisionTime": "2016-11-12T14:27:12Z"
 		},
 		{
 			"checksumSHA1": "LUrnGREfnifW4WDMaavmc9MlLI0=",


### PR DESCRIPTION
Option to enable `permessage-deflate` compression for raw websocket connections: `websocket_compression`. See #115 