### PR TITLE
Fix building deb packages with fpm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,5 +35,5 @@ deploy:
   - provider: script
     script: misc/scripts/travis_packagecloud.sh
     on:
-      branch: fpm_package_fix 
+      tags: true 
       go: '1.12.x'

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,5 +35,5 @@ deploy:
   - provider: script
     script: misc/scripts/travis_packagecloud.sh
     on:
-      tags: true 
+      branch: fpm_package_fix 
       go: '1.12.x'

--- a/misc/scripts/package.sh
+++ b/misc/scripts/package.sh
@@ -176,7 +176,6 @@ rm -r ./PACKAGES
 mkdir -p PACKAGES
 
 fpm -s dir -t rpm $COMMON_FPM_ARGS --description "$DESCRIPTION" \
-    --rpm-compression bzip2 \
     --rpm-os linux \
     -p PACKAGES/ \
     -a amd64 .
@@ -184,7 +183,6 @@ fpm -s dir -t rpm $COMMON_FPM_ARGS --description "$DESCRIPTION" \
 echo "Start building deb package"
 
 fpm -s dir -t deb $COMMON_FPM_ARGS --description "$DESCRIPTION" \
-    --deb-compression bzip2 \
     -p PACKAGES/ \
     -a amd64 .
 


### PR DESCRIPTION
Use default compression algorithms instead of `bzip2` broken in fpm 1.11.0

Fixes #275 