### PR TITLE
Add support for building snaps

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,0 +1,24 @@
+name: centrifugo
+version: '1.0'
+summary: Language-agnostic real-time messaging server  
+description: |
+  Language-agnostic real-time messaging server (Websocket and SockJS). 
+grade: stable
+confinement: strict
+base: core18
+parts:
+  centrifugo:
+    plugin: go
+    source: https://github.com/centrifugal/centrifugo.git
+    go-importpath: github.com/centrifugal/centrifugo
+    build-packages:
+      - build-essential
+apps:
+  centrifugo:
+    command: bin/centrifugo
+    daemon: simple
+    restart-condition: on-abnormal
+    plugs:
+      - home
+      - network
+      - network-bind


### PR DESCRIPTION
Hello guys,

I'd like to ask you to add support for snaps, if possible.

Snaps are cross-distro Linux software packages, and can be installed on a wide range of Linux distros (Ubuntu, Mint, Debian, Fedora, openSUSE, etc). They are automatically updated, and they are also featured in the Snap Store (https://snapcraft.io/store), which is accessible to millions of Linux users, so this could give you additional exposure to your project.

This PR is about adding snap support - it contains a snapcraft.yaml file for building snaps. If you use this YAML, you can package centrifugo as a snap, and then upload it to the store. The technical steps are listed below:

- Install snapcraft (command line for building snaps).
- Clone and checkout the add-snapcraft branch of your project
- Run snapcraft to build the snap (local build on a distro that supports snaps, e.g. Ubuntu 18.04)
- Install snap locally to test functionality
- Register a dev account in the Snap Store
- Login and upload your centrifugo snap to the store

If you are not familiar with snapcraft, I can help you with the syntax and post the exact sequence here.

After you've uploaded the snap to the store, we can help you with promotion, too.

Thanks.