### PR TITLE
Resolve history drop inactive edge case

### DIFF
--- a/libcentrifugo/engine/enginememory/engine_test.go
+++ b/libcentrifugo/engine/enginememory/engine_test.go
@@ -201,10 +201,10 @@ func TestMemoryHistoryHub(t *testing.T) {
 	assert.Equal(t, 0, len(h.history))
 	ch1 := string("channel1")
 	ch2 := string("channel2")
-	h.add(ch1, proto.Message{}, addHistoryOpts{1, 1, false})
-	h.add(ch1, proto.Message{}, addHistoryOpts{1, 1, false})
-	h.add(ch2, proto.Message{}, addHistoryOpts{2, 1, false})
-	h.add(ch2, proto.Message{}, addHistoryOpts{2, 1, true}) // Test that adding only if active works when it's active
+	h.add(ch1, proto.Message{}, &proto.ChannelOptions{HistorySize: 1, HistoryLifetime: 1, HistoryDropInactive: false}, false)
+	h.add(ch1, proto.Message{}, &proto.ChannelOptions{HistorySize: 1, HistoryLifetime: 1, HistoryDropInactive: false}, false)
+	h.add(ch2, proto.Message{}, &proto.ChannelOptions{HistorySize: 2, HistoryLifetime: 1, HistoryDropInactive: false}, false)
+	h.add(ch2, proto.Message{}, &proto.ChannelOptions{HistorySize: 2, HistoryLifetime: 1, HistoryDropInactive: true}, false) // Test that adding only if active works when it's active
 	hist, err := h.get(ch1, 0)
 	assert.Equal(t, nil, err)
 	assert.Equal(t, 1, len(hist))
@@ -219,18 +219,18 @@ func TestMemoryHistoryHub(t *testing.T) {
 	assert.Equal(t, nil, err)
 	assert.Equal(t, 0, len(hist))
 
-	// Now test adding history for inactive channel is a no-op if OnlySaveIfActvie is true
-	h.add(ch2, proto.Message{}, addHistoryOpts{2, 10, true})
+	// Now test adding history for inactive channel is a no-op if HistoryDropInactive is true
+	h.add(ch2, proto.Message{}, &proto.ChannelOptions{HistorySize: 2, HistoryLifetime: 10, HistoryDropInactive: true}, false)
 	assert.Equal(t, 0, len(h.history))
 	hist, err = h.get(ch2, 0)
 	assert.Equal(t, nil, err)
 	assert.Equal(t, 0, len(hist))
 
 	// test history messages limit
-	h.add(ch1, proto.Message{}, addHistoryOpts{10, 1, false})
-	h.add(ch1, proto.Message{}, addHistoryOpts{10, 1, false})
-	h.add(ch1, proto.Message{}, addHistoryOpts{10, 1, false})
-	h.add(ch1, proto.Message{}, addHistoryOpts{10, 1, false})
+	h.add(ch1, proto.Message{}, &proto.ChannelOptions{HistorySize: 10, HistoryLifetime: 1, HistoryDropInactive: false}, false)
+	h.add(ch1, proto.Message{}, &proto.ChannelOptions{HistorySize: 10, HistoryLifetime: 1, HistoryDropInactive: false}, false)
+	h.add(ch1, proto.Message{}, &proto.ChannelOptions{HistorySize: 10, HistoryLifetime: 1, HistoryDropInactive: false}, false)
+	h.add(ch1, proto.Message{}, &proto.ChannelOptions{HistorySize: 10, HistoryLifetime: 1, HistoryDropInactive: false}, false)
 	hist, err = h.get(ch1, 0)
 	assert.Equal(t, nil, err)
 	assert.Equal(t, 4, len(hist))
@@ -239,8 +239,8 @@ func TestMemoryHistoryHub(t *testing.T) {
 	assert.Equal(t, 1, len(hist))
 
 	// test history limit greater than history size
-	h.add(ch1, proto.Message{}, addHistoryOpts{1, 1, false})
-	h.add(ch1, proto.Message{}, addHistoryOpts{1, 1, false})
+	h.add(ch1, proto.Message{}, &proto.ChannelOptions{HistorySize: 1, HistoryLifetime: 1, HistoryDropInactive: false}, false)
+	h.add(ch1, proto.Message{}, &proto.ChannelOptions{HistorySize: 1, HistoryLifetime: 1, HistoryDropInactive: false}, false)
 	hist, err = h.get(ch1, 2)
 	assert.Equal(t, nil, err)
 	assert.Equal(t, 1, len(hist))


### PR DESCRIPTION
Attempt to resolve `history_drop_inactive` edge case described in #50 

Surprisingly it seems that it's enough to touch history for a `lifetime` period only on `unsubscribe` event. After `subscribe` we have at least one subscriber so we will push into history anyway. 

For memory engine I've added explicit method to `touch` history. For Redis engine new `touch` key with TTL was introduced. Originally I thought to just touch existing history list key - but due to how Redis works it's impossible as list key does not exist when there are no items in list (and I have not found a way to create empty list).  