### PR TITLE
Use go 1.15.7 for tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     strategy:
       matrix:
-        go-version: [1.15]
+        go-version: [1.15.7]
     steps:
       - name: Install Go stable version
         uses: actions/setup-go@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         go-version: [1.15.7]
     steps:
-      - name: Install Go stable version
+      - name: Install Go
         uses: actions/setup-go@v2
         with:
           go-version: ${{ matrix.go-version }}


### PR DESCRIPTION
Otherwise `actions/setup-go@v2` action uses 1.15.6
