### PR TITLE
Skeleton to support healthcheck endpoint

### DIFF
--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -1,0 +1,37 @@
+package health
+
+import (
+	"net/http"
+
+	"github.com/centrifugal/centrifuge"
+)
+
+// Config of health check handler.
+type Config struct{}
+
+// Handler handles health endpoint.
+type Handler struct {
+	mux    *http.ServeMux
+	node   *centrifuge.Node
+	config Config
+}
+
+// NewHandler creates new Handler.
+func NewHandler(n *centrifuge.Node, c Config) *Handler {
+	h := &Handler{
+		node:   n,
+		config: c,
+	}
+	return h
+}
+
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// err := h.node.Health()
+	// if err != nil {
+	// 	w.WriteHeader(http.StatusInternalServerError)
+	// } else {
+	// 	w.WriteHeader(http.StatusOK)
+	// }
+	w.Header().Set("Content-Type", "application/json")
+	w.Write([]byte(`{}`))
+}

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -26,12 +26,6 @@ func NewHandler(n *centrifuge.Node, c Config) *Handler {
 }
 
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	// err := h.node.Health()
-	// if err != nil {
-	// 	w.WriteHeader(http.StatusInternalServerError)
-	// } else {
-	// 	w.WriteHeader(http.StatusOK)
-	// }
 	w.Header().Set("Content-Type", "application/json")
 	w.Write([]byte(`{}`))
 }


### PR DESCRIPTION
This pr contains skeleton to support heal check endpoint in Centrifugo as requested in #252 

To finish this `Health()` method should be added to `Centrifuge` library. More details in https://github.com/centrifugal/centrifuge/issues/27