### PR TITLE
Channel package to isolate channel options from proto

### DIFF
--- a/libcentrifugo/api/v1/api_test.go
+++ b/libcentrifugo/api/v1/api_test.go
@@ -3,6 +3,7 @@ package apiv1
 import (
 	"testing"
 
+	"github.com/centrifugal/centrifugo/libcentrifugo/channel"
 	"github.com/centrifugal/centrifugo/libcentrifugo/node"
 	"github.com/centrifugal/centrifugo/libcentrifugo/proto"
 	"github.com/stretchr/testify/assert"
@@ -26,19 +27,19 @@ func (e *TestEngine) Shutdown() error {
 	return nil
 }
 
-func (e *TestEngine) PublishMessage(message *proto.Message, opts *proto.ChannelOptions) <-chan error {
+func (e *TestEngine) PublishMessage(message *proto.Message, opts *channel.Options) <-chan error {
 	eChan := make(chan error, 1)
 	eChan <- nil
 	return eChan
 }
 
-func (e *TestEngine) PublishJoin(message *proto.JoinMessage, opts *proto.ChannelOptions) <-chan error {
+func (e *TestEngine) PublishJoin(message *proto.JoinMessage, opts *channel.Options) <-chan error {
 	eChan := make(chan error, 1)
 	eChan <- nil
 	return eChan
 }
 
-func (e *TestEngine) PublishLeave(message *proto.LeaveMessage, opts *proto.ChannelOptions) <-chan error {
+func (e *TestEngine) PublishLeave(message *proto.LeaveMessage, opts *channel.Options) <-chan error {
 	eChan := make(chan error, 1)
 	eChan <- nil
 	return eChan
@@ -105,8 +106,8 @@ func (t *TestSession) Close(status uint32, reason string) error {
 	return nil
 }
 
-func getTestChannelOptions() proto.ChannelOptions {
-	return proto.ChannelOptions{
+func getTestChannelOptions() channel.Options {
+	return channel.Options{
 		Watch:           true,
 		Publish:         true,
 		Presence:        true,
@@ -115,20 +116,20 @@ func getTestChannelOptions() proto.ChannelOptions {
 	}
 }
 
-func getTestNamespace(name node.NamespaceKey) node.Namespace {
-	return node.Namespace{
-		Name:           name,
-		ChannelOptions: getTestChannelOptions(),
+func getTestNamespace(name channel.NamespaceKey) channel.Namespace {
+	return channel.Namespace{
+		Name:    name,
+		Options: getTestChannelOptions(),
 	}
 }
 
 func NewTestConfig() *node.Config {
 	c := node.DefaultConfig
-	var ns []node.Namespace
+	var ns []channel.Namespace
 	ns = append(ns, getTestNamespace("test"))
 	c.Namespaces = ns
 	c.Secret = "secret"
-	c.ChannelOptions = getTestChannelOptions()
+	c.Options = getTestChannelOptions()
 	return c
 }
 

--- a/libcentrifugo/channel/channel.go
+++ b/libcentrifugo/channel/channel.go
@@ -1,7 +1,19 @@
-package proto
+package channel
+
+// NamespaceKey is a name of namespace unique for project.
+type NamespaceKey string
+
+// Namespace allows to create channels with different channel options within the Project
+type Namespace struct {
+	// Name is a unique namespace name.
+	Name NamespaceKey `json:"name"`
+
+	// Options for namespace determine channel options for channels belonging to this namespace.
+	Options `mapstructure:",squash"`
+}
 
 // ChannelOptions represent channel specific configuration for namespace or project in a whole
-type ChannelOptions struct {
+type Options struct {
 	// Watch determines if message published into channel will be also sent into admin channel.
 	// Note that this option must be used carefully in channels with high rate of new messages
 	// as admin client can not process all of those messages. Use this option for testing or for

--- a/libcentrifugo/conns/adminconn/conn_test.go
+++ b/libcentrifugo/conns/adminconn/conn_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/centrifugal/centrifugo/libcentrifugo/auth"
+	"github.com/centrifugal/centrifugo/libcentrifugo/channel"
 	"github.com/centrifugal/centrifugo/libcentrifugo/conns"
 	"github.com/centrifugal/centrifugo/libcentrifugo/node"
 	"github.com/centrifugal/centrifugo/libcentrifugo/proto"
@@ -28,19 +29,19 @@ func (e *TestEngine) Shutdown() error {
 	return nil
 }
 
-func (e *TestEngine) PublishMessage(message *proto.Message, opts *proto.ChannelOptions) <-chan error {
+func (e *TestEngine) PublishMessage(message *proto.Message, opts *channel.Options) <-chan error {
 	eChan := make(chan error, 1)
 	eChan <- nil
 	return eChan
 }
 
-func (e *TestEngine) PublishJoin(message *proto.JoinMessage, opts *proto.ChannelOptions) <-chan error {
+func (e *TestEngine) PublishJoin(message *proto.JoinMessage, opts *channel.Options) <-chan error {
 	eChan := make(chan error, 1)
 	eChan <- nil
 	return eChan
 }
 
-func (e *TestEngine) PublishLeave(message *proto.LeaveMessage, opts *proto.ChannelOptions) <-chan error {
+func (e *TestEngine) PublishLeave(message *proto.LeaveMessage, opts *channel.Options) <-chan error {
 	eChan := make(chan error, 1)
 	eChan <- nil
 	return eChan
@@ -107,8 +108,8 @@ func (t *TestSession) Close(adv *conns.DisconnectAdvice) error {
 	return nil
 }
 
-func getTestChannelOptions() proto.ChannelOptions {
-	return proto.ChannelOptions{
+func getTestChannelOptions() channel.Options {
+	return channel.Options{
 		Watch:           true,
 		Publish:         true,
 		Presence:        true,
@@ -117,20 +118,20 @@ func getTestChannelOptions() proto.ChannelOptions {
 	}
 }
 
-func getTestNamespace(name node.NamespaceKey) node.Namespace {
-	return node.Namespace{
-		Name:           name,
-		ChannelOptions: getTestChannelOptions(),
+func getTestNamespace(name channel.NamespaceKey) channel.Namespace {
+	return channel.Namespace{
+		Name:    name,
+		Options: getTestChannelOptions(),
 	}
 }
 
 func NewTestConfig() *node.Config {
 	c := node.DefaultConfig
-	var ns []node.Namespace
+	var ns []channel.Namespace
 	ns = append(ns, getTestNamespace("test"))
 	c.Namespaces = ns
 	c.Secret = "secret"
-	c.ChannelOptions = getTestChannelOptions()
+	c.Options = getTestChannelOptions()
 	return c
 }
 

--- a/libcentrifugo/conns/clientconn/conn_test.go
+++ b/libcentrifugo/conns/clientconn/conn_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/centrifugal/centrifugo/libcentrifugo/auth"
+	"github.com/centrifugal/centrifugo/libcentrifugo/channel"
 	"github.com/centrifugal/centrifugo/libcentrifugo/conns"
 	"github.com/centrifugal/centrifugo/libcentrifugo/engine/enginememory"
 	"github.com/centrifugal/centrifugo/libcentrifugo/node"
@@ -45,19 +46,19 @@ func (e *TestEngine) Shutdown() error {
 	return nil
 }
 
-func (e *TestEngine) PublishMessage(message *proto.Message, opts *proto.ChannelOptions) <-chan error {
+func (e *TestEngine) PublishMessage(message *proto.Message, opts *channel.Options) <-chan error {
 	eChan := make(chan error, 1)
 	eChan <- nil
 	return eChan
 }
 
-func (e *TestEngine) PublishJoin(message *proto.JoinMessage, opts *proto.ChannelOptions) <-chan error {
+func (e *TestEngine) PublishJoin(message *proto.JoinMessage, opts *channel.Options) <-chan error {
 	eChan := make(chan error, 1)
 	eChan <- nil
 	return eChan
 }
 
-func (e *TestEngine) PublishLeave(message *proto.LeaveMessage, opts *proto.ChannelOptions) <-chan error {
+func (e *TestEngine) PublishLeave(message *proto.LeaveMessage, opts *channel.Options) <-chan error {
 	eChan := make(chan error, 1)
 	eChan <- nil
 	return eChan
@@ -124,8 +125,8 @@ func (t *TestSession) Close(adv *conns.DisconnectAdvice) error {
 	return nil
 }
 
-func getTestChannelOptions() proto.ChannelOptions {
-	return proto.ChannelOptions{
+func getTestChannelOptions() channel.Options {
+	return channel.Options{
 		Watch:           true,
 		Publish:         true,
 		Presence:        true,
@@ -134,20 +135,20 @@ func getTestChannelOptions() proto.ChannelOptions {
 	}
 }
 
-func getTestNamespace(name node.NamespaceKey) node.Namespace {
-	return node.Namespace{
-		Name:           name,
-		ChannelOptions: getTestChannelOptions(),
+func getTestNamespace(name channel.NamespaceKey) channel.Namespace {
+	return channel.Namespace{
+		Name:    name,
+		Options: getTestChannelOptions(),
 	}
 }
 
 func NewTestConfig() *node.Config {
 	c := node.DefaultConfig
-	var ns []node.Namespace
+	var ns []channel.Namespace
 	ns = append(ns, getTestNamespace("test"))
 	c.Namespaces = ns
 	c.Secret = "secret"
-	c.ChannelOptions = getTestChannelOptions()
+	c.Options = getTestChannelOptions()
 	return c
 }
 

--- a/libcentrifugo/engine/engine.go
+++ b/libcentrifugo/engine/engine.go
@@ -1,6 +1,7 @@
 package engine
 
 import (
+	"github.com/centrifugal/centrifugo/libcentrifugo/channel"
 	"github.com/centrifugal/centrifugo/libcentrifugo/proto"
 )
 
@@ -23,11 +24,11 @@ type Engine interface {
 	// The returned value is channel in which we will send error as soon as engine finishes
 	// publish operation. Also the task of this method is to maintain history for channels
 	// if enabled.
-	PublishMessage(*proto.Message, *proto.ChannelOptions) <-chan error
+	PublishMessage(*proto.Message, *channel.Options) <-chan error
 	// PublishJoin allows to send join message into channel.
-	PublishJoin(*proto.JoinMessage, *proto.ChannelOptions) <-chan error
+	PublishJoin(*proto.JoinMessage, *channel.Options) <-chan error
 	// PublishLeave allows to send leave message into channel.
-	PublishLeave(*proto.LeaveMessage, *proto.ChannelOptions) <-chan error
+	PublishLeave(*proto.LeaveMessage, *channel.Options) <-chan error
 	// PublishControl allows to send control message to all connected nodes.
 	PublishControl(*proto.ControlMessage) <-chan error
 	// PublishAdmin allows to send admin message to all connected admins.

--- a/libcentrifugo/engine/enginememory/engine.go
+++ b/libcentrifugo/engine/enginememory/engine.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/centrifugal/centrifugo/libcentrifugo/channel"
 	"github.com/centrifugal/centrifugo/libcentrifugo/config"
 	"github.com/centrifugal/centrifugo/libcentrifugo/engine"
 	"github.com/centrifugal/centrifugo/libcentrifugo/logger"
@@ -66,7 +67,7 @@ func (e *MemoryEngine) Shutdown() error {
 
 // PublishMessage adds message into history hub and calls node ClientMsg method to handle message.
 // We don't have any PUB/SUB here as Memory Engine is single node only.
-func (e *MemoryEngine) PublishMessage(message *proto.Message, opts *proto.ChannelOptions) <-chan error {
+func (e *MemoryEngine) PublishMessage(message *proto.Message, opts *channel.Options) <-chan error {
 
 	ch := message.Channel
 
@@ -85,14 +86,14 @@ func (e *MemoryEngine) PublishMessage(message *proto.Message, opts *proto.Channe
 }
 
 // PublishJoin - see Engine interface description.
-func (e *MemoryEngine) PublishJoin(message *proto.JoinMessage, opts *proto.ChannelOptions) <-chan error {
+func (e *MemoryEngine) PublishJoin(message *proto.JoinMessage, opts *channel.Options) <-chan error {
 	eChan := make(chan error, 1)
 	eChan <- e.node.JoinMsg(message)
 	return eChan
 }
 
 // PublishLeave - see Engine interface description.
-func (e *MemoryEngine) PublishLeave(message *proto.LeaveMessage, opts *proto.ChannelOptions) <-chan error {
+func (e *MemoryEngine) PublishLeave(message *proto.LeaveMessage, opts *channel.Options) <-chan error {
 	eChan := make(chan error, 1)
 	eChan <- e.node.LeaveMsg(message)
 	return eChan
@@ -273,7 +274,7 @@ func (h *historyHub) expire() {
 	}
 }
 
-func (h *historyHub) touch(ch string, opts *proto.ChannelOptions) {
+func (h *historyHub) touch(ch string, opts *channel.Options) {
 	h.Lock()
 	defer h.Unlock()
 
@@ -296,7 +297,7 @@ func (h *historyHub) touch(ch string, opts *proto.ChannelOptions) {
 	}
 }
 
-func (h *historyHub) add(ch string, msg proto.Message, opts *proto.ChannelOptions, hasSubscribers bool) error {
+func (h *historyHub) add(ch string, msg proto.Message, opts *channel.Options, hasSubscribers bool) error {
 	h.Lock()
 	defer h.Unlock()
 

--- a/libcentrifugo/engine/engineredis/engine.go
+++ b/libcentrifugo/engine/engineredis/engine.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/FZambia/go-sentinel"
 	"github.com/centrifugal/centrifugo/libcentrifugo/api/v1"
+	"github.com/centrifugal/centrifugo/libcentrifugo/channel"
 	"github.com/centrifugal/centrifugo/libcentrifugo/config"
 	"github.com/centrifugal/centrifugo/libcentrifugo/engine"
 	"github.com/centrifugal/centrifugo/libcentrifugo/logger"
@@ -665,17 +666,17 @@ func (e *RedisEngine) Run() error {
 }
 
 // PublishMessage - see engine interface description.
-func (e *RedisEngine) PublishMessage(message *proto.Message, opts *proto.ChannelOptions) <-chan error {
+func (e *RedisEngine) PublishMessage(message *proto.Message, opts *channel.Options) <-chan error {
 	return e.shards[e.shardIndex(message.Channel)].PublishMessage(message, opts)
 }
 
 // PublishJoin - see engine interface description.
-func (e *RedisEngine) PublishJoin(message *proto.JoinMessage, opts *proto.ChannelOptions) <-chan error {
+func (e *RedisEngine) PublishJoin(message *proto.JoinMessage, opts *channel.Options) <-chan error {
 	return e.shards[e.shardIndex(message.Channel)].PublishJoin(message, opts)
 }
 
 // PublishLeave - see engine interface description.
-func (e *RedisEngine) PublishLeave(message *proto.LeaveMessage, opts *proto.ChannelOptions) <-chan error {
+func (e *RedisEngine) PublishLeave(message *proto.LeaveMessage, opts *channel.Options) <-chan error {
 	return e.shards[e.shardIndex(message.Channel)].PublishLeave(message, opts)
 }
 
@@ -1115,7 +1116,7 @@ type pubRequest struct {
 	message    []byte
 	historyKey string
 	touchKey   string
-	opts       *proto.ChannelOptions
+	opts       *channel.Options
 	err        *chan error
 }
 
@@ -1391,7 +1392,7 @@ func (e *Shard) typeFromChannelID(chID ChannelID) string {
 }
 
 // PublishMessage - see engine interface description.
-func (e *Shard) PublishMessage(message *proto.Message, opts *proto.ChannelOptions) <-chan error {
+func (e *Shard) PublishMessage(message *proto.Message, opts *channel.Options) <-chan error {
 	ch := message.Channel
 
 	eChan := make(chan error, 1)
@@ -1427,7 +1428,7 @@ func (e *Shard) PublishMessage(message *proto.Message, opts *proto.ChannelOption
 }
 
 // PublishJoin - see engine interface description.
-func (e *Shard) PublishJoin(message *proto.JoinMessage, opts *proto.ChannelOptions) <-chan error {
+func (e *Shard) PublishJoin(message *proto.JoinMessage, opts *channel.Options) <-chan error {
 	ch := message.Channel
 
 	eChan := make(chan error, 1)
@@ -1450,7 +1451,7 @@ func (e *Shard) PublishJoin(message *proto.JoinMessage, opts *proto.ChannelOptio
 }
 
 // PublishLeave - see engine interface description.
-func (e *Shard) PublishLeave(message *proto.LeaveMessage, opts *proto.ChannelOptions) <-chan error {
+func (e *Shard) PublishLeave(message *proto.LeaveMessage, opts *channel.Options) <-chan error {
 	ch := message.Channel
 
 	eChan := make(chan error, 1)

--- a/libcentrifugo/integration/integration_test.go
+++ b/libcentrifugo/integration/integration_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/centrifugal/centrifugo/libcentrifugo/api/v1"
 	"github.com/centrifugal/centrifugo/libcentrifugo/auth"
+	"github.com/centrifugal/centrifugo/libcentrifugo/channel"
 	"github.com/centrifugal/centrifugo/libcentrifugo/conns"
 	"github.com/centrifugal/centrifugo/libcentrifugo/conns/clientconn"
 	"github.com/centrifugal/centrifugo/libcentrifugo/engine/enginememory"
@@ -36,19 +37,19 @@ func (e *TestEngine) Shutdown() error {
 	return nil
 }
 
-func (e *TestEngine) PublishMessage(message *proto.Message, opts *proto.ChannelOptions) <-chan error {
+func (e *TestEngine) PublishMessage(message *proto.Message, opts *channel.Options) <-chan error {
 	eChan := make(chan error, 1)
 	eChan <- nil
 	return eChan
 }
 
-func (e *TestEngine) PublishJoin(message *proto.JoinMessage, opts *proto.ChannelOptions) <-chan error {
+func (e *TestEngine) PublishJoin(message *proto.JoinMessage, opts *channel.Options) <-chan error {
 	eChan := make(chan error, 1)
 	eChan <- nil
 	return eChan
 }
 
-func (e *TestEngine) PublishLeave(message *proto.LeaveMessage, opts *proto.ChannelOptions) <-chan error {
+func (e *TestEngine) PublishLeave(message *proto.LeaveMessage, opts *channel.Options) <-chan error {
 	eChan := make(chan error, 1)
 	eChan <- nil
 	return eChan
@@ -115,8 +116,8 @@ func (t *TestSession) Close(adv *conns.DisconnectAdvice) error {
 	return nil
 }
 
-func getTestChannelOptions() proto.ChannelOptions {
-	return proto.ChannelOptions{
+func getTestChannelOptions() channel.Options {
+	return channel.Options{
 		Watch:           false,
 		Publish:         true,
 		Presence:        true,
@@ -125,20 +126,20 @@ func getTestChannelOptions() proto.ChannelOptions {
 	}
 }
 
-func getTestNamespace(name node.NamespaceKey) node.Namespace {
-	return node.Namespace{
-		Name:           name,
-		ChannelOptions: getTestChannelOptions(),
+func getTestNamespace(name channel.NamespaceKey) channel.Namespace {
+	return channel.Namespace{
+		Name:    name,
+		Options: getTestChannelOptions(),
 	}
 }
 
 func NewTestConfig() *node.Config {
 	c := node.DefaultConfig
-	var ns []node.Namespace
+	var ns []channel.Namespace
 	ns = append(ns, getTestNamespace("test"))
 	c.Namespaces = ns
 	c.Secret = "secret"
-	c.ChannelOptions = getTestChannelOptions()
+	c.Options = getTestChannelOptions()
 	return c
 }
 
@@ -427,9 +428,9 @@ func TestPublish(t *testing.T) {
 	c := NewTestConfig()
 
 	// Set custom options for default namespace
-	c.ChannelOptions.HistoryLifetime = 10
-	c.ChannelOptions.HistorySize = 2
-	c.ChannelOptions.HistoryDropInactive = true
+	c.Options.HistoryLifetime = 10
+	c.Options.HistorySize = 2
+	c.Options.HistoryDropInactive = true
 
 	app := NewTestMemoryNodeWithConfig(c)
 	createTestClients(app, 10, 1, nil)

--- a/libcentrifugo/node/config.go
+++ b/libcentrifugo/node/config.go
@@ -6,21 +6,10 @@ import (
 	"regexp"
 	"time"
 
+	"github.com/centrifugal/centrifugo/libcentrifugo/channel"
 	"github.com/centrifugal/centrifugo/libcentrifugo/config"
 	"github.com/centrifugal/centrifugo/libcentrifugo/proto"
 )
-
-// NamespaceKey is a name of namespace unique for project.
-type NamespaceKey string
-
-// Namespace allows to create channels with different channel options within the Project
-type Namespace struct {
-	// Name is a unique namespace name.
-	Name NamespaceKey `json:"name"`
-
-	// ChannelOptions for namespace determine channel options for channels belonging to this namespace.
-	proto.ChannelOptions `mapstructure:",squash"`
-}
 
 // Config contains Application configuration options.
 type Config struct {
@@ -133,11 +122,11 @@ type Config struct {
 	// ConnLifetime determines time until connection expire, 0 means no connection expire at all.
 	ConnLifetime int64 `json:"connection_lifetime"`
 
-	// ChannelOptions embedded to config.
-	proto.ChannelOptions `json:"channel_options"`
+	// channel.Options embedded to config.
+	channel.Options `json:"channel_options"`
 
 	// Namespaces - list of namespaces for custom channel options.
-	Namespaces []Namespace `json:"namespaces"`
+	Namespaces []channel.Namespace `json:"namespaces"`
 }
 
 func stringInSlice(a string, list []string) bool {
@@ -170,16 +159,16 @@ func (c *Config) Validate() error {
 }
 
 // channelOpts searches for channel options for specified namespace key.
-func (c *Config) channelOpts(nk NamespaceKey) (proto.ChannelOptions, error) {
-	if nk == NamespaceKey("") {
-		return c.ChannelOptions, nil
+func (c *Config) channelOpts(nk channel.NamespaceKey) (channel.Options, error) {
+	if nk == channel.NamespaceKey("") {
+		return c.Options, nil
 	}
 	for _, n := range c.Namespaces {
 		if n.Name == nk {
-			return n.ChannelOptions, nil
+			return n.Options, nil
 		}
 	}
-	return proto.ChannelOptions{}, proto.ErrNamespaceNotFound
+	return channel.Options{}, proto.ErrNamespaceNotFound
 }
 
 const (
@@ -282,8 +271,8 @@ func getApplicationName(v config.Getter) string {
 	return hostname + "_" + port
 }
 
-func namespacesFromConfig(v config.Getter) []Namespace {
-	ns := []Namespace{}
+func namespacesFromConfig(v config.Getter) []channel.Namespace {
+	ns := []channel.Namespace{}
 	if !v.IsSet("namespaces") {
 		return ns
 	}

--- a/libcentrifugo/node/config_test.go
+++ b/libcentrifugo/node/config_test.go
@@ -3,12 +3,13 @@ package node
 import (
 	"testing"
 
+	"github.com/centrifugal/centrifugo/libcentrifugo/channel"
 	"github.com/centrifugal/centrifugo/libcentrifugo/proto"
 	"github.com/stretchr/testify/assert"
 )
 
-func getTestChannelOptions() proto.ChannelOptions {
-	return proto.ChannelOptions{
+func getTestChannelOptions() channel.Options {
+	return channel.Options{
 		Watch:           true,
 		Publish:         true,
 		Presence:        true,
@@ -17,20 +18,20 @@ func getTestChannelOptions() proto.ChannelOptions {
 	}
 }
 
-func getTestNamespace(name NamespaceKey) Namespace {
-	return Namespace{
-		Name:           name,
-		ChannelOptions: getTestChannelOptions(),
+func getTestNamespace(name channel.NamespaceKey) channel.Namespace {
+	return channel.Namespace{
+		Name:    name,
+		Options: getTestChannelOptions(),
 	}
 }
 
 func newTestConfig() Config {
 	c := *DefaultConfig
-	var ns []Namespace
+	var ns []channel.Namespace
 	ns = append(ns, getTestNamespace("test"))
 	c.Namespaces = ns
 	c.Secret = "secret"
-	c.ChannelOptions = getTestChannelOptions()
+	c.Options = getTestChannelOptions()
 	return c
 }
 
@@ -55,7 +56,7 @@ func TestValidate(t *testing.T) {
 
 func TestValidateErrorNamespaceNotUnique(t *testing.T) {
 	c := *DefaultConfig
-	var ns []Namespace
+	var ns []channel.Namespace
 	ns = append(ns, getTestNamespace("test"))
 	ns = append(ns, getTestNamespace("test"))
 	c.Namespaces = ns
@@ -65,7 +66,7 @@ func TestValidateErrorNamespaceNotUnique(t *testing.T) {
 
 func TestValidateErrorNamespaceWrongName(t *testing.T) {
 	c := *DefaultConfig
-	var ns []Namespace
+	var ns []channel.Namespace
 	ns = append(ns, getTestNamespace("test xwxw"))
 	c.Namespaces = ns
 	err := c.Validate()

--- a/libcentrifugo/node/node.go
+++ b/libcentrifugo/node/node.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/centrifugal/centrifugo/libcentrifugo/channel"
 	"github.com/centrifugal/centrifugo/libcentrifugo/config"
 	"github.com/centrifugal/centrifugo/libcentrifugo/conns"
 	"github.com/centrifugal/centrifugo/libcentrifugo/engine"
@@ -509,7 +510,7 @@ func makeErrChan(err error) <-chan error {
 
 // Publish sends a message to all clients subscribed on channel. All running nodes
 // will receive it and will send it to all clients on node subscribed on channel.
-func (n *Node) Publish(msg *proto.Message, opts *proto.ChannelOptions) <-chan error {
+func (n *Node) Publish(msg *proto.Message, opts *channel.Options) <-chan error {
 	if opts == nil {
 		chOpts, err := n.ChannelOpts(msg.Channel)
 		if err != nil {
@@ -523,7 +524,7 @@ func (n *Node) Publish(msg *proto.Message, opts *proto.ChannelOptions) <-chan er
 
 // PublishJoin allows to publish join message into channel when someone subscribes on it
 // or leave message when someone unsubscribes from channel.
-func (n *Node) PublishJoin(msg *proto.JoinMessage, opts *proto.ChannelOptions) <-chan error {
+func (n *Node) PublishJoin(msg *proto.JoinMessage, opts *channel.Options) <-chan error {
 	if opts == nil {
 		chOpts, err := n.ChannelOpts(msg.Channel)
 		if err != nil {
@@ -537,7 +538,7 @@ func (n *Node) PublishJoin(msg *proto.JoinMessage, opts *proto.ChannelOptions) <
 
 // PublishLeave allows to publish join message into channel when someone subscribes on it
 // or leave message when someone unsubscribes from channel.
-func (n *Node) PublishLeave(msg *proto.LeaveMessage, opts *proto.ChannelOptions) <-chan error {
+func (n *Node) PublishLeave(msg *proto.LeaveMessage, opts *channel.Options) <-chan error {
 	if opts == nil {
 		chOpts, err := n.ChannelOpts(msg.Channel)
 		if err != nil {
@@ -767,17 +768,17 @@ func (n *Node) disconnectUser(user string, reconnect bool) error {
 }
 
 // namespaceKey returns namespace key from channel name if exists.
-func (n *Node) namespaceKey(ch string) NamespaceKey {
+func (n *Node) namespaceKey(ch string) channel.NamespaceKey {
 	cTrim := strings.TrimPrefix(ch, n.config.PrivateChannelPrefix)
 	if strings.Contains(cTrim, n.config.NamespaceChannelBoundary) {
 		parts := strings.SplitN(cTrim, n.config.NamespaceChannelBoundary, 2)
-		return NamespaceKey(parts[0])
+		return channel.NamespaceKey(parts[0])
 	}
-	return NamespaceKey("")
+	return channel.NamespaceKey("")
 }
 
 // ChannelOpts returns channel options for channel using current application structure.
-func (n *Node) ChannelOpts(ch string) (proto.ChannelOptions, error) {
+func (n *Node) ChannelOpts(ch string) (channel.Options, error) {
 	n.RLock()
 	defer n.RUnlock()
 	return n.config.channelOpts(n.namespaceKey(ch))

--- a/libcentrifugo/node/node_test.go
+++ b/libcentrifugo/node/node_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/centrifugal/centrifugo/libcentrifugo/channel"
 	"github.com/centrifugal/centrifugo/libcentrifugo/conns"
 	"github.com/centrifugal/centrifugo/libcentrifugo/proto"
 	"github.com/stretchr/testify/assert"
@@ -28,19 +29,19 @@ func (e *TestEngine) Shutdown() error {
 	return nil
 }
 
-func (e *TestEngine) PublishMessage(message *proto.Message, opts *proto.ChannelOptions) <-chan error {
+func (e *TestEngine) PublishMessage(message *proto.Message, opts *channel.Options) <-chan error {
 	eChan := make(chan error, 1)
 	eChan <- nil
 	return eChan
 }
 
-func (e *TestEngine) PublishJoin(message *proto.JoinMessage, opts *proto.ChannelOptions) <-chan error {
+func (e *TestEngine) PublishJoin(message *proto.JoinMessage, opts *channel.Options) <-chan error {
 	eChan := make(chan error, 1)
 	eChan <- nil
 	return eChan
 }
 
-func (e *TestEngine) PublishLeave(message *proto.LeaveMessage, opts *proto.ChannelOptions) <-chan error {
+func (e *TestEngine) PublishLeave(message *proto.LeaveMessage, opts *channel.Options) <-chan error {
 	eChan := make(chan error, 1)
 	eChan <- nil
 	return eChan
@@ -148,10 +149,10 @@ func TestClientAllowed(t *testing.T) {
 
 func TestNamespaceKey(t *testing.T) {
 	app := testNode()
-	assert.Equal(t, NamespaceKey("ns"), app.namespaceKey("ns:channel"))
-	assert.Equal(t, NamespaceKey(""), app.namespaceKey("channel"))
-	assert.Equal(t, NamespaceKey("ns"), app.namespaceKey("ns:channel:opa"))
-	assert.Equal(t, NamespaceKey("ns"), app.namespaceKey("ns::channel"))
+	assert.Equal(t, channel.NamespaceKey("ns"), app.namespaceKey("ns:channel"))
+	assert.Equal(t, channel.NamespaceKey(""), app.namespaceKey("channel"))
+	assert.Equal(t, channel.NamespaceKey("ns"), app.namespaceKey("ns:channel:opa"))
+	assert.Equal(t, channel.NamespaceKey("ns"), app.namespaceKey("ns::channel"))
 }
 
 func TestApplicationNode(t *testing.T) {

--- a/libcentrifugo/server/httpserver/handlers_test.go
+++ b/libcentrifugo/server/httpserver/handlers_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/centrifugal/centrifugo/libcentrifugo/auth"
+	"github.com/centrifugal/centrifugo/libcentrifugo/channel"
 	"github.com/centrifugal/centrifugo/libcentrifugo/node"
 	"github.com/centrifugal/centrifugo/libcentrifugo/proto"
 	"github.com/centrifugal/centrifugo/libcentrifugo/server"
@@ -36,19 +37,19 @@ func (e *TestEngine) Shutdown() error {
 	return nil
 }
 
-func (e *TestEngine) PublishMessage(message *proto.Message, opts *proto.ChannelOptions) <-chan error {
+func (e *TestEngine) PublishMessage(message *proto.Message, opts *channel.Options) <-chan error {
 	eChan := make(chan error, 1)
 	eChan <- nil
 	return eChan
 }
 
-func (e *TestEngine) PublishJoin(message *proto.JoinMessage, opts *proto.ChannelOptions) <-chan error {
+func (e *TestEngine) PublishJoin(message *proto.JoinMessage, opts *channel.Options) <-chan error {
 	eChan := make(chan error, 1)
 	eChan <- nil
 	return eChan
 }
 
-func (e *TestEngine) PublishLeave(message *proto.LeaveMessage, opts *proto.ChannelOptions) <-chan error {
+func (e *TestEngine) PublishLeave(message *proto.LeaveMessage, opts *channel.Options) <-chan error {
 	eChan := make(chan error, 1)
 	eChan <- nil
 	return eChan
@@ -94,8 +95,8 @@ func (e *TestEngine) Channels() ([]string, error) {
 	return []string{}, nil
 }
 
-func getTestChannelOptions() proto.ChannelOptions {
-	return proto.ChannelOptions{
+func getTestChannelOptions() channel.Options {
+	return channel.Options{
 		Watch:           true,
 		Publish:         true,
 		Presence:        true,
@@ -104,20 +105,20 @@ func getTestChannelOptions() proto.ChannelOptions {
 	}
 }
 
-func getTestNamespace(name node.NamespaceKey) node.Namespace {
-	return node.Namespace{
-		Name:           name,
-		ChannelOptions: getTestChannelOptions(),
+func getTestNamespace(name channel.NamespaceKey) channel.Namespace {
+	return channel.Namespace{
+		Name:    name,
+		Options: getTestChannelOptions(),
 	}
 }
 
 func NewTestConfig() *node.Config {
 	c := node.DefaultConfig
-	var ns []node.Namespace
+	var ns []channel.Namespace
 	ns = append(ns, getTestNamespace("test"))
 	c.Namespaces = ns
 	c.Secret = "secret"
-	c.ChannelOptions = getTestChannelOptions()
+	c.Options = getTestChannelOptions()
 	return c
 }
 


### PR DESCRIPTION
Made some layout refactor to move channel specifics to separate package. @banks what do you think? My main idea was to isolate channel opts from proto package because we can't make channel options part of protocol anyway - this is stable part of Centrifugo and does not depend on request/response message format.