### PR TITLE
Corrected reference to riak documentation

### DIFF
--- a/docs/content/deploy/tuning.md
+++ b/docs/content/deploy/tuning.md
@@ -15,7 +15,7 @@ ulimit -n
 
 The result shows approximately how many clients your server can handle.
 
-See http://docs.basho.com/riak/latest/ops/tuning/open-files-limit/ to know how to increase this number.
+See https://docs.riak.com/riak/kv/2.2.3/using/performance/open-files-limit.1.html to know how to increase this number.
 
 If you install Centrifugo using RPM from repo then it automatically sets max open files limit to 32768.
 


### PR DESCRIPTION
Existing link redirects to generic Riak documentation, so fixed reference to proper page.