### PR TITLE
Stricter log file perm

### DIFF
--- a/main.go
+++ b/main.go
@@ -675,7 +675,7 @@ func setupLogging() *os.File {
 	zerolog.SetGlobalLevel(logLevel)
 
 	if viper.IsSet("log_file") && viper.GetString("log_file") != "" {
-		f, err := os.OpenFile(viper.GetString("log_file"), os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
+		f, err := os.OpenFile(viper.GetString("log_file"), os.O_RDWR|os.O_CREATE|os.O_APPEND, 0644)
 		if err != nil {
 			log.Fatal().Msgf("error opening log file: %v", err)
 		}


### PR DESCRIPTION
Allow writing for a process user only. Maybe should be 0600, but I think 0644 is tolerable for Centrifugo and should not break existing setups.