### PR TITLE
Redis sharding support

### DIFF
--- a/libcentrifugo/engine/engineredis/engine.go
+++ b/libcentrifugo/engine/engineredis/engine.go
@@ -100,6 +100,7 @@ const (
 // connected to the same Redis and load balance clients between instances.
 type RedisEngine struct {
 	sync.RWMutex
+	node     *node.Node
 	sharding bool
 	Shards   []*RedisShard
 }
@@ -212,7 +213,7 @@ func newPool(conf *Config) *redis.Pool {
 	apiEnabled := yesno(conf.API)
 	var shardsSuffix string
 	if conf.API {
-		shardsSuffix = fmt.Sprintf(", num shard queues: %d", conf.NumAPIShards)
+		shardsSuffix = fmt.Sprintf(", num API shard queues: %d", conf.NumAPIShards)
 	}
 	if !useSentinel {
 		logger.INFO.Printf("Redis: %s/%s, pool: %d, using password: %s, API enabled: %s%s\n", serverAddr, db, conf.PoolSize, usingPassword, apiEnabled, shardsSuffix)
@@ -478,6 +479,7 @@ func New(n *node.Node, configs []*Config) (engine.Engine, error) {
 	}
 
 	e := &RedisEngine{
+		node:     n,
 		Shards:   shards,
 		sharding: len(shards) > 1,
 	}

--- a/libcentrifugo/engine/engineredis/hash.go
+++ b/libcentrifugo/engine/engineredis/hash.go
@@ -1,0 +1,26 @@
+package engineredis
+
+import (
+	"hash/fnv"
+)
+
+// Adapted from from https://github.com/dgryski/go-jump package by Damian Gryski.
+// Hash consistently chooses a hash bucket number in the range [0, numBuckets) for the given key.
+// numBuckets must be >= 1.
+func Hash(ch string, numBuckets int) int32 {
+
+	hash := fnv.New64a()
+	hash.Write([]byte(ch))
+	key := hash.Sum64()
+
+	var b int64 = -1
+	var j int64
+
+	for j < int64(numBuckets) {
+		b = j
+		key = key*2862933555777941757 + 1
+		j = int64(float64(b+1) * (float64(int64(1)<<31) / float64((key>>33)+1)))
+	}
+
+	return int32(b)
+}

--- a/libcentrifugo/engine/engineredis/hash_test.go
+++ b/libcentrifugo/engine/engineredis/hash_test.go
@@ -1,0 +1,16 @@
+package engineredis
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHash(t *testing.T) {
+	chans := []string{"chan1", "chan2", "chan3", "chan4", "chan5", "chan6", "chan7", "chan8"}
+	for _, ch := range chans {
+		bucket := Hash(ch, 2)
+		assert.True(t, bucket >= 0)
+		assert.True(t, bucket < 2)
+	}
+}


### PR DESCRIPTION
At moment in large Centrifugo setup Redis could become a bottleneck. It's insanely fast and capable to server more than 100k requests per second but it's not an unreachable number in real world.

So this is a pr that adds basic Redis sharding support for Centrifugo - it's a consistent hashing based on channel name using [jump algorithm](https://arxiv.org/pdf/1406.2294.pdf).

For example to run Centrifugo which will spread load between 2 local Redis instances running on ports 6379 and 6380:

```
./centrifugo --engine=redis --redis_port=6379,6380
```