### PR TITLE
Fix mass resubscribe

### DIFF
--- a/libcentrifugo/engine/engineredis/engine.go
+++ b/libcentrifugo/engine/engineredis/engine.go
@@ -64,10 +64,7 @@ func Configure(setter config.Setter) error {
 
 const (
 	// RedisSubscribeChannelSize is the size for the internal buffered channels RedisEngine
-	// uses to synchronize subscribe/unsubscribe. It allows for effective batching during bulk
-	// re-subscriptions, and allows large volume of incoming subscriptions to not block when
-	// PubSub connection is reconnecting. Two channels of this size will be allocated, one for
-	// Subscribe and one for Unsubscribe
+	// uses to synchronize subscribe/unsubscribe.
 	RedisSubscribeChannelSize = 4096
 	// RedisPubSubWorkerChannelSize sets buffer size of channel to which we send all
 	// messages received from Redis PUB/SUB connection to process in separate goroutine.


### PR DESCRIPTION
When node subscribed on many channels and Redis disconnects - it's possible that node does not restore it's subscribing state after reconnecting to Redis. Including control channels. This leads to situation where some nodes become isolated from PUB/SUB. Here is patch for this.