### PR TITLE
Use goreleaser to release.

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -18,10 +18,32 @@ builds:
 - goos:
   - linux
   - darwin
+  - freebsd
   - windows
   goarch:
   - amd64
   - "386"
+  - arm
+  - arm64
+  ignore:
+    - goos: darwin
+      goarch: "386"
+    - goos: darwin
+      goarch: arm
+    - goos: darwin
+      goarch: arm64
+    - goos: windows
+      goarch: "386"
+    - goos: windows
+      goarch: arm
+    - goos: windows
+      goarch: arm64
+    - goos: freebsd
+      goarch: "386"
+    - goos: freebsd
+      goarch: arm
+    - goos: freebsd
+      goarch: arm64
   main: .
   ldflags: -s -w -X main.VERSION={{.Version}}
   binary: centrifugo
@@ -44,17 +66,17 @@ archive:
   format_overrides:
     - goos: windows
       format: zip
-nfpm:
-  name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm
-    }}v{{ .Arm }}{{ end }}'
-  homepage: https://github.com/centrifugal/centrifugo
-  maintainer: Alexander Emelin <frvzmb@gmail.com>
-  description: Centrifugo - real-time websocket messaging server.
-  license: MIT
-  formats:
-    - deb
-    - rpm
-  bindir: /usr/local/bin
+# nfpm:
+#   name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm
+#     }}v{{ .Arm }}{{ end }}'
+#   homepage: https://github.com/centrifugal/centrifugo
+#   maintainer: Alexander Emelin <frvzmb@gmail.com>
+#   description: Centrifugo – real-time messaging server.
+#   license: MIT
+#   formats:
+#     - deb
+#     - rpm
+#   bindir: /usr/local/bin
 checksum:
   name_template: '{{ .ProjectName }}_{{ .Version }}_checksums.txt'
 dist: dist

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,81 @@
+project_name: centrifugo
+release:
+  github:
+    owner: centrifugal
+    name: centrifugo
+  name_template: '{{.Tag}}'
+  # If set to true, will not auto-publish the release.
+  draft: true
+  # If set to true, will mark the release as not ready for production.
+  prerelease: true
+brew:
+  commit_author:
+    name: Alexander Emelin
+    email: frvzmb@gmail.com
+  install: bin.install "centrifugo"
+  skip_upload: true
+builds:
+- goos:
+  - linux
+  - darwin
+  - windows
+  goarch:
+  - amd64
+  - "386"
+  main: .
+  ldflags: -s -w -X main.VERSION={{.Version}}
+  binary: centrifugo
+  env:
+    # https://github.com/goreleaser/goreleaser/issues/225
+    - CGO_ENABLED=0
+archive:
+  name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm
+    }}v{{ .Arm }}{{ end }}'
+  format: tar.gz
+  files:
+  - licence*
+  - LICENCE*
+  - license*
+  - LICENSE*
+  - readme*
+  - README*
+  - changelog*
+  - CHANGELOG*
+  format_overrides:
+    - goos: windows
+      format: zip
+nfpm:
+  name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm
+    }}v{{ .Arm }}{{ end }}'
+  homepage: https://github.com/centrifugal/centrifugo
+  maintainer: Alexander Emelin <frvzmb@gmail.com>
+  description: Centrifugo - real-time websocket messaging server.
+  license: MIT
+  formats:
+    - deb
+    - rpm
+  bindir: /usr/local/bin
+checksum:
+  name_template: '{{ .ProjectName }}_{{ .Version }}_checksums.txt'
+dist: dist
+sign:
+  cmd: gpg
+  args:
+  - --output
+  - $signature
+  - --detach-sig
+  - $artifact
+  signature: ${artifact}.sig
+  artifacts: none
+dockers:
+  -
+    binary: centrifugo
+    goos: linux
+    goarch: amd64
+    goarm: ''
+    image: centrifugo/centrifugo
+    tag_templates:
+    - "{{ .Tag }}"
+    - "v{{ .Major }}"
+    - "v{{ .Major }}.{{ .Minor }}"
+    - latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,37 @@
 sudo: required
+
 language: go
+
 go:
-  - 1.10
+  # Use quotes to fill in safe:
+  # https://github.com/travis-ci/gimme/issues/132
+  - '1.9.x'
+  - '1.10.x'
+  - 'tip'
+
+addons:
+  apt:
+    packages:
+    # needed for the nfpm pipe:
+    - rpm
+
 services:
+  - docker
   - redis-server  
+
 before_install:
+  - docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
   - go get golang.org/x/tools/cmd/cover
   - go get github.com/mitchellh/gox
+
 script: make test
+
 deploy:
   - provider: script
-    script: extras/scripts/travis_packagecloud.sh
+    skip_cleanup: true
+    script: curl -sL http://git.io/goreleaser | bash
     on:
-      tags: true 
-      go: 1.10
+      tags: true
+      condition: $TRAVIS_OS_NAME = linux
+      go: '1.10'
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ language: go
 go:
   # Use quotes to fill in safe:
   # https://github.com/travis-ci/gimme/issues/132
-  - '1.9.x'
   - '1.10.x'
   - 'tip'
 
@@ -22,7 +21,6 @@ services:
 before_install:
   - docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
   - go get golang.org/x/tools/cmd/cover
-  - go get github.com/mitchellh/gox
 
 script: make test
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,32 +1,8 @@
-FROM centos:7
+FROM alpine:3.7
 
-ENV VERSION 1.7.5
+RUN apk --no-cache upgrade && apk --no-cache add ca-certificates
 
-ENV CENTRIFUGO_SHA256 63ea1c92801117f0d143fc92e4dfd34f58d7c22c97d1508ab0ca986acf33732b
-
-ENV DOWNLOAD https://github.com/centrifugal/centrifugo/releases/download/v$VERSION/centrifugo-$VERSION-linux-amd64.zip
-
-RUN curl -sSL "$DOWNLOAD" -o /tmp/centrifugo.zip && \
-    echo "${CENTRIFUGO_SHA256}  /tmp/centrifugo.zip" | sha256sum -c - && \
-    yum install -y unzip && \
-    unzip -jo /tmp/centrifugo.zip -d /tmp/ && \
-    yum remove -y unzip && \
-    mv /tmp/centrifugo /usr/bin/centrifugo && \
-    rm -f /tmp/centrifugo.zip && \
-    echo "centrifugo - nofile 65536" >> /etc/security/limits.d/centrifugo.nofiles.conf
-
-RUN groupadd -r centrifugo && useradd -r -g centrifugo centrifugo
-
-RUN mkdir /centrifugo && chown centrifugo:centrifugo /centrifugo && \
-    mkdir /var/log/centrifugo && chown centrifugo:centrifugo /var/log/centrifugo
-
-VOLUME ["/centrifugo", "/var/log/centrifugo"]
-
-WORKDIR /centrifugo
-
-USER centrifugo
+COPY centrifugo /usr/local/bin/centrifugo 
 
 CMD ["centrifugo"]
-
-EXPOSE 8000
 


### PR DESCRIPTION
Simplify release workflow using [goreleaser](https://github.com/goreleaser/goreleaser).
Build with `-s -w` flags to minify output file.
Use alpine:3.7 as FROM Docker image.

Fixes #197

Signed-off-by: Artemiy Ryabinkov <getlag@ya.ru>