### PR TITLE
do not send unsubscribe on shutdown

### DIFF
--- a/libcentrifugo/conns/hubs.go
+++ b/libcentrifugo/conns/hubs.go
@@ -69,9 +69,6 @@ func (h *clientHub) Shutdown() error {
 			sem <- struct{}{}
 			go func(cc ClientConn) {
 				defer func() { <-sem }()
-				for _, ch := range cc.Channels() {
-					cc.Unsubscribe(ch)
-				}
 				cc.Close(advice)
 				wg.Done()
 			}(cc)


### PR DESCRIPTION
This will allow to reliably unsubscribe clients when sending unsubscribe command via HTTP API. All unsubscribe events will be fired on client side anyway as soon as client disconnected - so actually that was unnecessary step.