### PR TITLE
Add 400 status code for bad requests

### DIFF
--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -90,6 +90,9 @@ func (s *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 			return
 		}
+		if rep.Error != nil {
+			w.WriteHeader(400)
+		}
 	}
 	resp := encoder.Finish()
 	w.Header().Set("Content-Type", contentType)


### PR DESCRIPTION
Server sends HTTP 200 status code on bad requests instead of HTTP 400.
The change sets HTTP 400 status code for bad requests.

### Request
```
curl -v \
  --header 'Authorization: apikey apikey' \
  --header 'Content-Type: application/json' \
  -d '{
        "method": "publish",
        "params": {
          "channel": "unknown:channel",
          "data": {"1": "2"}
        } 
    }' http://localhost:8000/api
```
### :heavy_check_mark: Response (after the change)
```
*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 8000 (#0)
> POST /api HTTP/1.1
> Host: localhost:8000
> User-Agent: curl/7.61.0
> Accept: */*
> Authorization: apikey apikey
> Content-Type: application/json
> Content-Length: 155
> 
* upload completely sent off: 155 out of 155 bytes
< HTTP/1.1 400 Bad Request
< Date: Wed, 30 Jan 2019 05:42:43 GMT
< Content-Length: 55
< Content-Type: text/plain; charset=utf-8
< 
{"error":{"code":102,"message":"namespace not found"}}
* Connection #0 to host localhost left intact
```

### :exclamation: Response (before the change)
```
*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 8000 (#0)
> POST /api HTTP/1.1
> Host: localhost:8000
> User-Agent: curl/7.61.0
> Accept: */*
> Authorization: apikey apikey
> Content-Type: application/json
> Content-Length: 155
> 
* upload completely sent off: 155 out of 155 bytes
< HTTP/1.1 200 OK
< Content-Type: application/json
< Date: Wed, 30 Jan 2019 05:45:15 GMT
< Content-Length: 55
< 
{"error":{"code":102,"message":"namespace not found"}}
* Connection #0 to host localhost left intact
```