### PR TITLE
Fix v2.2.3 sockjs websocket regression for cross domain requests

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -51,7 +51,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:b43c4a782e6494fdb8d69b65d8ebe8d422adbb417d9a108e356a65b966bad0c3"
+  digest = "1:b28331c7e2ed6f7663e302f525aa3128e1e1ad9e88c49cc3e4502b46876c2a10"
   name = "github.com/centrifugal/centrifuge"
   packages = [
     ".",
@@ -63,7 +63,7 @@
     "internal/uuid",
   ]
   pruneopts = "UT"
-  revision = "feda41da8e8768a33836c1dc482d573565f983ca"
+  revision = "564e0615e74a7e2236e5bb1ffd595fa534c7e499"
 
 [[projects]]
   digest = "1:a2c1d0e43bd3baaa071d1b9ed72c27d78169b2b269f71c105ac4ba34b1be4a39"

--- a/main.go
+++ b/main.go
@@ -902,6 +902,8 @@ func sockjsHandlerConfig() centrifuge.SockjsConfig {
 	cfg := centrifuge.SockjsConfig{}
 	cfg.URL = v.GetString("sockjs_url")
 	cfg.HeartbeatDelay = time.Duration(v.GetInt("sockjs_heartbeat_delay")) * time.Second
+	cfg.CheckOrigin = func(*http.Request) bool { return true }
+	cfg.WebsocketCheckOrigin = func(r *http.Request) bool { return true }
 	cfg.WebsocketReadBufferSize = v.GetInt("websocket_read_buffer_size")
 	cfg.WebsocketWriteBufferSize = v.GetInt("websocket_write_buffer_size")
 	return cfg

--- a/vendor/github.com/centrifugal/centrifuge/.travis.yml
+++ b/vendor/github.com/centrifugal/centrifuge/.travis.yml
@@ -4,8 +4,8 @@ env:
   - GO111MODULE=off
 
 go:
-  - "1.11.x"
   - "1.12.x"
+  - "1.13.x"
   - tip
 
 services:

--- a/vendor/github.com/centrifugal/centrifuge/handler_sockjs.go
+++ b/vendor/github.com/centrifugal/centrifuge/handler_sockjs.go
@@ -118,6 +118,7 @@ func NewSockjsHandler(n *Node, c SockjsConfig) *SockjsHandler {
 		ReadBufferSize:  c.WebsocketReadBufferSize,
 		WriteBufferSize: c.WebsocketWriteBufferSize,
 		CheckOrigin:     c.WebsocketCheckOrigin,
+		Error:           func(w http.ResponseWriter, r *http.Request, status int, reason error) {},
 	}
 	// Override sockjs url. It's important to use the same SockJS
 	// library version on client and server sides when using iframe


### PR DESCRIPTION
v2.2.3 introduced regression in SockJS WebSocket transport: cross-domain requests were prohibited while in previous version we allowed to work cross-domain. This fixes a regression. 

