### PR TITLE
Add CentrifugoBundle for Symfony framework to the list of HTTP API client

### DIFF
--- a/docs/content/libraries/api.md
+++ b/docs/content/libraries/api.md
@@ -14,5 +14,6 @@ Also there are libraries supported by community:
 
 * [laracent](https://github.com/AlexHnydiuk/laracent) for Laravel framework
 * [crystalcent](https://github.com/devops-israel/crystalcent) for Crystal language
+* [CentrifugoBundle](https://github.com/fre5h/CentrifugoBundle) for Symfony framework
 
 Also keep in mind that Centrifugo [has GRPC API](../server/grpc_api.md) so you can automatically generate client API code for your language.


### PR DESCRIPTION
I developed a bundle for PHP-framework Symfony [https://github.com/fre5h/CentrifugoBundle](https://github.com/fre5h/CentrifugoBundle) and want to add a link in Centrifugo docs. So PHP-developers can find it, if they want to integrate Centrifugo into Symfony applications.