### PR TITLE
Fixed typos and metrics name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -236,7 +236,7 @@ v1.6.2
 ### Fixes
 
 * Fix calling presence remove for every channel (not only channels with presence option enabled).
-* Change subscribing/unsubscribing algorithm to Redis channels - it fixes theretical possibility of wrong subscribing state in Redis.
+* Change subscribing/unsubscribing algorithm to Redis channels - it fixes theoretical possibility of wrong subscribing state in Redis.
 
 ### Internal (for developers/contributors)
 
@@ -268,7 +268,7 @@ As Centrifugo written in Go the only performant way to write plugins is to impor
 
 ### Release highlights:
 
-* New metrics. Several useful new metrics have beed added. For example HTTP API and client request HDR histograms. See updated documentation for complete list. Refactoring resulted in backwards incompatible issue when working with Centrifugo metrics (see below). [Here is a docs chapter](https://fzambia.gitbooks.io/centrifugal/content/server/stats.html) about metrics.
+* New metrics. Several useful new metrics have been added. For example HTTP API and client request HDR histograms. See updated documentation for complete list. Refactoring resulted in backwards incompatible issue when working with Centrifugo metrics (see below). [Here is a docs chapter](https://fzambia.gitbooks.io/centrifugal/content/server/stats.html) about metrics.
 * Optimizations for client side ping, `centrifuge-js` now automatically sends periodic `ping` commands to server. Centrifugo checks client's last activity time and closes stale connections. Builtin SockJS server won't send heartbeat frames to SockJS clients by default. You can restore the old behaviour though: setting `ping: false` on client side and `sockjs_heartbeat_delay: 25` option in Centrifugo configuration. This all means that you better update `centrifuge-js` client to latest version (`1.4.0`). Read [more about pings in docs](https://fzambia.gitbooks.io/centrifugal/content/mixed/ping.html).
 * Experimental websocket compression support for raw websockets - see [#115](https://github.com/centrifugal/centrifugo/issues/115). Read more details how to enable it [in docs](https://fzambia.gitbooks.io/centrifugal/content/mixed/websocket_compression.html). Keep in mind that enabling websocket compression can result in slower Centrifugo performance - depending on your load this can be noticeable.
 * Serious improvements in Redis API queue consuming. There was a bottleneck as we used BLPOP command to get every message from Redis which resulted in extra RTT. Now it's fixed and we can get several API messages from queue at once and process them. The format of Redis API queue changed - see new format description [in docs](https://fzambia.gitbooks.io/centrifugal/content/server/engines.html). Actually it's now the same as single HTTP API command - so we believe you should be comfortable with it. Old format is still supported but **DEPRECATED** and will be removed in next releases.
@@ -422,7 +422,7 @@ Possible backwards incompatibility here (in client side code) - see first point.
 * new channel option `history_drop_inactive` to drastically reduce resource usage (engine memory, messages travelling around) when you use message history. See [#50](https://github.com/centrifugal/centrifugo/issues/50)
 * new Redis engine option `--redis_api_num_shards`. This option sets a number of Redis shard queues Centrifugo will use in addition to standard `centrifugo.api` queue. This allows to increase amount of messages you can publish into Centrifugo and preserve message order in channels. See [#52](https://github.com/centrifugal/centrifugo/issues/52) and [documentation](https://fzambia.gitbooks.io/centrifugal/content/server/engines.html) for more details.
 * fix race condition resulting in client disconnections on high channel subscribe/unsubscribe rate. [#54](https://github.com/centrifugal/centrifugo/issues/54)
-* refactor `last_event_id` related stuff to prevent memory leaks on large amout of channels. [#48](https://github.com/centrifugal/centrifugo/issues/48)
+* refactor `last_event_id` related stuff to prevent memory leaks on large amount of channels. [#48](https://github.com/centrifugal/centrifugo/issues/48)
 * send special disconnect message to client when we don't want it to reconnect to Centrifugo (at moment to client sending malformed message). 
 * pong wait handler for raw websocket to detect non responding clients.
 

--- a/docs/content/deploy/docker.md
+++ b/docs/content/deploy/docker.md
@@ -12,4 +12,4 @@ Run:
 docker run --ulimit nofile=65536:65536 -v /host/dir/with/config/file:/centrifugo -p 8000:8000 centrifugo/centrifugo centrifugo -c config.json
 ```
 
-Note that docker allows to set `nofile` limits in command-line arguments which is pretty important to handle lots of simultenious persistent connections and not run out of open file limit.
+Note that docker allows to set `nofile` limits in command-line arguments which is pretty important to handle lots of simultaneous persistent connections and not run out of open file limit.

--- a/docs/content/server/admin.md
+++ b/docs/content/server/admin.md
@@ -45,7 +45,7 @@ If you don't want to use embedded web interface you can specify path to your own
 
 This can be useful if you want to modify official [web interface code](https://github.com/centrifugal/web) in some way.
 
-There is also an option to run Centrifugo in insecure admin mode - in this case you don't need to set `admin_password` and `admin_secret` in config – in web interface you will be logged in automatically without any password. Note that this is only an option for productionr if you protected admin web interface with firewall rules. Otherwide anyone in internet will have full access to admin functionality described above. To start Centrifugo with admin web interface in insecure admin mode run:
+There is also an option to run Centrifugo in insecure admin mode - in this case you don't need to set `admin_password` and `admin_secret` in config – in web interface you will be logged in automatically without any password. Note that this is only an option for production if you protected admin web interface with firewall rules. Otherwise anyone in internet will have full access to admin functionality described above. To start Centrifugo with admin web interface in insecure admin mode run:
 
 ```
 centrifugo --config=config.json --admin --admin_insecure

--- a/docs/content/transports/sockjs.md
+++ b/docs/content/transports/sockjs.md
@@ -9,6 +9,6 @@ If you have a requirement to work everywhere SockJS is the solution. SockJS will
 * Long-polling
 * And more (see SockJS docs)
 
-One caveat when using SockJS is that **you need to use sticky sessions mechanism if you have many Centrifugo nodes running**. This mechanism is usually supported by load balancers (for example Nginx). Sticky sessions mean that all requests from the same client will come to the same Centrifugo node. This is necessary because SockJS maintains connection session in process memory thus allowing bidirectional communication between client and server. Sticky mechnism is not required if you only use one Centrifugo node on backend. See how enable sticky sessions in Nginx in deploy section of this doc.
+One caveat when using SockJS is that **you need to use sticky sessions mechanism if you have many Centrifugo nodes running**. This mechanism is usually supported by load balancers (for example Nginx). Sticky sessions mean that all requests from the same client will come to the same Centrifugo node. This is necessary because SockJS maintains connection session in process memory thus allowing bidirectional communication between client and server. Sticky mechanism is not required if you only use one Centrifugo node on backend. See how enable sticky sessions in Nginx in deploy section of this doc.
 
 SockJS connection endpoint in Centrifugo is `/connection/sockjs`. SockJS does not support binary so you only limited in using JSON with it. 

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -136,7 +136,7 @@ func (h *apiExecutor) Broadcast(ctx context.Context, cmd *BroadcastRequest) *Bro
 // control message to other nodes so they could also unsubscribe user.
 func (h *apiExecutor) Unsubscribe(ctx context.Context, cmd *UnsubscribeRequest) *UnsubscribeResponse {
 	defer func(started time.Time) {
-		apiCommandDurationSummary.WithLabelValues(h.protocol, "unsibscribe").Observe(time.Since(started).Seconds())
+		apiCommandDurationSummary.WithLabelValues(h.protocol, "unsubscribe").Observe(time.Since(started).Seconds())
 	}(time.Now())
 
 	resp := &UnsubscribeResponse{}

--- a/internal/api/grpc.go
+++ b/internal/api/grpc.go
@@ -40,7 +40,7 @@ func (s *grpcAPIService) Broadcast(ctx context.Context, req *BroadcastRequest) (
 	return s.api.Broadcast(ctx, req), nil
 }
 
-// Channels allows to retrive list of channels.
+// Channels allows to retrieve list of channels.
 func (s *grpcAPIService) Channels(ctx context.Context, req *ChannelsRequest) (*ChannelsResponse, error) {
 	return s.api.Channels(ctx, req), nil
 }

--- a/internal/api/unmarshal.go
+++ b/internal/api/unmarshal.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 )
 
-// UnmarshalJSON helps to unmarshal comamnd method when set as string.
+// UnmarshalJSON helps to unmarshal command method when set as string.
 func (m *MethodType) UnmarshalJSON(data []byte) error {
 	val, err := strconv.Atoi(string(data))
 	if err != nil {

--- a/internal/graphite/graphite.go
+++ b/internal/graphite/graphite.go
@@ -99,7 +99,7 @@ type Config struct {
 type Bridge struct {
 	url              string
 	prefix           string
-	countersAsDetlas bool
+	countersAsDeltas bool
 	interval         time.Duration
 	timeout          time.Duration
 
@@ -156,7 +156,7 @@ func NewBridge(c *Config) (*Bridge, error) {
 
 	b.errorHandling = c.ErrorHandling
 	b.lastValue = map[model.Fingerprint]float64{}
-	b.countersAsDetlas = c.CountersAsDelta
+	b.countersAsDeltas = c.CountersAsDelta
 
 	return b, nil
 }
@@ -289,14 +289,10 @@ func writeMetric(buf *bufio.Writer, m model.Metric, mf *dto.MetricFamily) error 
 		}
 	}
 
-	if err = addExtentionConventionForRollups(buf, mf, m); err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
-func addExtentionConventionForRollups(buf *bufio.Writer, mf *dto.MetricFamily, m model.Metric) error {
+func addExtensionConventionForRollups(buf *bufio.Writer, mf *dto.MetricFamily, m model.Metric) error {
 	// Adding `.count` `.sum` suffix makes it possible to configure
 	// different rollup strategies based on metric type
 
@@ -384,7 +380,7 @@ func replaceInvalidRune(c rune) rune {
 }
 
 func (b *Bridge) replaceCounterWithDelta(mf *dto.MetricFamily, metric model.Metric, value model.SampleValue) float64 {
-	if !b.countersAsDetlas {
+	if !b.countersAsDeltas {
 		return float64(value)
 	}
 

--- a/main.go
+++ b/main.go
@@ -83,7 +83,7 @@ func main() {
 
 			absConfPath, err := filepath.Abs(configFile)
 			if err != nil {
-				log.Fatal().Msgf("Error retreiving config file absolute path: %v", err)
+				log.Fatal().Msgf("Error retrieving config file absolute path: %v", err)
 			}
 
 			err = viper.ReadInConfig()


### PR DESCRIPTION
I have fixed a couple of typos in comments, READMEs and variable names. However, there was typo in a the following line of code - ...WithLabelValues(h.protocol, "unsibscribe")... where "unsubscribe" was incorrectly spelled. This can be a problem if metrics label names are incorrectly spelled, so it might be a good idea to put those names in a separate const ( ... ) space.