### PR TITLE
Support RSA tokens

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {
-  "secret": "secret",
+  "token_hmac_secret_key": "secret",
   "admin_password": "password",
   "admin_secret": "secret",
   "namespaces": [

--- a/internal/jwt/jwt.go
+++ b/internal/jwt/jwt.go
@@ -1,0 +1,40 @@
+package jwt
+
+import (
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+)
+
+var (
+	errKeyMustBePEMEncoded = errors.New("key must be PEM encoded")
+	errNotRSAPublicKey     = errors.New("key is not a valid RSA public key")
+)
+
+// ParseRSAPublicKeyFromPEM parses PEM encoded PKCS1 or PKCS8 public key.
+func ParseRSAPublicKeyFromPEM(key []byte) (*rsa.PublicKey, error) {
+	var err error
+
+	var block *pem.Block
+	if block, _ = pem.Decode(key); block == nil {
+		return nil, errKeyMustBePEMEncoded
+	}
+
+	var parsedKey interface{}
+	if parsedKey, err = x509.ParsePKIXPublicKey(block.Bytes); err != nil {
+		if cert, err := x509.ParseCertificate(block.Bytes); err == nil {
+			parsedKey = cert.PublicKey
+		} else {
+			return nil, err
+		}
+	}
+
+	var pkey *rsa.PublicKey
+	var ok bool
+	if pkey, ok = parsedKey.(*rsa.PublicKey); !ok {
+		return nil, errNotRSAPublicKey
+	}
+
+	return pkey, nil
+}

--- a/main.go
+++ b/main.go
@@ -27,6 +27,7 @@ import (
 	"github.com/centrifugal/centrifugo/internal/admin"
 	"github.com/centrifugal/centrifugo/internal/api"
 	"github.com/centrifugal/centrifugo/internal/health"
+	"github.com/centrifugal/centrifugo/internal/jwt"
 	"github.com/centrifugal/centrifugo/internal/metrics/graphite"
 	"github.com/centrifugal/centrifugo/internal/middleware"
 	"github.com/centrifugal/centrifugo/internal/webui"
@@ -92,7 +93,8 @@ func main() {
 				"presence_disable_for_client", "admin_handler_prefix", "websocket_handler_prefix",
 				"sockjs_handler_prefix", "api_handler_prefix", "prometheus_handler_prefix",
 				"health_handler_prefix", "grpc_api_tls", "grpc_api_tls_disable",
-				"grpc_api_tls_cert", "grpc_api_tls_key",
+				"grpc_api_tls_cert", "grpc_api_tls_key", "token_rsa_public_key",
+				"token_hmac_secret_key",
 			}
 			for _, env := range bindEnvs {
 				viper.BindEnv(env)
@@ -357,6 +359,8 @@ var configDefaults = map[string]interface{}{
 	"engine":                               "memory",
 	"name":                                 "",
 	"secret":                               "",
+	"token_hmac_secret_key":                "",
+	"token_rsa_public_key":                 "",
 	"publish":                              false,
 	"subscribe_to_publish":                 false,
 	"anonymous":                            false,
@@ -771,20 +775,20 @@ func pathExists(path string) (bool, error) {
 }
 
 var jsonConfigTemplate = `{
-  "secret": "{{.Secret}}",
+  "token_hmac_secret_key": "{{.TokenSecret}}",
   "admin_password": "{{.AdminPassword}}",
   "admin_secret": "{{.AdminSecret}}",
   "api_key": "{{.APIKey}}"
 }
 `
 
-var tomlConfigTemplate = `secret = {{.Secret}}
+var tomlConfigTemplate = `token_hmac_secret_key = {{.TokenSecret}}
 admin_password = {{.AdminPassword}}
 admin_secret = {{.AdminSecret}}
 api_key = {{.APIKey}}
 `
 
-var yamlConfigTemplate = `secret: {{.Secret}}
+var yamlConfigTemplate = `token_hmac_secret_key: {{.TokenSecret}}
 admin_password: {{.AdminPassword}}
 admin_secret: {{.AdminSecret}}
 api_key: {{.APIKey}}
@@ -827,7 +831,7 @@ func generateConfig(f string) error {
 
 	var output bytes.Buffer
 	t.Execute(&output, struct {
-		Secret        string
+		TokenSecret   string
 		AdminPassword string
 		AdminSecret   string
 		APIKey        string
@@ -884,7 +888,25 @@ func nodeConfig() *centrifuge.Config {
 
 	cfg.Version = VERSION
 	cfg.Name = applicationName()
-	cfg.Secret = v.GetString("secret")
+
+	hmacSecretKey := v.GetString("token_hmac_secret_key")
+	if hmacSecretKey != "" {
+		cfg.TokenHMACSecretKey = hmacSecretKey
+	} else {
+		if v.GetString("secret") != "" {
+			log.Warn().Msg("secret is deprecated, use token_hmac_secret_key instead")
+		}
+		cfg.TokenHMACSecretKey = v.GetString("secret")
+	}
+
+	rsaPublicKey := v.GetString("token_rsa_public_key")
+	if rsaPublicKey != "" {
+		pubKey, err := jwt.ParseRSAPublicKeyFromPEM([]byte(rsaPublicKey))
+		if err != nil {
+			log.Fatal().Msgf("error parsing RSA public key: %v", err)
+		}
+		cfg.TokenRSAPublicKey = pubKey
+	}
 
 	cfg.Publish = v.GetBool("publish")
 	cfg.SubscribeToPublish = v.GetBool("subscribe_to_publish")

--- a/vendor/github.com/rs/zerolog/go.mod
+++ b/vendor/github.com/rs/zerolog/go.mod
@@ -1,1 +1,3 @@
 module github.com/rs/zerolog
+
+go 1.13

--- a/vendor/github.com/rs/zerolog/go.mod
+++ b/vendor/github.com/rs/zerolog/go.mod
@@ -1,3 +1,1 @@
 module github.com/rs/zerolog
-
-go 1.13


### PR DESCRIPTION
## Proposed changes

This pull request adds support for JWT with RSA algorithm. Previously Centrifugo only worked with HMAC tokens.

Added new option `token_rsa_public_key` which is a public key string in PEM format.

`secret` option is deprecated and will be removed in next major release if it happens (Centrifugo v3, not even planned yet). We suggest to use `token_hmac_secret_key` instead which is much more meaningful.
