### PR TITLE
Add option to set allowed origins

### DIFF
--- a/docs/content/guide.md
+++ b/docs/content/guide.md
@@ -4,7 +4,7 @@ This chapter aims to help you get started with Centrifugo. We will look at a ste
 
 As Centrifugo is language-agnostic and can be used together with any language/framework we won't be specific here about any backend or frontend technology your application can be built with. Only abstract steps which you can extrapolate to your application stack.
 
-So first of all let's look again at a simplified scheme:
+Let's look again at a simplified scheme:
 
 ![Centrifugo scheme](images/scheme.png)
 
@@ -27,6 +27,8 @@ Create basic configuration file with `token_hmac_secret_key` (or `token_rsa_publ
 – which will generate `config.json` file for you with all required fields.
 
 A generated configuration also includes `v3_use_offset` option set to `true`. This is an option that enables using actual `offset` field in client-server protocol and will be used by default in Centrifugo v3. This option available since Centrifugo v2.5.0 and described in detail [in v2.5.0 release notes](https://github.com/centrifugal/centrifugo/releases/tag/v2.5.0).
+
+Properly configure [allowed_origins](server/configuration.md#allowed_origins) option.
 
 ## 2. Configure your backend
 

--- a/docs/content/quick_start.md
+++ b/docs/content/quick_start.md
@@ -10,23 +10,44 @@ First you need to [install Centrifugo](server/install.md). Below in this example
 
 It will generate `config.json` file in the same directory with content like this:
 
-```
+```json
 {
   "v3_use_offset": true,
   "token_hmac_secret_key": "46b38493-147e-4e3f-86e0-dc5ec54f5133",
   "admin_password": "ad0dff75-3131-4a02-8d64-9279b4f1c57b",
   "admin_secret": "583bc4b7-0fa5-4c4a-8566-16d3ce4ad401",
-  "api_key": "aaaf202f-b5f8-4b34-bf88-f6c03a1ecda6"
+  "api_key": "aaaf202f-b5f8-4b34-bf88-f6c03a1ecda6",
+  "allowed_origins": []
 }
 ```
 
 Now we can start server, and let's start it with built-in admin web interface:
 
-```
+```console
 ./centrifugo --config=config.json --admin
 ```
 
-Now open http://localhost:8000 – and you should see Centrifugo admin web panel. Enter `admin_password` from configuration file to log in.
+We could also enable admin web interface by not using `--admin` flag but simply add `"admin": true` option to configuration file:
+
+```json
+{
+  "v3_use_offset": true,
+  "token_hmac_secret_key": "46b38493-147e-4e3f-86e0-dc5ec54f5133",
+  "admin": true,
+  "admin_password": "ad0dff75-3131-4a02-8d64-9279b4f1c57b",
+  "admin_secret": "583bc4b7-0fa5-4c4a-8566-16d3ce4ad401",
+  "api_key": "aaaf202f-b5f8-4b34-bf88-f6c03a1ecda6",
+  "allowed_origins": []
+}
+```
+
+And running:
+
+```console
+./centrifugo --config=config.json
+```
+
+Now open [http://localhost:8000](http://localhost:8000). You should see Centrifugo admin web panel. Enter `admin_password` from configuration file to log in.
 
 ![Admin web panel](images/quick_start_admin.png)
 
@@ -41,7 +62,7 @@ Now let's create `index.html` file with our simple app:
     </head>
     <body>
         <div id="counter">-</div>
-        <script src="https://cdn.jsdelivr.net/gh/centrifugal/centrifuge-js@2.6.2/dist/centrifuge.min.js"></script>
+        <script src="https://cdn.jsdelivr.net/gh/centrifugal/centrifuge-js@2.7.1/dist/centrifuge.min.js"></script>
         <script type="text/javascript">
             const container = document.getElementById('counter')
             const centrifuge = new Centrifuge("ws://localhost:8000/connection/websocket");
@@ -66,26 +87,47 @@ Now let's create `index.html` file with our simple app:
 </html>
 ```
 
-Note that we are using `centrifuge-js` 2.6.2 in this example, you better use its latest version for a moment of reading this.
+Note that we are using `centrifuge-js` 2.7.1 in this example, you better use its latest version for a moment of reading this.
 
-We create an instance of client providing it Centrifugo default WebSocket endpoint address, then we subscribe to channel `channel` and provide callback function to process real-time messages. Then we call `connect` method to create WebSocket connection. 
+We create an instance of a client providing it Centrifugo default WebSocket endpoint address, then we subscribe to a channel `channel` and provide callback function to process real-time messages. Then we call `connect` method to create WebSocket connection. 
 
-You need to open this file in a browser, for example on MacOS:
-
-```
-open index.html
-```
-
-Or just enter sth like `file:///path/to/index.html` to browser address bar. In real application you will serve your HTML files with a proper web server – but for this simple example we don't need it.
-
-Now if you look at browser developer tools or in Centrifugo logs you will notice that connection not successfully established:
+You need to serve this file with HTTP server, for example with Python 3 (in real Javascript application you will serve your HTML files with a proper web server – but for this simple example we can use a simple one):
 
 ```
-2020-05-16 01:19:59 [INF] invalid connection token error="jwt: token format is not valid" client=45a1b8f4-d6dc-4679-9927-93e41c14ad93
-2020-05-16 01:19:59 [INF] disconnect after handling command client=45a1b8f4-d6dc-4679-9927-93e41c14ad93 command="id:1 params:\"{\\\"token\\\":\\\"<TOKEN>\\\"}\" " reason="invalid token" user=
+python3 -m http.server 2000
 ```
 
-That's because client should provide valid JWT (JSON Web Token) to authenticate itself. This token **must be generated on your backend** and passed to client side. Since in our simple example we don't have application backend we can quickly generate example token for a user using `centrifugo` sub-command `gentoken`. Like this:
+If you don't have Python 3 then [this gist can be useful](https://gist.github.com/willurd/5720255).
+
+Open [http://localhost:2000/](http://localhost:2000/).
+
+Now if you look at browser developer tools or in Centrifugo logs you will notice a connection can not be successfully established:
+
+```
+2021-02-26 17:37:47 [INF] error checking request origin error="request Origin \"http://localhost:2000\" is not authorized for Host \"localhost:8000\""
+```
+
+That's because we are running our application on `localhost:2000` while Centrifugo runs on `localhost:8000`. We need to additionally configure `allowed_origins` option:
+
+```json
+{
+  ...
+  "allowed_origins": [
+    "localhost:2000"    
+  ]
+}
+```
+
+Restart Centrifugo after fixing a configuration file.
+
+Now if you reload a browser window with an application you should see new information logs in server output:
+
+```
+2021-02-26 17:47:47 [INF] invalid connection token error="jwt: token format is not valid" client=45a1b8f4-d6dc-4679-9927-93e41c14ad93
+2021-02-26 17:47:47 [INF] disconnect after handling command client=45a1b8f4-d6dc-4679-9927-93e41c14ad93 command="id:1 params:\"{\\\"token\\\":\\\"<TOKEN>\\\"}\" " reason="invalid token" user=
+```
+
+We still can not connect. That's because client should provide a valid JWT (JSON Web Token) to authenticate itself. This token **must be generated on your backend** and passed to a client side. Since in our simple example we don't have application backend we can quickly generate example token for a user using `centrifugo` sub-command `gentoken`. Like this:
 
 ```
 ./centrifugo gentoken -u 123722
@@ -112,7 +154,7 @@ If you open developer tools and look at WebSocket frames panel you should see st
 
 ![Connected](images/quick_start_connected.png)
 
-OK, the last thing we need to do here is publish new counter value to channel and make sure our app works properly.
+OK, the last thing we need to do here is to publish new counter value to a channel and make sure our app works properly.
 
 We can do this over Centrifugo API sending HTTP request to default API endpoint `http://localhost:8000/api`, but let's do this over admin web panel first.
 
@@ -144,7 +186,7 @@ curl --header "Content-Type: application/json" \
 
 – where for `Authorization` header we set `api_key` value from Centrifugo config file generated above.
 
-We did it! We built the simplest app with Centrifugo and its Javascript client. It does not have backend, it's not very useful to be honest, but it should give you an insight on how to start working with Centrifugo server. Read more about Centrifugo server in next documentations chapters – it can do much-much more than we just showed here. [Integration guide](guide.md) describes a process of idiomatic Centrifugo integration with your application backend.
+We did it! We built the simplest browser real-time app with Centrifugo and its Javascript client. It does not have backend, it's not very useful to be honest, but it should give you an insight on how to start working with Centrifugo server. Read more about Centrifugo server in next documentations chapters – it can do much-much more than we just showed here. [Integration guide](guide.md) describes a process of idiomatic Centrifugo integration with your application backend.
 
 ### More examples
 

--- a/docs/content/quick_start.md
+++ b/docs/content/quick_start.md
@@ -113,7 +113,7 @@ That's because we are running our application on `localhost:2000` while Centrifu
 {
   ...
   "allowed_origins": [
-    "localhost:2000"    
+    "http://localhost:2000"
   ]
 }
 ```

--- a/docs/content/server/configuration.md
+++ b/docs/content/server/configuration.md
@@ -83,36 +83,34 @@ Some of the most important options you can configure when running Centrifugo:
 
 ### address
 
-Bind your Centrifugo to specific interface address (by default `""` - listen on all available interfaces).
+Bind your Centrifugo to specific interface address (string, by default `""` - listen on all available interfaces).
 
 ### port
 
-Port to bind Centrifugo to (by default `8000`)
+Port to bind Centrifugo to (string, by default `"8000"`).
 
 ### engine
 
-Engine to use - `memory` or `redis` (by default `memory`). Read more about engines in [special chapter](engines).
+Engine to use - `memory` or `redis` (string, by default `memory`). Read more about engines in [special chapter](engines).
 
 ### allowed_origins
 
 New in Centrifugo v2.9.0.
 
-This option allows setting an array of allowed origin host patterns to prevent CSRF attacks. This is especially important if you are using [connect proxy](proxy.md#connect-proxy) feature.
+This option allows setting an array of allowed origin host patterns (array of strings) for WebSocket and SockJS endpoints to prevent [CSRF](https://en.wikipedia.org/wiki/Cross-site_request_forgery) attacks. This is especially important if you are using [connect proxy](proxy.md#connect-proxy) feature.
 
 If `allowed_origins` option not set at all then no origin check will be performed by Centrifugo.
-
-If set to an empty array then only requests that follow same-origin strategy will pass the check. An example same-origin scenario is when you are connecting from `https://example.com` to Centrifugo running on the same domain `https://example.com/connection/websocket`.
 
 !!!danger
     Centrifugo v3 will enforce same-origin strategy by default, so you better to properly configure `allowed_origins` as soon as possible.
 
-If `allowed_origins` has array items then every non same-origin connection request will be checked against each pattern in an array.
+If `allowed_origins` defined then every connection request will be checked against each pattern in an array.
 
-For example, you are connecting to Centrifugo (which is run on `localhost:8000`) from application on `localhost:3000`. In this case you need to configure `allowed_origins` this way:
+For example, you are connecting to Centrifugo (which is run on `localhost:8000`) from application on `http://localhost:3000`. In this case you need to configure `allowed_origins` this way:
 
 ```
 "allowed_origins": [
-    "localhost:3000"
+    "http://localhost:3000"
 ]
 ```
 
@@ -120,7 +118,7 @@ If you are connecting from `https://example.com` to Centrifugo `https://centrifu
 
 ```
 "allowed_origins": [
-    "example.com"
+    "https://example.com"
 ]
 ```
 
@@ -128,11 +126,11 @@ Origin pattern can contain wildcard symbol `*` to match subdomains:
 
 ```
 "allowed_origins": [
-    "*.example.com"
+    "https://*.example.com"
 ]
 ```
 
-– in this case requests with Origin headers like `https://foo.example.com` or `https://bar.example.com` will pass the check.
+– in this case requests with Origin header like `https://foo.example.com` or `https://bar.example.com` will pass the check.
 
 ## Advanced options
 

--- a/docs/content/server/configuration.md
+++ b/docs/content/server/configuration.md
@@ -6,7 +6,7 @@ Here we will look at how Centrifugo can be configured.
 
 Centrifugo can be configured in several ways:
 
-* over command-line flags, see `centrifugo -h` for available flags, command-line flags limited to most frequently used
+* over command-line flags, see `centrifugo -h` for available flags, command-line flags limited to most frequently used. Command-line options have the highest priority when set than other ways to configure Centrifugo. See description of [viper](https://github.com/spf13/viper) library (used in Centrifugo internally) for more details about configuration ways priority.
 * over configuration file, configuration file supports all options mentioned in this documentation
 * over OS environment variables, **all Centrifugo options can be set over env in format `CENTRIFUGO_<OPTION_NAME>`** (mostly straightforward except namespaces - [see how to set namespaces via env](channels.md#setting-namespaces-over-env))
 
@@ -32,7 +32,7 @@ This is a minimal Centrifugo configuration file:
 {
   "v3_use_offset": true,
   "token_hmac_secret_key": "<YOUR-SECRET-STRING-HERE>",
-  "api_key": "<YOUR-API-KEY-HERE>",
+  "api_key": "<YOUR-API-KEY-HERE>"
 }
 ```
 
@@ -81,11 +81,58 @@ With YAML remember to use spaces, not tabs when writing configuration file.
 
 Some of the most important options you can configure when running Centrifugo:
 
-* `address` – bind your Centrifugo to specific interface address (by default `""`)
-* `port` – port to bind Centrifugo to (by default `8000`)
-* `engine` – engine to use - `memory` or `redis` (by default `memory`). Read more about engines in [special chapter](engines).
+## address
 
-Note that some options can be set via command-line. Command-line options are more valuable when set than configuration file's options. See description of [viper](https://github.com/spf13/viper) – to see more details about configuration options priority.
+Bind your Centrifugo to specific interface address (by default `""` - listen on all available interfaces).
+
+## port
+
+Port to bind Centrifugo to (by default `8000`)
+
+## engine
+
+Engine to use - `memory` or `redis` (by default `memory`). Read more about engines in [special chapter](engines).
+
+## allowed_origins
+
+New in Centrifugo v2.9.0.
+
+This option allows setting an array of allowed origin host patterns to prevent CSRF attacks. This is especially important if you are using [connect proxy](proxy.md#connect-proxy) feature.
+
+If `allowed_origins` option not set at all then no origin check will be performed by Centrifugo.
+
+If set to an empty array then only requests that follow same-origin strategy will pass the check. An example same-origin scenario is when you are connecting from `https://example.com` to Centrifugo running on the same domain `https://example.com/connection/websocket`.
+
+!!!danger
+    Centrifugo v3 will enforce same-origin strategy by default, so you better to properly configure `allowed_origins` as soon as possible.
+
+If `allowed_origins` has array items then every non same-origin connection request will be checked against each pattern in an array.
+
+For example, you are connecting to Centrifugo (which is run on `localhost:8000`) from application on `localhost:3000`. In this case you need to configure `allowed_origins` this way:
+
+```
+"allowed_origins": [
+    "localhost:3000"
+]
+```
+
+If you are connecting from `https://example.com` to Centrifugo `https://centrifugo.example.com`:
+
+```
+"allowed_origins": [
+    "example.com"
+]
+```
+
+Origin pattern can contain wildcard symbol `*` to match subdomains:
+
+```
+"allowed_origins": [
+    "*.example.com"
+]
+```
+
+– in this case requests with Origin headers like `https://foo.example.com` or `https://bar.example.com` will pass the check.
 
 ## Advanced options
 

--- a/docs/content/server/configuration.md
+++ b/docs/content/server/configuration.md
@@ -97,16 +97,16 @@ Engine to use - `memory` or `redis` (string, by default `memory`). Read more abo
 
 New in Centrifugo v2.9.0.
 
-This option allows setting an array of allowed origin host patterns (array of strings) for WebSocket and SockJS endpoints to prevent [CSRF](https://en.wikipedia.org/wiki/Cross-site_request_forgery) attacks. This is especially important if you are using [connect proxy](proxy.md#connect-proxy) feature.
+This option allows setting an array of allowed origin patterns (array of strings) for WebSocket and SockJS endpoints to prevent [CSRF](https://en.wikipedia.org/wiki/Cross-site_request_forgery) attack. This is especially important if you are using [connect proxy](proxy.md#connect-proxy) feature.
 
 If `allowed_origins` option not set at all then no origin check will be performed by Centrifugo.
 
 !!!danger
     Centrifugo v3 will enforce same-origin strategy by default, so you better to properly configure `allowed_origins` as soon as possible.
 
-If `allowed_origins` defined then every connection request will be checked against each pattern in an array.
+As soon as `allowed_origins` defined every connection request will be checked against each pattern in an array.
 
-For example, you are connecting to Centrifugo (which is run on `localhost:8000`) from application on `http://localhost:3000`. In this case you need to configure `allowed_origins` this way:
+For example, you are connecting to Centrifugo from an application on `http://localhost:3000`. In this case you need to configure `allowed_origins` this way:
 
 ```
 "allowed_origins": [
@@ -114,7 +114,7 @@ For example, you are connecting to Centrifugo (which is run on `localhost:8000`)
 ]
 ```
 
-If you are connecting from `https://example.com` to Centrifugo `https://centrifugo.example.com`:
+If you are connecting from `https://example.com`:
 
 ```
 "allowed_origins": [
@@ -130,11 +130,13 @@ Origin pattern can contain wildcard symbol `*` to match subdomains:
 ]
 ```
 
-– in this case requests with Origin header like `https://foo.example.com` or `https://bar.example.com` will pass the check.
+– in this case requests with `Origin` header like `https://foo.example.com` or `https://bar.example.com` will pass the check.
+
+Connection requests without `Origin` header set are passing through without any checks (i.e. always allowed).
 
 ## Advanced options
 
-Centrifugo has some options for which default values make sense for most applications. In many case you don't need (and you really should not) change them. This chapter is about such options.
+Centrifugo has some options for which default values make sense for most applications. In many cases you don't need (and you really should not) change them. This chapter is about such options.
 
 ### client_channel_limit
 

--- a/docs/content/server/configuration.md
+++ b/docs/content/server/configuration.md
@@ -81,19 +81,19 @@ With YAML remember to use spaces, not tabs when writing configuration file.
 
 Some of the most important options you can configure when running Centrifugo:
 
-## address
+### address
 
 Bind your Centrifugo to specific interface address (by default `""` - listen on all available interfaces).
 
-## port
+### port
 
 Port to bind Centrifugo to (by default `8000`)
 
-## engine
+### engine
 
 Engine to use - `memory` or `redis` (by default `memory`). Read more about engines in [special chapter](engines).
 
-## allowed_origins
+### allowed_origins
 
 New in Centrifugo v2.9.0.
 

--- a/docs/content/server/configuration.md
+++ b/docs/content/server/configuration.md
@@ -10,7 +10,7 @@ Centrifugo can be configured in several ways:
 * over configuration file, configuration file supports all options mentioned in this documentation
 * over OS environment variables, **all Centrifugo options can be set over env in format `CENTRIFUGO_<OPTION_NAME>`** (mostly straightforward except namespaces - [see how to set namespaces via env](channels.md#setting-namespaces-over-env))
 
-The basic way to start with Centrifugo is run `centrifugo genconfig` command which will generate `config.json` configuration file with some options (in a current directory), so you can then run Centrifugo:
+The basic way to start with Centrifugo is run `centrifugo genconfig` command which will generate `config.json` configuration file with some options (in a current directory), so it's then possible to run Centrifugo:
 
 ```
 centrifugo -c config.json
@@ -97,16 +97,16 @@ Engine to use - `memory` or `redis` (string, by default `memory`). Read more abo
 
 New in Centrifugo v2.9.0.
 
-This option allows setting an array of allowed origin patterns (array of strings) for WebSocket and SockJS endpoints to prevent [CSRF](https://en.wikipedia.org/wiki/Cross-site_request_forgery) attack. This is especially important if you are using [connect proxy](proxy.md#connect-proxy) feature.
+This option allows setting an array of allowed origin patterns (array of strings) for WebSocket and SockJS endpoints to prevent [CSRF](https://en.wikipedia.org/wiki/Cross-site_request_forgery) attack. This is especially important when using [connect proxy](proxy.md#connect-proxy) feature.
 
 If `allowed_origins` option not set at all then no origin check will be performed by Centrifugo.
 
 !!!danger
-    Centrifugo v3 will enforce same-origin strategy by default, so you better to properly configure `allowed_origins` as soon as possible.
+    Centrifugo v3 may enforce same-origin strategy by default, so it's better to properly configure `allowed_origins` as soon as possible.
 
 As soon as `allowed_origins` defined every connection request will be checked against each pattern in an array.
 
-For example, you are connecting to Centrifugo from an application on `http://localhost:3000`. In this case you need to configure `allowed_origins` this way:
+For example, when connecting to Centrifugo from an application on `http://localhost:3000`. In this case `allowed_origins` should be configured this way:
 
 ```
 "allowed_origins": [
@@ -114,7 +114,7 @@ For example, you are connecting to Centrifugo from an application on `http://loc
 ]
 ```
 
-If you are connecting from `https://example.com`:
+When connecting from `https://example.com`:
 
 ```
 "allowed_origins": [
@@ -135,8 +135,6 @@ Origin pattern can contain wildcard symbol `*` to match subdomains:
 Connection requests without `Origin` header set are passing through without any checks (i.e. always allowed).
 
 ## Advanced options
-
-Centrifugo has some options for which default values make sense for most applications. In many cases you don't need (and you really should not) change them. This chapter is about such options.
 
 ### client_channel_limit
 
@@ -202,11 +200,11 @@ Enable websocket compression, see chapter about websocket transport for more det
 
 Default: 0
 
-By default, Centrifugo runs on all available CPU cores. If you want to limit amount of cores Centrifugo can utilize in one moment use this option.
+By default, Centrifugo runs on all available CPU cores. To limit amount of cores Centrifugo can utilize in one moment use this option.
 
 ## Advanced endpoint configuration.
 
-After you started Centrifugo you have several endpoints available. As soon as you have not provided any extra options you have 3 endpoints by default.
+After Centrifugo started there are several endpoints available.
 
 ### Default endpoints.
 
@@ -222,13 +220,13 @@ Then there is SockJS endpoint - it's needed to serve client connections that use
 http://localhost:8000/connection/sockjs
 ```
 
-And finally you have API endpoint to `publish` messages to channels (and execute other available API commands):
+Finally, API endpoint to `publish` messages to channels (and execute other available API commands):
 
 ```
 http://localhost:8000/api
 ```
 
-By default, all endpoints work on port `8000`. You can change it using `port` option:
+By default, all endpoints work on port `8000`. This can be changed with `port` option:
 
 ```
 {
@@ -236,7 +234,7 @@ By default, all endpoints work on port `8000`. You can change it using `port` op
 }
 ```
 
-In production setup you will have your domain name in endpoint addresses above instead of `localhost`. Also if your Centrifugo will be behind proxy or load balancer software you most probably won't have ports in your endpoint addresses. What will always be the same as shown above are URL paths: `/connection/sockjs`, `/connection/websocket`, `/api`.
+In production setup you may have a proper domain name in endpoint addresses above instead of `localhost`. While domain name and port parts can differ depending on setup – URL paths stay the same: `/connection/sockjs`, `/connection/websocket`, `/api`.
 
 Let's look at possibilities to tweak available endpoints.
 
@@ -274,7 +272,7 @@ And endpoint:
 http://localhost:8000/debug/pprof/
 ```
 
-– will show you useful info about internal state of Centrifugo instance. This info is especially helpful when troubleshooting. See [wiki page](https://github.com/centrifugal/centrifugo/wiki/Investigating-performance-issues) for more info.
+– will show useful information about internal state of Centrifugo instance. This info is especially helpful when troubleshooting. See [wiki page](https://github.com/centrifugal/centrifugo/wiki/Investigating-performance-issues) for more info.
 
 ### Health check endpoint
 
@@ -296,7 +294,7 @@ We strongly recommend to not expose API, admin, debug and prometheus endpoints t
 * Health check endpoint (`/health`) - used to do health checks
 * Debug endpoints (`/debug/pprof`) - used to inspect internal server state
 
-It's a good practice to protect those endpoints with firewall. For example, you can do this in `location` section of Nginx configuration.
+It's a good practice to protect those endpoints with firewall. For example, it's possible to configure in `location` section of Nginx configuration.
 
 Though sometimes you don't have access to per-location configuration in your proxy/load balancer software. For example when using Amazon ELB. In this case you can change ports on which your internal endpoints work.
 
@@ -346,7 +344,7 @@ Starting from Centrifugo v2.2.5 it's possible to customize server HTTP handler e
 
 ## Signal handling
 
-You can send HUP signal to Centrifugo to reload a configuration:
+It's possible to send HUP signal to Centrifugo to reload a configuration:
 
 ```
 kill -HUP <PID>

--- a/docs/content/server/proxy.md
+++ b/docs/content/server/proxy.md
@@ -123,6 +123,9 @@ if __name__ == '__main__':
 
 This example should help you to implement similar HTTP handler in any language/framework you are using on backend side.
 
+!!!danger
+    Make sure you properly configured [allowed_origins](configuration.md#allowed_origins) Centrifugo option or check request origin on your backend side upon receiving connect request from Centrifugo.
+
 ### Refresh proxy
 
 With the following options in configuration file:

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/centrifugal/centrifuge v0.14.2
 	github.com/centrifugal/protocol v0.3.4
 	github.com/cristalhq/jwt/v3 v3.0.9
+	github.com/gobwas/glob v0.2.3
 	github.com/gogo/protobuf v1.3.1
 	github.com/google/go-cmp v0.5.4 // indirect
 	github.com/google/uuid v1.1.2

--- a/go.sum
+++ b/go.sum
@@ -95,6 +95,8 @@ github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
 github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
+github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 github.com/gogo/googleapis v1.1.0/go.mod h1:gf4bu3Q80BeJ6H1S1vYPm8/ELATdvryBaNFGgqEef3s=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=

--- a/go.sum
+++ b/go.sum
@@ -33,9 +33,7 @@ github.com/aryann/difflib v0.0.0-20170710044230-e206f873d14a/go.mod h1:DAHtR1m6l
 github.com/aws/aws-lambda-go v1.13.3/go.mod h1:4UKl9IzQMoD+QF79YdCuzCwp8VbmG4VAQwij/eHl5CU=
 github.com/aws/aws-sdk-go v1.27.0/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go-v2 v0.18.0/go.mod h1:JWVYvqSMppoMJC0x5wdwiImzgXTI9FuZwxzkQq9wy+g=
-github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 h1:xJ4a3vCFaGF/jqvzLMYoU8P317H5OQ+Via4RmuPwCS0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
-github.com/beorn7/perks v1.0.0 h1:HWo1m869IqiPhD389kmkxeTalrjNbbJTC8LXupb+sl0=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
@@ -71,7 +69,6 @@ github.com/cristalhq/jwt/v3 v3.0.9/go.mod h1:XOnIXst8ozq/esy5N1XOlSyQqBd+84fxJ99
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
@@ -104,7 +101,6 @@ github.com/gogo/protobuf v1.2.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7a
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/gogo/protobuf v1.3.1 h1:DqDEcV5aeaTmdFBePNpYsp3FlcVH/2ISVVM9Qf8PSls=
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
-github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -113,7 +109,6 @@ github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfb
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
-github.com/golang/protobuf v1.3.3 h1:gyjaxf+svBWX08ZjK86iN9geUJF0H6gp2IRKX6Nf6/I=
 github.com/golang/protobuf v1.3.3/go.mod h1:vzj43D7+SQXF/4pzW/hwtAqwc6iTitCiVSaWz5lYuqw=
 github.com/golang/protobuf v1.3.5/go.mod h1:6O5/vntMXwX2lRkT1hjjk0nAC1IDOTvTlVgjlRvqsdk=
 github.com/golang/protobuf v1.4.0-rc.1/go.mod h1:ceaxUfeHdC40wWswd/P6IGgMaK3YpKi5j83Wpe3EHw8=
@@ -132,16 +127,13 @@ github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
-github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.0 h1:/QaMHBdZ26BB3SSst0Iwl10Epc+xhTquomWX0oZEB6w=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.4 h1:L8R9j+yAqZuZjsqh/z+F1NCffTKKLShY6zXTItVIZ8M=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -249,7 +241,6 @@ github.com/nats-io/nats-server/v2 v2.1.2/go.mod h1:Afk+wRZqkMQs/p45uXdrVLuab3gwv
 github.com/nats-io/nats-server/v2 v2.1.6 h1:qAaHZaS8pRRNQLFaiBA1rq5WynyEGp9DFgmMfoaiXGY=
 github.com/nats-io/nats-server/v2 v2.1.6/go.mod h1:BL1NOtaBQ5/y97djERRVWNouMW7GT3gxnmbE/eC8u8A=
 github.com/nats-io/nats.go v1.9.1/go.mod h1:ZjDU1L/7fJ09jvUSRVBR2e7+RnLiiIQyqyzEE/Zbp4w=
-github.com/nats-io/nats.go v1.9.2 h1:oDeERm3NcZVrPpdR/JpGdWHMv3oJ8yY30YwxKq+DU2s=
 github.com/nats-io/nats.go v1.9.2/go.mod h1:AjGArbfyR50+afOUotNX2Xs5SYHf+CoOa5HH1eEl2HE=
 github.com/nats-io/nats.go v1.10.0 h1:L8qnKaofSfNFbXg0C5F71LdjPRnmQwSsA4ukmkt1TvY=
 github.com/nats-io/nats.go v1.10.0/go.mod h1:AjGArbfyR50+afOUotNX2Xs5SYHf+CoOa5HH1eEl2HE=
@@ -302,7 +293,6 @@ github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829/go.mod 
 github.com/prometheus/client_golang v0.9.3/go.mod h1:/TN21ttK/J9q6uSwhBd54HahCDft0ttaMvbicHlPoso=
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=
 github.com/prometheus/client_golang v1.3.0/go.mod h1:hJaj2vgQTGQmVCsAACORcieXFeDPbaTKGT+JTgUa3og=
-github.com/prometheus/client_golang v1.6.0 h1:YVPodQOcK15POxhgARIvnDRVpLcuK8mglnMrWfyrw6A=
 github.com/prometheus/client_golang v1.6.0/go.mod h1:ZLOG9ck3JLRdB5MgO8f+lLTe83AXG6ro35rLTxvnIl4=
 github.com/prometheus/client_golang v1.7.1 h1:NTGy1Ja9pByO+xAeH/qiWnLrKtr3hJPNjaVUwnjpdpA=
 github.com/prometheus/client_golang v1.7.1/go.mod h1:PY5Wy2awLA44sXw4AOSfFBetzPP4j5+D6mVACh+pe2M=
@@ -320,7 +310,6 @@ github.com/prometheus/common v0.4.0/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y8
 github.com/prometheus/common v0.4.1/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
 github.com/prometheus/common v0.7.0/go.mod h1:DjGbpBbp5NYNiECxcL/VnbXCCaQpKd3tt26CguLLsqA=
 github.com/prometheus/common v0.9.1/go.mod h1:yhUN8i9wzaXS3w1O07YhxHEBxD+W35wd8bs7vj7HSQ4=
-github.com/prometheus/common v0.10.0 h1:RyRA7RzGXQZiW+tGMr7sxa85G1z0yOpM1qq5c8lNawc=
 github.com/prometheus/common v0.10.0/go.mod h1:Tlit/dnDKsSWFlCLTWaA1cyBgKHSMdTB80sz/V91rCo=
 github.com/prometheus/common v0.14.0 h1:RHRyE8UocrbjU+6UvRzwi6HjiDfxrrBU91TtbKzkGp4=
 github.com/prometheus/common v0.14.0/go.mod h1:U+gB1OBLb1lF3O42bTCL+FK18tX9Oar16Clt/msog/s=
@@ -330,9 +319,7 @@ github.com/prometheus/procfs v0.0.0-20190117184657-bf6a532e95b1/go.mod h1:c3At6R
 github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+GxbHq6oeK9A=
-github.com/prometheus/procfs v0.0.11 h1:DhHlBtkHWPYi8O2y31JkK0TF+DGM+51OopZjH/Ia5qI=
 github.com/prometheus/procfs v0.0.11/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
-github.com/prometheus/procfs v0.1.3 h1:F0+tqvhOksq22sc6iCHF5WGlWjdwj92p0udFh1VFBS8=
 github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
 github.com/prometheus/procfs v0.2.0 h1:wH4vA7pcjKuZzjF7lM8awk4fnuJO6idemZXoKnULUx4=
 github.com/prometheus/procfs v0.2.0/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
@@ -375,12 +362,10 @@ github.com/streadway/amqp v0.0.0-20190404075320-75d898a42a94/go.mod h1:AZpEONHx3
 github.com/streadway/amqp v0.0.0-20190827072141-edfb9018d271/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
 github.com/streadway/handy v0.0.0-20190108123426-d5acb3125c2a/go.mod h1:qNTQ5P5JnDBl6z3cMAg/SywNDC5ABu5ApDIw6lUbRmI=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/objx v0.1.1 h1:2vfRuCMp5sSVIDSqO8oNnWJq7mPa6KVP3iPIwFBuy8A=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
-github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
@@ -412,7 +397,6 @@ golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200323165209-0ec3e9974c59/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
-golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 h1:psW17arqaxU48Z5kZ0CQnkZWQJsqcURM6tKiBApRjXI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad h1:DN0cp81fZ3njFcrLCytUHRSUkqBjfTo4Tx9RJTWs0EY=
 golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
@@ -450,7 +434,6 @@ golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e h1:vcxGaoTs7kV8m5Np9uUNQin4BrLOthgV7252N8V+FwY=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a h1:DcqTD9SDLc+1P/r1EmRBwnVsrOwW+kk2vWf9n+1sGhs=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -476,12 +459,10 @@ golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200420163511-1957bb5e6d1f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae h1:Ih9Yo4hSPImZOpfGuA4bR/ORKTAbhZo2AbWNRCnevdo=
 golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f h1:+Nyd8tzPX9R7BWHguqsrbFdRx3WQ/1ib8I44HXV5yTA=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
-golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
@@ -515,7 +496,6 @@ google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoA
 google.golang.org/genproto v0.0.0-20190307195333-5fe7a883aa19/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
 google.golang.org/genproto v0.0.0-20190425155659-357c62f0e4bb/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
 google.golang.org/genproto v0.0.0-20190530194941-fb225487d101/go.mod h1:z3L6/3dTEVtUr6QSP8miRzeRqwQOioJ9I66odjN4I7s=
-google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55 h1:gSJIx1SDwno+2ElGhA4+qG2zF97qiUzTM+rQ0klBOcE=
 google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
 google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 h1:+kGHl1aib/qcwaRi1CbqBZ1rk19r85MNUf8HaBghugY=
 google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013/go.mod h1:NbSheEEYHJ7i3ixzK3sjbqSGDJWnxyFXZblF3eUsNvo=
@@ -538,7 +518,6 @@ google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQ
 google.golang.org/protobuf v1.20.1-0.20200309200217-e05f789c0967/go.mod h1:A+miEFZTKqfCUM6K7xSMQL9OKL/b6hQv+e19PK+JZNE=
 google.golang.org/protobuf v1.21.0/go.mod h1:47Nbq4nVaFHyn7ilMalzfO3qCViNmqZ2kzikPIcrTAo=
 google.golang.org/protobuf v1.22.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
-google.golang.org/protobuf v1.23.0 h1:4MY060fB1DLGMB/7MBTLnwQUY6+F09GEiz6SsrNqyzM=
 google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.25.0 h1:Ejskq+SyPohKW+1uil0JJMtmHCgJPJ/qWTxr8qp+R4c=
@@ -561,11 +540,9 @@ gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bl
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.2.5 h1:ymVxjfMaHvXD8RqPRmzHHsB3VvucivSkIAvJFDI5O3c=
 gopkg.in/yaml.v2 v2.2.5/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/origin/origin.go
+++ b/internal/origin/origin.go
@@ -1,0 +1,57 @@
+package origin
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"path/filepath"
+	"strings"
+)
+
+func match(pattern, s string) (bool, error) {
+	return filepath.Match(strings.ToLower(pattern), strings.ToLower(s))
+}
+
+type Checker struct {
+	allowedOrigins []string
+}
+
+func NewChecker(allowedOrigins []string) (*Checker, error) {
+	for _, pattern := range allowedOrigins {
+		// check bad pattern error on start.
+		if _, err := match(pattern, "_"); err != nil {
+			return nil, fmt.Errorf("malformed origin pattern: %w", err)
+		}
+	}
+	return &Checker{
+		allowedOrigins: allowedOrigins,
+	}, nil
+}
+
+func (a *Checker) Check(r *http.Request) error {
+	origin := r.Header.Get("Origin")
+	if origin == "" {
+		return nil
+	}
+
+	u, err := url.Parse(origin)
+	if err != nil {
+		return fmt.Errorf("failed to parse Origin header %q: %w", origin, err)
+	}
+
+	if strings.EqualFold(r.Host, u.Host) {
+		return nil
+	}
+
+	for _, pattern := range a.allowedOrigins {
+		matched, err := match(pattern, u.Host)
+		if err != nil {
+			return fmt.Errorf("failed to parse filepath pattern %q: %w", pattern, err)
+		}
+		if matched {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("request Origin %q is not authorized for Host %q", origin, r.Host)
+}

--- a/internal/origin/origin.go
+++ b/internal/origin/origin.go
@@ -42,7 +42,7 @@ func (a *PatternChecker) Check(r *http.Request) error {
 	return fmt.Errorf("request Origin %q is not authorized for Host %q", origin, r.Host)
 }
 
-func CheckSameOrigin(r *http.Request) error {
+func CheckSameHost(r *http.Request) error {
 	origin := r.Header.Get("Origin")
 	if origin == "" {
 		return nil

--- a/internal/origin/origin_test.go
+++ b/internal/origin/origin_test.go
@@ -1,0 +1,99 @@
+package origin
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheck(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name           string
+		origin         string
+		url            string
+		originPatterns []string
+		success        bool
+	}{
+		{
+			name:    "no_origin",
+			success: true,
+			url:     "https://example.com/websocket/connection",
+		},
+		{
+			name:    "invalid_host",
+			origin:  "invalid",
+			url:     "https://example.com/websocket/connection",
+			success: false,
+		},
+		{
+			name:    "unauthorized",
+			origin:  "https://example.com",
+			url:     "https://example1.com/websocket/connection",
+			success: false,
+		},
+		{
+			name:    "authorized",
+			origin:  "https://example.com",
+			url:     "https://example.com/websocket/connection",
+			success: true,
+		},
+		{
+			name:    "authorizedCaseInsensitive",
+			origin:  "https://examplE.com",
+			url:     "https://example.com/websocket/connection",
+			success: true,
+		},
+		{
+			name:   "originPatterns",
+			origin: "https://two.Example.com",
+			url:    "https://example.com/websocket/connection",
+			originPatterns: []string{
+				"*.example.com",
+				"foo.com",
+			},
+			success: true,
+		},
+		{
+			name:   "originPatternsCyrillicEInOrigin",
+			origin: "https://two.еxample.com",
+			url:    "https://example.com/websocket/connection",
+			originPatterns: []string{
+				"*.example.com",
+				"foo.com",
+			},
+			success: false,
+		},
+		{
+			name:   "originPatternsUnauthorized",
+			origin: "https://two.Example.com",
+			url:    "https://example.com/websocket/connection",
+			originPatterns: []string{
+				"foo.com",
+				"bar.com",
+			},
+			success: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			r := httptest.NewRequest("GET", tc.url, nil)
+			r.Header.Set("Origin", tc.origin)
+
+			a, err := NewChecker(tc.originPatterns)
+			require.NoError(t, err)
+			err = a.Check(r)
+			if tc.success {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+			}
+		})
+	}
+}

--- a/internal/tools/config.go
+++ b/internal/tools/config.go
@@ -38,7 +38,8 @@ var jsonConfigTemplate = `{
   "token_hmac_secret_key": "{{.TokenSecret}}",
   "admin_password": "{{.AdminPassword}}",
   "admin_secret": "{{.AdminSecret}}",
-  "api_key": "{{.APIKey}}"
+  "api_key": "{{.APIKey}}",
+  "allowed_origins": []
 }
 `
 
@@ -47,6 +48,7 @@ token_hmac_secret_key = "{{.TokenSecret}}"
 admin_password = "{{.AdminPassword}}"
 admin_secret = "{{.AdminSecret}}"
 api_key = "{{.APIKey}}"
+allowed_origins = []
 `
 
 var yamlConfigTemplate = `v3_use_offset: true
@@ -54,6 +56,7 @@ token_hmac_secret_key: {{.TokenSecret}}
 admin_password: {{.AdminPassword}}
 admin_secret: {{.AdminSecret}}
 api_key: {{.APIKey}}
+allowed_origins: []
 `
 
 // GenerateConfig generates configuration file at provided path.

--- a/main.go
+++ b/main.go
@@ -1202,7 +1202,7 @@ func websocketHandlerConfig() centrifuge.WebsocketConfig {
 
 	if v.IsSet("allowed_origins") {
 		allowedOrigins := v.GetStringSlice("allowed_origins")
-		originChecker, err := origin.NewChecker(allowedOrigins)
+		originChecker, err := origin.NewPatternChecker(allowedOrigins)
 		if err != nil {
 			log.Fatal().Msgf("error creating origin checker: %v", err)
 		}
@@ -1236,7 +1236,7 @@ func sockjsHandlerConfig() centrifuge.SockjsConfig {
 	}
 	if v.IsSet("allowed_origins") {
 		allowedOrigins := v.GetStringSlice("allowed_origins")
-		originChecker, err := origin.NewChecker(allowedOrigins)
+		originChecker, err := origin.NewPatternChecker(allowedOrigins)
 		if err != nil {
 			log.Fatal().Msgf("error creating origin checker: %v", err)
 		}

--- a/vendor/github.com/gobwas/glob/.gitignore
+++ b/vendor/github.com/gobwas/glob/.gitignore
@@ -1,0 +1,8 @@
+glob.iml
+.idea
+*.cpu
+*.mem
+*.test
+*.dot
+*.png
+*.svg

--- a/vendor/github.com/gobwas/glob/.travis.yml
+++ b/vendor/github.com/gobwas/glob/.travis.yml
@@ -1,0 +1,9 @@
+sudo: false
+
+language: go
+
+go:
+  - 1.5.3
+
+script:
+  - go test -v ./...

--- a/vendor/github.com/gobwas/glob/LICENSE
+++ b/vendor/github.com/gobwas/glob/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 Sergey Kamardin
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/gobwas/glob/bench.sh
+++ b/vendor/github.com/gobwas/glob/bench.sh
@@ -1,0 +1,26 @@
+#! /bin/bash
+
+bench() {
+    filename="/tmp/$1-$2.bench"
+    if test -e "${filename}";
+    then
+        echo "Already exists ${filename}"
+    else
+        backup=`git rev-parse --abbrev-ref HEAD`
+        git checkout $1
+        echo -n "Creating ${filename}... "
+        go test ./... -run=NONE -bench=$2 > "${filename}" -benchmem
+        echo "OK"
+        git checkout ${backup}
+        sleep 5
+    fi
+}
+
+
+to=$1
+current=`git rev-parse --abbrev-ref HEAD`
+
+bench ${to} $2
+bench ${current} $2
+
+benchcmp $3 "/tmp/${to}-$2.bench" "/tmp/${current}-$2.bench"

--- a/vendor/github.com/gobwas/glob/compiler/compiler.go
+++ b/vendor/github.com/gobwas/glob/compiler/compiler.go
@@ -1,0 +1,525 @@
+package compiler
+
+// TODO use constructor with all matchers, and to their structs private
+// TODO glue multiple Text nodes (like after QuoteMeta)
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/gobwas/glob/match"
+	"github.com/gobwas/glob/syntax/ast"
+	"github.com/gobwas/glob/util/runes"
+)
+
+func optimizeMatcher(matcher match.Matcher) match.Matcher {
+	switch m := matcher.(type) {
+
+	case match.Any:
+		if len(m.Separators) == 0 {
+			return match.NewSuper()
+		}
+
+	case match.AnyOf:
+		if len(m.Matchers) == 1 {
+			return m.Matchers[0]
+		}
+
+		return m
+
+	case match.List:
+		if m.Not == false && len(m.List) == 1 {
+			return match.NewText(string(m.List))
+		}
+
+		return m
+
+	case match.BTree:
+		m.Left = optimizeMatcher(m.Left)
+		m.Right = optimizeMatcher(m.Right)
+
+		r, ok := m.Value.(match.Text)
+		if !ok {
+			return m
+		}
+
+		var (
+			leftNil  = m.Left == nil
+			rightNil = m.Right == nil
+		)
+		if leftNil && rightNil {
+			return match.NewText(r.Str)
+		}
+
+		_, leftSuper := m.Left.(match.Super)
+		lp, leftPrefix := m.Left.(match.Prefix)
+		la, leftAny := m.Left.(match.Any)
+
+		_, rightSuper := m.Right.(match.Super)
+		rs, rightSuffix := m.Right.(match.Suffix)
+		ra, rightAny := m.Right.(match.Any)
+
+		switch {
+		case leftSuper && rightSuper:
+			return match.NewContains(r.Str, false)
+
+		case leftSuper && rightNil:
+			return match.NewSuffix(r.Str)
+
+		case rightSuper && leftNil:
+			return match.NewPrefix(r.Str)
+
+		case leftNil && rightSuffix:
+			return match.NewPrefixSuffix(r.Str, rs.Suffix)
+
+		case rightNil && leftPrefix:
+			return match.NewPrefixSuffix(lp.Prefix, r.Str)
+
+		case rightNil && leftAny:
+			return match.NewSuffixAny(r.Str, la.Separators)
+
+		case leftNil && rightAny:
+			return match.NewPrefixAny(r.Str, ra.Separators)
+		}
+
+		return m
+	}
+
+	return matcher
+}
+
+func compileMatchers(matchers []match.Matcher) (match.Matcher, error) {
+	if len(matchers) == 0 {
+		return nil, fmt.Errorf("compile error: need at least one matcher")
+	}
+	if len(matchers) == 1 {
+		return matchers[0], nil
+	}
+	if m := glueMatchers(matchers); m != nil {
+		return m, nil
+	}
+
+	idx := -1
+	maxLen := -1
+	var val match.Matcher
+	for i, matcher := range matchers {
+		if l := matcher.Len(); l != -1 && l >= maxLen {
+			maxLen = l
+			idx = i
+			val = matcher
+		}
+	}
+
+	if val == nil { // not found matcher with static length
+		r, err := compileMatchers(matchers[1:])
+		if err != nil {
+			return nil, err
+		}
+		return match.NewBTree(matchers[0], nil, r), nil
+	}
+
+	left := matchers[:idx]
+	var right []match.Matcher
+	if len(matchers) > idx+1 {
+		right = matchers[idx+1:]
+	}
+
+	var l, r match.Matcher
+	var err error
+	if len(left) > 0 {
+		l, err = compileMatchers(left)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if len(right) > 0 {
+		r, err = compileMatchers(right)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return match.NewBTree(val, l, r), nil
+}
+
+func glueMatchers(matchers []match.Matcher) match.Matcher {
+	if m := glueMatchersAsEvery(matchers); m != nil {
+		return m
+	}
+	if m := glueMatchersAsRow(matchers); m != nil {
+		return m
+	}
+	return nil
+}
+
+func glueMatchersAsRow(matchers []match.Matcher) match.Matcher {
+	if len(matchers) <= 1 {
+		return nil
+	}
+
+	var (
+		c []match.Matcher
+		l int
+	)
+	for _, matcher := range matchers {
+		if ml := matcher.Len(); ml == -1 {
+			return nil
+		} else {
+			c = append(c, matcher)
+			l += ml
+		}
+	}
+	return match.NewRow(l, c...)
+}
+
+func glueMatchersAsEvery(matchers []match.Matcher) match.Matcher {
+	if len(matchers) <= 1 {
+		return nil
+	}
+
+	var (
+		hasAny    bool
+		hasSuper  bool
+		hasSingle bool
+		min       int
+		separator []rune
+	)
+
+	for i, matcher := range matchers {
+		var sep []rune
+
+		switch m := matcher.(type) {
+		case match.Super:
+			sep = []rune{}
+			hasSuper = true
+
+		case match.Any:
+			sep = m.Separators
+			hasAny = true
+
+		case match.Single:
+			sep = m.Separators
+			hasSingle = true
+			min++
+
+		case match.List:
+			if !m.Not {
+				return nil
+			}
+			sep = m.List
+			hasSingle = true
+			min++
+
+		default:
+			return nil
+		}
+
+		// initialize
+		if i == 0 {
+			separator = sep
+		}
+
+		if runes.Equal(sep, separator) {
+			continue
+		}
+
+		return nil
+	}
+
+	if hasSuper && !hasAny && !hasSingle {
+		return match.NewSuper()
+	}
+
+	if hasAny && !hasSuper && !hasSingle {
+		return match.NewAny(separator)
+	}
+
+	if (hasAny || hasSuper) && min > 0 && len(separator) == 0 {
+		return match.NewMin(min)
+	}
+
+	every := match.NewEveryOf()
+
+	if min > 0 {
+		every.Add(match.NewMin(min))
+
+		if !hasAny && !hasSuper {
+			every.Add(match.NewMax(min))
+		}
+	}
+
+	if len(separator) > 0 {
+		every.Add(match.NewContains(string(separator), true))
+	}
+
+	return every
+}
+
+func minimizeMatchers(matchers []match.Matcher) []match.Matcher {
+	var done match.Matcher
+	var left, right, count int
+
+	for l := 0; l < len(matchers); l++ {
+		for r := len(matchers); r > l; r-- {
+			if glued := glueMatchers(matchers[l:r]); glued != nil {
+				var swap bool
+
+				if done == nil {
+					swap = true
+				} else {
+					cl, gl := done.Len(), glued.Len()
+					swap = cl > -1 && gl > -1 && gl > cl
+					swap = swap || count < r-l
+				}
+
+				if swap {
+					done = glued
+					left = l
+					right = r
+					count = r - l
+				}
+			}
+		}
+	}
+
+	if done == nil {
+		return matchers
+	}
+
+	next := append(append([]match.Matcher{}, matchers[:left]...), done)
+	if right < len(matchers) {
+		next = append(next, matchers[right:]...)
+	}
+
+	if len(next) == len(matchers) {
+		return next
+	}
+
+	return minimizeMatchers(next)
+}
+
+// minimizeAnyOf tries to apply some heuristics to minimize number of nodes in given tree
+func minimizeTree(tree *ast.Node) *ast.Node {
+	switch tree.Kind {
+	case ast.KindAnyOf:
+		return minimizeTreeAnyOf(tree)
+	default:
+		return nil
+	}
+}
+
+// minimizeAnyOf tries to find common children of given node of AnyOf pattern
+// it searches for common children from left and from right
+// if any common children are found – then it returns new optimized ast tree
+// else it returns nil
+func minimizeTreeAnyOf(tree *ast.Node) *ast.Node {
+	if !areOfSameKind(tree.Children, ast.KindPattern) {
+		return nil
+	}
+
+	commonLeft, commonRight := commonChildren(tree.Children)
+	commonLeftCount, commonRightCount := len(commonLeft), len(commonRight)
+	if commonLeftCount == 0 && commonRightCount == 0 { // there are no common parts
+		return nil
+	}
+
+	var result []*ast.Node
+	if commonLeftCount > 0 {
+		result = append(result, ast.NewNode(ast.KindPattern, nil, commonLeft...))
+	}
+
+	var anyOf []*ast.Node
+	for _, child := range tree.Children {
+		reuse := child.Children[commonLeftCount : len(child.Children)-commonRightCount]
+		var node *ast.Node
+		if len(reuse) == 0 {
+			// this pattern is completely reduced by commonLeft and commonRight patterns
+			// so it become nothing
+			node = ast.NewNode(ast.KindNothing, nil)
+		} else {
+			node = ast.NewNode(ast.KindPattern, nil, reuse...)
+		}
+		anyOf = appendIfUnique(anyOf, node)
+	}
+	switch {
+	case len(anyOf) == 1 && anyOf[0].Kind != ast.KindNothing:
+		result = append(result, anyOf[0])
+	case len(anyOf) > 1:
+		result = append(result, ast.NewNode(ast.KindAnyOf, nil, anyOf...))
+	}
+
+	if commonRightCount > 0 {
+		result = append(result, ast.NewNode(ast.KindPattern, nil, commonRight...))
+	}
+
+	return ast.NewNode(ast.KindPattern, nil, result...)
+}
+
+func commonChildren(nodes []*ast.Node) (commonLeft, commonRight []*ast.Node) {
+	if len(nodes) <= 1 {
+		return
+	}
+
+	// find node that has least number of children
+	idx := leastChildren(nodes)
+	if idx == -1 {
+		return
+	}
+	tree := nodes[idx]
+	treeLength := len(tree.Children)
+
+	// allocate max able size for rightCommon slice
+	// to get ability insert elements in reverse order (from end to start)
+	// without sorting
+	commonRight = make([]*ast.Node, treeLength)
+	lastRight := treeLength // will use this to get results as commonRight[lastRight:]
+
+	var (
+		breakLeft   bool
+		breakRight  bool
+		commonTotal int
+	)
+	for i, j := 0, treeLength-1; commonTotal < treeLength && j >= 0 && !(breakLeft && breakRight); i, j = i+1, j-1 {
+		treeLeft := tree.Children[i]
+		treeRight := tree.Children[j]
+
+		for k := 0; k < len(nodes) && !(breakLeft && breakRight); k++ {
+			// skip least children node
+			if k == idx {
+				continue
+			}
+
+			restLeft := nodes[k].Children[i]
+			restRight := nodes[k].Children[j+len(nodes[k].Children)-treeLength]
+
+			breakLeft = breakLeft || !treeLeft.Equal(restLeft)
+
+			// disable searching for right common parts, if left part is already overlapping
+			breakRight = breakRight || (!breakLeft && j <= i)
+			breakRight = breakRight || !treeRight.Equal(restRight)
+		}
+
+		if !breakLeft {
+			commonTotal++
+			commonLeft = append(commonLeft, treeLeft)
+		}
+		if !breakRight {
+			commonTotal++
+			lastRight = j
+			commonRight[j] = treeRight
+		}
+	}
+
+	commonRight = commonRight[lastRight:]
+
+	return
+}
+
+func appendIfUnique(target []*ast.Node, val *ast.Node) []*ast.Node {
+	for _, n := range target {
+		if reflect.DeepEqual(n, val) {
+			return target
+		}
+	}
+	return append(target, val)
+}
+
+func areOfSameKind(nodes []*ast.Node, kind ast.Kind) bool {
+	for _, n := range nodes {
+		if n.Kind != kind {
+			return false
+		}
+	}
+	return true
+}
+
+func leastChildren(nodes []*ast.Node) int {
+	min := -1
+	idx := -1
+	for i, n := range nodes {
+		if idx == -1 || (len(n.Children) < min) {
+			min = len(n.Children)
+			idx = i
+		}
+	}
+	return idx
+}
+
+func compileTreeChildren(tree *ast.Node, sep []rune) ([]match.Matcher, error) {
+	var matchers []match.Matcher
+	for _, desc := range tree.Children {
+		m, err := compile(desc, sep)
+		if err != nil {
+			return nil, err
+		}
+		matchers = append(matchers, optimizeMatcher(m))
+	}
+	return matchers, nil
+}
+
+func compile(tree *ast.Node, sep []rune) (m match.Matcher, err error) {
+	switch tree.Kind {
+	case ast.KindAnyOf:
+		// todo this could be faster on pattern_alternatives_combine_lite (see glob_test.go)
+		if n := minimizeTree(tree); n != nil {
+			return compile(n, sep)
+		}
+		matchers, err := compileTreeChildren(tree, sep)
+		if err != nil {
+			return nil, err
+		}
+		return match.NewAnyOf(matchers...), nil
+
+	case ast.KindPattern:
+		if len(tree.Children) == 0 {
+			return match.NewNothing(), nil
+		}
+		matchers, err := compileTreeChildren(tree, sep)
+		if err != nil {
+			return nil, err
+		}
+		m, err = compileMatchers(minimizeMatchers(matchers))
+		if err != nil {
+			return nil, err
+		}
+
+	case ast.KindAny:
+		m = match.NewAny(sep)
+
+	case ast.KindSuper:
+		m = match.NewSuper()
+
+	case ast.KindSingle:
+		m = match.NewSingle(sep)
+
+	case ast.KindNothing:
+		m = match.NewNothing()
+
+	case ast.KindList:
+		l := tree.Value.(ast.List)
+		m = match.NewList([]rune(l.Chars), l.Not)
+
+	case ast.KindRange:
+		r := tree.Value.(ast.Range)
+		m = match.NewRange(r.Lo, r.Hi, r.Not)
+
+	case ast.KindText:
+		t := tree.Value.(ast.Text)
+		m = match.NewText(t.Text)
+
+	default:
+		return nil, fmt.Errorf("could not compile tree: unknown node type")
+	}
+
+	return optimizeMatcher(m), nil
+}
+
+func Compile(tree *ast.Node, sep []rune) (match.Matcher, error) {
+	m, err := compile(tree, sep)
+	if err != nil {
+		return nil, err
+	}
+
+	return m, nil
+}

--- a/vendor/github.com/gobwas/glob/glob.go
+++ b/vendor/github.com/gobwas/glob/glob.go
@@ -1,0 +1,80 @@
+package glob
+
+import (
+	"github.com/gobwas/glob/compiler"
+	"github.com/gobwas/glob/syntax"
+)
+
+// Glob represents compiled glob pattern.
+type Glob interface {
+	Match(string) bool
+}
+
+// Compile creates Glob for given pattern and strings (if any present after pattern) as separators.
+// The pattern syntax is:
+//
+//    pattern:
+//        { term }
+//
+//    term:
+//        `*`         matches any sequence of non-separator characters
+//        `**`        matches any sequence of characters
+//        `?`         matches any single non-separator character
+//        `[` [ `!` ] { character-range } `]`
+//                    character class (must be non-empty)
+//        `{` pattern-list `}`
+//                    pattern alternatives
+//        c           matches character c (c != `*`, `**`, `?`, `\`, `[`, `{`, `}`)
+//        `\` c       matches character c
+//
+//    character-range:
+//        c           matches character c (c != `\\`, `-`, `]`)
+//        `\` c       matches character c
+//        lo `-` hi   matches character c for lo <= c <= hi
+//
+//    pattern-list:
+//        pattern { `,` pattern }
+//                    comma-separated (without spaces) patterns
+//
+func Compile(pattern string, separators ...rune) (Glob, error) {
+	ast, err := syntax.Parse(pattern)
+	if err != nil {
+		return nil, err
+	}
+
+	matcher, err := compiler.Compile(ast, separators)
+	if err != nil {
+		return nil, err
+	}
+
+	return matcher, nil
+}
+
+// MustCompile is the same as Compile, except that if Compile returns error, this will panic
+func MustCompile(pattern string, separators ...rune) Glob {
+	g, err := Compile(pattern, separators...)
+	if err != nil {
+		panic(err)
+	}
+
+	return g
+}
+
+// QuoteMeta returns a string that quotes all glob pattern meta characters
+// inside the argument text; For example, QuoteMeta(`{foo*}`) returns `\[foo\*\]`.
+func QuoteMeta(s string) string {
+	b := make([]byte, 2*len(s))
+
+	// a byte loop is correct because all meta characters are ASCII
+	j := 0
+	for i := 0; i < len(s); i++ {
+		if syntax.Special(s[i]) {
+			b[j] = '\\'
+			j++
+		}
+		b[j] = s[i]
+		j++
+	}
+
+	return string(b[0:j])
+}

--- a/vendor/github.com/gobwas/glob/match/any.go
+++ b/vendor/github.com/gobwas/glob/match/any.go
@@ -1,0 +1,45 @@
+package match
+
+import (
+	"fmt"
+	"github.com/gobwas/glob/util/strings"
+)
+
+type Any struct {
+	Separators []rune
+}
+
+func NewAny(s []rune) Any {
+	return Any{s}
+}
+
+func (self Any) Match(s string) bool {
+	return strings.IndexAnyRunes(s, self.Separators) == -1
+}
+
+func (self Any) Index(s string) (int, []int) {
+	found := strings.IndexAnyRunes(s, self.Separators)
+	switch found {
+	case -1:
+	case 0:
+		return 0, segments0
+	default:
+		s = s[:found]
+	}
+
+	segments := acquireSegments(len(s))
+	for i := range s {
+		segments = append(segments, i)
+	}
+	segments = append(segments, len(s))
+
+	return 0, segments
+}
+
+func (self Any) Len() int {
+	return lenNo
+}
+
+func (self Any) String() string {
+	return fmt.Sprintf("<any:![%s]>", string(self.Separators))
+}

--- a/vendor/github.com/gobwas/glob/match/any_of.go
+++ b/vendor/github.com/gobwas/glob/match/any_of.go
@@ -1,0 +1,82 @@
+package match
+
+import "fmt"
+
+type AnyOf struct {
+	Matchers Matchers
+}
+
+func NewAnyOf(m ...Matcher) AnyOf {
+	return AnyOf{Matchers(m)}
+}
+
+func (self *AnyOf) Add(m Matcher) error {
+	self.Matchers = append(self.Matchers, m)
+	return nil
+}
+
+func (self AnyOf) Match(s string) bool {
+	for _, m := range self.Matchers {
+		if m.Match(s) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (self AnyOf) Index(s string) (int, []int) {
+	index := -1
+
+	segments := acquireSegments(len(s))
+	for _, m := range self.Matchers {
+		idx, seg := m.Index(s)
+		if idx == -1 {
+			continue
+		}
+
+		if index == -1 || idx < index {
+			index = idx
+			segments = append(segments[:0], seg...)
+			continue
+		}
+
+		if idx > index {
+			continue
+		}
+
+		// here idx == index
+		segments = appendMerge(segments, seg)
+	}
+
+	if index == -1 {
+		releaseSegments(segments)
+		return -1, nil
+	}
+
+	return index, segments
+}
+
+func (self AnyOf) Len() (l int) {
+	l = -1
+	for _, m := range self.Matchers {
+		ml := m.Len()
+		switch {
+		case l == -1:
+			l = ml
+			continue
+
+		case ml == -1:
+			return -1
+
+		case l != ml:
+			return -1
+		}
+	}
+
+	return
+}
+
+func (self AnyOf) String() string {
+	return fmt.Sprintf("<any_of:[%s]>", self.Matchers)
+}

--- a/vendor/github.com/gobwas/glob/match/btree.go
+++ b/vendor/github.com/gobwas/glob/match/btree.go
@@ -1,0 +1,146 @@
+package match
+
+import (
+	"fmt"
+	"unicode/utf8"
+)
+
+type BTree struct {
+	Value            Matcher
+	Left             Matcher
+	Right            Matcher
+	ValueLengthRunes int
+	LeftLengthRunes  int
+	RightLengthRunes int
+	LengthRunes      int
+}
+
+func NewBTree(Value, Left, Right Matcher) (tree BTree) {
+	tree.Value = Value
+	tree.Left = Left
+	tree.Right = Right
+
+	lenOk := true
+	if tree.ValueLengthRunes = Value.Len(); tree.ValueLengthRunes == -1 {
+		lenOk = false
+	}
+
+	if Left != nil {
+		if tree.LeftLengthRunes = Left.Len(); tree.LeftLengthRunes == -1 {
+			lenOk = false
+		}
+	}
+
+	if Right != nil {
+		if tree.RightLengthRunes = Right.Len(); tree.RightLengthRunes == -1 {
+			lenOk = false
+		}
+	}
+
+	if lenOk {
+		tree.LengthRunes = tree.LeftLengthRunes + tree.ValueLengthRunes + tree.RightLengthRunes
+	} else {
+		tree.LengthRunes = -1
+	}
+
+	return tree
+}
+
+func (self BTree) Len() int {
+	return self.LengthRunes
+}
+
+// todo?
+func (self BTree) Index(s string) (int, []int) {
+	return -1, nil
+}
+
+func (self BTree) Match(s string) bool {
+	inputLen := len(s)
+
+	// self.Length, self.RLen and self.LLen are values meaning the length of runes for each part
+	// here we manipulating byte length for better optimizations
+	// but these checks still works, cause minLen of 1-rune string is 1 byte.
+	if self.LengthRunes != -1 && self.LengthRunes > inputLen {
+		return false
+	}
+
+	// try to cut unnecessary parts
+	// by knowledge of length of right and left part
+	var offset, limit int
+	if self.LeftLengthRunes >= 0 {
+		offset = self.LeftLengthRunes
+	}
+	if self.RightLengthRunes >= 0 {
+		limit = inputLen - self.RightLengthRunes
+	} else {
+		limit = inputLen
+	}
+
+	for offset < limit {
+		// search for matching part in substring
+		index, segments := self.Value.Index(s[offset:limit])
+		if index == -1 {
+			releaseSegments(segments)
+			return false
+		}
+
+		l := s[:offset+index]
+		var left bool
+		if self.Left != nil {
+			left = self.Left.Match(l)
+		} else {
+			left = l == ""
+		}
+
+		if left {
+			for i := len(segments) - 1; i >= 0; i-- {
+				length := segments[i]
+
+				var right bool
+				var r string
+				// if there is no string for the right branch
+				if inputLen <= offset+index+length {
+					r = ""
+				} else {
+					r = s[offset+index+length:]
+				}
+
+				if self.Right != nil {
+					right = self.Right.Match(r)
+				} else {
+					right = r == ""
+				}
+
+				if right {
+					releaseSegments(segments)
+					return true
+				}
+			}
+		}
+
+		_, step := utf8.DecodeRuneInString(s[offset+index:])
+		offset += index + step
+
+		releaseSegments(segments)
+	}
+
+	return false
+}
+
+func (self BTree) String() string {
+	const n string = "<nil>"
+	var l, r string
+	if self.Left == nil {
+		l = n
+	} else {
+		l = self.Left.String()
+	}
+	if self.Right == nil {
+		r = n
+	} else {
+		r = self.Right.String()
+	}
+
+	return fmt.Sprintf("<btree:[%s<-%s->%s]>", l, self.Value, r)
+}

--- a/vendor/github.com/gobwas/glob/match/contains.go
+++ b/vendor/github.com/gobwas/glob/match/contains.go
@@ -1,0 +1,58 @@
+package match
+
+import (
+	"fmt"
+	"strings"
+)
+
+type Contains struct {
+	Needle string
+	Not    bool
+}
+
+func NewContains(needle string, not bool) Contains {
+	return Contains{needle, not}
+}
+
+func (self Contains) Match(s string) bool {
+	return strings.Contains(s, self.Needle) != self.Not
+}
+
+func (self Contains) Index(s string) (int, []int) {
+	var offset int
+
+	idx := strings.Index(s, self.Needle)
+
+	if !self.Not {
+		if idx == -1 {
+			return -1, nil
+		}
+
+		offset = idx + len(self.Needle)
+		if len(s) <= offset {
+			return 0, []int{offset}
+		}
+		s = s[offset:]
+	} else if idx != -1 {
+		s = s[:idx]
+	}
+
+	segments := acquireSegments(len(s) + 1)
+	for i := range s {
+		segments = append(segments, offset+i)
+	}
+
+	return 0, append(segments, offset+len(s))
+}
+
+func (self Contains) Len() int {
+	return lenNo
+}
+
+func (self Contains) String() string {
+	var not string
+	if self.Not {
+		not = "!"
+	}
+	return fmt.Sprintf("<contains:%s[%s]>", not, self.Needle)
+}

--- a/vendor/github.com/gobwas/glob/match/every_of.go
+++ b/vendor/github.com/gobwas/glob/match/every_of.go
@@ -1,0 +1,99 @@
+package match
+
+import (
+	"fmt"
+)
+
+type EveryOf struct {
+	Matchers Matchers
+}
+
+func NewEveryOf(m ...Matcher) EveryOf {
+	return EveryOf{Matchers(m)}
+}
+
+func (self *EveryOf) Add(m Matcher) error {
+	self.Matchers = append(self.Matchers, m)
+	return nil
+}
+
+func (self EveryOf) Len() (l int) {
+	for _, m := range self.Matchers {
+		if ml := m.Len(); l > 0 {
+			l += ml
+		} else {
+			return -1
+		}
+	}
+
+	return
+}
+
+func (self EveryOf) Index(s string) (int, []int) {
+	var index int
+	var offset int
+
+	// make `in` with cap as len(s),
+	// cause it is the maximum size of output segments values
+	next := acquireSegments(len(s))
+	current := acquireSegments(len(s))
+
+	sub := s
+	for i, m := range self.Matchers {
+		idx, seg := m.Index(sub)
+		if idx == -1 {
+			releaseSegments(next)
+			releaseSegments(current)
+			return -1, nil
+		}
+
+		if i == 0 {
+			// we use copy here instead of `current = seg`
+			// cause seg is a slice from reusable buffer `in`
+			// and it could be overwritten in next iteration
+			current = append(current, seg...)
+		} else {
+			// clear the next
+			next = next[:0]
+
+			delta := index - (idx + offset)
+			for _, ex := range current {
+				for _, n := range seg {
+					if ex+delta == n {
+						next = append(next, n)
+					}
+				}
+			}
+
+			if len(next) == 0 {
+				releaseSegments(next)
+				releaseSegments(current)
+				return -1, nil
+			}
+
+			current = append(current[:0], next...)
+		}
+
+		index = idx + offset
+		sub = s[index:]
+		offset += idx
+	}
+
+	releaseSegments(next)
+
+	return index, current
+}
+
+func (self EveryOf) Match(s string) bool {
+	for _, m := range self.Matchers {
+		if !m.Match(s) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (self EveryOf) String() string {
+	return fmt.Sprintf("<every_of:[%s]>", self.Matchers)
+}

--- a/vendor/github.com/gobwas/glob/match/list.go
+++ b/vendor/github.com/gobwas/glob/match/list.go
@@ -1,0 +1,49 @@
+package match
+
+import (
+	"fmt"
+	"github.com/gobwas/glob/util/runes"
+	"unicode/utf8"
+)
+
+type List struct {
+	List []rune
+	Not  bool
+}
+
+func NewList(list []rune, not bool) List {
+	return List{list, not}
+}
+
+func (self List) Match(s string) bool {
+	r, w := utf8.DecodeRuneInString(s)
+	if len(s) > w {
+		return false
+	}
+
+	inList := runes.IndexRune(self.List, r) != -1
+	return inList == !self.Not
+}
+
+func (self List) Len() int {
+	return lenOne
+}
+
+func (self List) Index(s string) (int, []int) {
+	for i, r := range s {
+		if self.Not == (runes.IndexRune(self.List, r) == -1) {
+			return i, segmentsByRuneLength[utf8.RuneLen(r)]
+		}
+	}
+
+	return -1, nil
+}
+
+func (self List) String() string {
+	var not string
+	if self.Not {
+		not = "!"
+	}
+
+	return fmt.Sprintf("<list:%s[%s]>", not, string(self.List))
+}

--- a/vendor/github.com/gobwas/glob/match/match.go
+++ b/vendor/github.com/gobwas/glob/match/match.go
@@ -1,0 +1,81 @@
+package match
+
+// todo common table of rune's length
+
+import (
+	"fmt"
+	"strings"
+)
+
+const lenOne = 1
+const lenZero = 0
+const lenNo = -1
+
+type Matcher interface {
+	Match(string) bool
+	Index(string) (int, []int)
+	Len() int
+	String() string
+}
+
+type Matchers []Matcher
+
+func (m Matchers) String() string {
+	var s []string
+	for _, matcher := range m {
+		s = append(s, fmt.Sprint(matcher))
+	}
+
+	return fmt.Sprintf("%s", strings.Join(s, ","))
+}
+
+// appendMerge merges and sorts given already SORTED and UNIQUE segments.
+func appendMerge(target, sub []int) []int {
+	lt, ls := len(target), len(sub)
+	out := make([]int, 0, lt+ls)
+
+	for x, y := 0, 0; x < lt || y < ls; {
+		if x >= lt {
+			out = append(out, sub[y:]...)
+			break
+		}
+
+		if y >= ls {
+			out = append(out, target[x:]...)
+			break
+		}
+
+		xValue := target[x]
+		yValue := sub[y]
+
+		switch {
+
+		case xValue == yValue:
+			out = append(out, xValue)
+			x++
+			y++
+
+		case xValue < yValue:
+			out = append(out, xValue)
+			x++
+
+		case yValue < xValue:
+			out = append(out, yValue)
+			y++
+
+		}
+	}
+
+	target = append(target[:0], out...)
+
+	return target
+}
+
+func reverseSegments(input []int) {
+	l := len(input)
+	m := l / 2
+
+	for i := 0; i < m; i++ {
+		input[i], input[l-i-1] = input[l-i-1], input[i]
+	}
+}

--- a/vendor/github.com/gobwas/glob/match/max.go
+++ b/vendor/github.com/gobwas/glob/match/max.go
@@ -1,0 +1,49 @@
+package match
+
+import (
+	"fmt"
+	"unicode/utf8"
+)
+
+type Max struct {
+	Limit int
+}
+
+func NewMax(l int) Max {
+	return Max{l}
+}
+
+func (self Max) Match(s string) bool {
+	var l int
+	for range s {
+		l += 1
+		if l > self.Limit {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (self Max) Index(s string) (int, []int) {
+	segments := acquireSegments(self.Limit + 1)
+	segments = append(segments, 0)
+	var count int
+	for i, r := range s {
+		count++
+		if count > self.Limit {
+			break
+		}
+		segments = append(segments, i+utf8.RuneLen(r))
+	}
+
+	return 0, segments
+}
+
+func (self Max) Len() int {
+	return lenNo
+}
+
+func (self Max) String() string {
+	return fmt.Sprintf("<max:%d>", self.Limit)
+}

--- a/vendor/github.com/gobwas/glob/match/min.go
+++ b/vendor/github.com/gobwas/glob/match/min.go
@@ -1,0 +1,57 @@
+package match
+
+import (
+	"fmt"
+	"unicode/utf8"
+)
+
+type Min struct {
+	Limit int
+}
+
+func NewMin(l int) Min {
+	return Min{l}
+}
+
+func (self Min) Match(s string) bool {
+	var l int
+	for range s {
+		l += 1
+		if l >= self.Limit {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (self Min) Index(s string) (int, []int) {
+	var count int
+
+	c := len(s) - self.Limit + 1
+	if c <= 0 {
+		return -1, nil
+	}
+
+	segments := acquireSegments(c)
+	for i, r := range s {
+		count++
+		if count >= self.Limit {
+			segments = append(segments, i+utf8.RuneLen(r))
+		}
+	}
+
+	if len(segments) == 0 {
+		return -1, nil
+	}
+
+	return 0, segments
+}
+
+func (self Min) Len() int {
+	return lenNo
+}
+
+func (self Min) String() string {
+	return fmt.Sprintf("<min:%d>", self.Limit)
+}

--- a/vendor/github.com/gobwas/glob/match/nothing.go
+++ b/vendor/github.com/gobwas/glob/match/nothing.go
@@ -1,0 +1,27 @@
+package match
+
+import (
+	"fmt"
+)
+
+type Nothing struct{}
+
+func NewNothing() Nothing {
+	return Nothing{}
+}
+
+func (self Nothing) Match(s string) bool {
+	return len(s) == 0
+}
+
+func (self Nothing) Index(s string) (int, []int) {
+	return 0, segments0
+}
+
+func (self Nothing) Len() int {
+	return lenZero
+}
+
+func (self Nothing) String() string {
+	return fmt.Sprintf("<nothing>")
+}

--- a/vendor/github.com/gobwas/glob/match/prefix.go
+++ b/vendor/github.com/gobwas/glob/match/prefix.go
@@ -1,0 +1,50 @@
+package match
+
+import (
+	"fmt"
+	"strings"
+	"unicode/utf8"
+)
+
+type Prefix struct {
+	Prefix string
+}
+
+func NewPrefix(p string) Prefix {
+	return Prefix{p}
+}
+
+func (self Prefix) Index(s string) (int, []int) {
+	idx := strings.Index(s, self.Prefix)
+	if idx == -1 {
+		return -1, nil
+	}
+
+	length := len(self.Prefix)
+	var sub string
+	if len(s) > idx+length {
+		sub = s[idx+length:]
+	} else {
+		sub = ""
+	}
+
+	segments := acquireSegments(len(sub) + 1)
+	segments = append(segments, length)
+	for i, r := range sub {
+		segments = append(segments, length+i+utf8.RuneLen(r))
+	}
+
+	return idx, segments
+}
+
+func (self Prefix) Len() int {
+	return lenNo
+}
+
+func (self Prefix) Match(s string) bool {
+	return strings.HasPrefix(s, self.Prefix)
+}
+
+func (self Prefix) String() string {
+	return fmt.Sprintf("<prefix:%s>", self.Prefix)
+}

--- a/vendor/github.com/gobwas/glob/match/prefix_any.go
+++ b/vendor/github.com/gobwas/glob/match/prefix_any.go
@@ -1,0 +1,55 @@
+package match
+
+import (
+	"fmt"
+	"strings"
+	"unicode/utf8"
+
+	sutil "github.com/gobwas/glob/util/strings"
+)
+
+type PrefixAny struct {
+	Prefix     string
+	Separators []rune
+}
+
+func NewPrefixAny(s string, sep []rune) PrefixAny {
+	return PrefixAny{s, sep}
+}
+
+func (self PrefixAny) Index(s string) (int, []int) {
+	idx := strings.Index(s, self.Prefix)
+	if idx == -1 {
+		return -1, nil
+	}
+
+	n := len(self.Prefix)
+	sub := s[idx+n:]
+	i := sutil.IndexAnyRunes(sub, self.Separators)
+	if i > -1 {
+		sub = sub[:i]
+	}
+
+	seg := acquireSegments(len(sub) + 1)
+	seg = append(seg, n)
+	for i, r := range sub {
+		seg = append(seg, n+i+utf8.RuneLen(r))
+	}
+
+	return idx, seg
+}
+
+func (self PrefixAny) Len() int {
+	return lenNo
+}
+
+func (self PrefixAny) Match(s string) bool {
+	if !strings.HasPrefix(s, self.Prefix) {
+		return false
+	}
+	return sutil.IndexAnyRunes(s[len(self.Prefix):], self.Separators) == -1
+}
+
+func (self PrefixAny) String() string {
+	return fmt.Sprintf("<prefix_any:%s![%s]>", self.Prefix, string(self.Separators))
+}

--- a/vendor/github.com/gobwas/glob/match/prefix_suffix.go
+++ b/vendor/github.com/gobwas/glob/match/prefix_suffix.go
@@ -1,0 +1,62 @@
+package match
+
+import (
+	"fmt"
+	"strings"
+)
+
+type PrefixSuffix struct {
+	Prefix, Suffix string
+}
+
+func NewPrefixSuffix(p, s string) PrefixSuffix {
+	return PrefixSuffix{p, s}
+}
+
+func (self PrefixSuffix) Index(s string) (int, []int) {
+	prefixIdx := strings.Index(s, self.Prefix)
+	if prefixIdx == -1 {
+		return -1, nil
+	}
+
+	suffixLen := len(self.Suffix)
+	if suffixLen <= 0 {
+		return prefixIdx, []int{len(s) - prefixIdx}
+	}
+
+	if (len(s) - prefixIdx) <= 0 {
+		return -1, nil
+	}
+
+	segments := acquireSegments(len(s) - prefixIdx)
+	for sub := s[prefixIdx:]; ; {
+		suffixIdx := strings.LastIndex(sub, self.Suffix)
+		if suffixIdx == -1 {
+			break
+		}
+
+		segments = append(segments, suffixIdx+suffixLen)
+		sub = sub[:suffixIdx]
+	}
+
+	if len(segments) == 0 {
+		releaseSegments(segments)
+		return -1, nil
+	}
+
+	reverseSegments(segments)
+
+	return prefixIdx, segments
+}
+
+func (self PrefixSuffix) Len() int {
+	return lenNo
+}
+
+func (self PrefixSuffix) Match(s string) bool {
+	return strings.HasPrefix(s, self.Prefix) && strings.HasSuffix(s, self.Suffix)
+}
+
+func (self PrefixSuffix) String() string {
+	return fmt.Sprintf("<prefix_suffix:[%s,%s]>", self.Prefix, self.Suffix)
+}

--- a/vendor/github.com/gobwas/glob/match/range.go
+++ b/vendor/github.com/gobwas/glob/match/range.go
@@ -1,0 +1,48 @@
+package match
+
+import (
+	"fmt"
+	"unicode/utf8"
+)
+
+type Range struct {
+	Lo, Hi rune
+	Not    bool
+}
+
+func NewRange(lo, hi rune, not bool) Range {
+	return Range{lo, hi, not}
+}
+
+func (self Range) Len() int {
+	return lenOne
+}
+
+func (self Range) Match(s string) bool {
+	r, w := utf8.DecodeRuneInString(s)
+	if len(s) > w {
+		return false
+	}
+
+	inRange := r >= self.Lo && r <= self.Hi
+
+	return inRange == !self.Not
+}
+
+func (self Range) Index(s string) (int, []int) {
+	for i, r := range s {
+		if self.Not != (r >= self.Lo && r <= self.Hi) {
+			return i, segmentsByRuneLength[utf8.RuneLen(r)]
+		}
+	}
+
+	return -1, nil
+}
+
+func (self Range) String() string {
+	var not string
+	if self.Not {
+		not = "!"
+	}
+	return fmt.Sprintf("<range:%s[%s,%s]>", not, string(self.Lo), string(self.Hi))
+}

--- a/vendor/github.com/gobwas/glob/match/row.go
+++ b/vendor/github.com/gobwas/glob/match/row.go
@@ -1,0 +1,77 @@
+package match
+
+import (
+	"fmt"
+)
+
+type Row struct {
+	Matchers    Matchers
+	RunesLength int
+	Segments    []int
+}
+
+func NewRow(len int, m ...Matcher) Row {
+	return Row{
+		Matchers:    Matchers(m),
+		RunesLength: len,
+		Segments:    []int{len},
+	}
+}
+
+func (self Row) matchAll(s string) bool {
+	var idx int
+	for _, m := range self.Matchers {
+		length := m.Len()
+
+		var next, i int
+		for next = range s[idx:] {
+			i++
+			if i == length {
+				break
+			}
+		}
+
+		if i < length || !m.Match(s[idx:idx+next+1]) {
+			return false
+		}
+
+		idx += next + 1
+	}
+
+	return true
+}
+
+func (self Row) lenOk(s string) bool {
+	var i int
+	for range s {
+		i++
+		if i > self.RunesLength {
+			return false
+		}
+	}
+	return self.RunesLength == i
+}
+
+func (self Row) Match(s string) bool {
+	return self.lenOk(s) && self.matchAll(s)
+}
+
+func (self Row) Len() (l int) {
+	return self.RunesLength
+}
+
+func (self Row) Index(s string) (int, []int) {
+	for i := range s {
+		if len(s[i:]) < self.RunesLength {
+			break
+		}
+		if self.matchAll(s[i:]) {
+			return i, self.Segments
+		}
+	}
+	return -1, nil
+}
+
+func (self Row) String() string {
+	return fmt.Sprintf("<row_%d:[%s]>", self.RunesLength, self.Matchers)
+}

--- a/vendor/github.com/gobwas/glob/match/segments.go
+++ b/vendor/github.com/gobwas/glob/match/segments.go
@@ -1,0 +1,91 @@
+package match
+
+import (
+	"sync"
+)
+
+type SomePool interface {
+	Get() []int
+	Put([]int)
+}
+
+var segmentsPools [1024]sync.Pool
+
+func toPowerOfTwo(v int) int {
+	v--
+	v |= v >> 1
+	v |= v >> 2
+	v |= v >> 4
+	v |= v >> 8
+	v |= v >> 16
+	v++
+
+	return v
+}
+
+const (
+	cacheFrom             = 16
+	cacheToAndHigher      = 1024
+	cacheFromIndex        = 15
+	cacheToAndHigherIndex = 1023
+)
+
+var (
+	segments0 = []int{0}
+	segments1 = []int{1}
+	segments2 = []int{2}
+	segments3 = []int{3}
+	segments4 = []int{4}
+)
+
+var segmentsByRuneLength [5][]int = [5][]int{
+	0: segments0,
+	1: segments1,
+	2: segments2,
+	3: segments3,
+	4: segments4,
+}
+
+func init() {
+	for i := cacheToAndHigher; i >= cacheFrom; i >>= 1 {
+		func(i int) {
+			segmentsPools[i-1] = sync.Pool{New: func() interface{} {
+				return make([]int, 0, i)
+			}}
+		}(i)
+	}
+}
+
+func getTableIndex(c int) int {
+	p := toPowerOfTwo(c)
+	switch {
+	case p >= cacheToAndHigher:
+		return cacheToAndHigherIndex
+	case p <= cacheFrom:
+		return cacheFromIndex
+	default:
+		return p - 1
+	}
+}
+
+func acquireSegments(c int) []int {
+	// make []int with less capacity than cacheFrom
+	// is faster than acquiring it from pool
+	if c < cacheFrom {
+		return make([]int, 0, c)
+	}
+
+	return segmentsPools[getTableIndex(c)].Get().([]int)[:0]
+}
+
+func releaseSegments(s []int) {
+	c := cap(s)
+
+	// make []int with less capacity than cacheFrom
+	// is faster than acquiring it from pool
+	if c < cacheFrom {
+		return
+	}
+
+	segmentsPools[getTableIndex(c)].Put(s)
+}

--- a/vendor/github.com/gobwas/glob/match/single.go
+++ b/vendor/github.com/gobwas/glob/match/single.go
@@ -1,0 +1,43 @@
+package match
+
+import (
+	"fmt"
+	"github.com/gobwas/glob/util/runes"
+	"unicode/utf8"
+)
+
+// single represents ?
+type Single struct {
+	Separators []rune
+}
+
+func NewSingle(s []rune) Single {
+	return Single{s}
+}
+
+func (self Single) Match(s string) bool {
+	r, w := utf8.DecodeRuneInString(s)
+	if len(s) > w {
+		return false
+	}
+
+	return runes.IndexRune(self.Separators, r) == -1
+}
+
+func (self Single) Len() int {
+	return lenOne
+}
+
+func (self Single) Index(s string) (int, []int) {
+	for i, r := range s {
+		if runes.IndexRune(self.Separators, r) == -1 {
+			return i, segmentsByRuneLength[utf8.RuneLen(r)]
+		}
+	}
+
+	return -1, nil
+}
+
+func (self Single) String() string {
+	return fmt.Sprintf("<single:![%s]>", string(self.Separators))
+}

--- a/vendor/github.com/gobwas/glob/match/suffix.go
+++ b/vendor/github.com/gobwas/glob/match/suffix.go
@@ -1,0 +1,35 @@
+package match
+
+import (
+	"fmt"
+	"strings"
+)
+
+type Suffix struct {
+	Suffix string
+}
+
+func NewSuffix(s string) Suffix {
+	return Suffix{s}
+}
+
+func (self Suffix) Len() int {
+	return lenNo
+}
+
+func (self Suffix) Match(s string) bool {
+	return strings.HasSuffix(s, self.Suffix)
+}
+
+func (self Suffix) Index(s string) (int, []int) {
+	idx := strings.Index(s, self.Suffix)
+	if idx == -1 {
+		return -1, nil
+	}
+
+	return 0, []int{idx + len(self.Suffix)}
+}
+
+func (self Suffix) String() string {
+	return fmt.Sprintf("<suffix:%s>", self.Suffix)
+}

--- a/vendor/github.com/gobwas/glob/match/suffix_any.go
+++ b/vendor/github.com/gobwas/glob/match/suffix_any.go
@@ -1,0 +1,43 @@
+package match
+
+import (
+	"fmt"
+	"strings"
+
+	sutil "github.com/gobwas/glob/util/strings"
+)
+
+type SuffixAny struct {
+	Suffix     string
+	Separators []rune
+}
+
+func NewSuffixAny(s string, sep []rune) SuffixAny {
+	return SuffixAny{s, sep}
+}
+
+func (self SuffixAny) Index(s string) (int, []int) {
+	idx := strings.Index(s, self.Suffix)
+	if idx == -1 {
+		return -1, nil
+	}
+
+	i := sutil.LastIndexAnyRunes(s[:idx], self.Separators) + 1
+
+	return i, []int{idx + len(self.Suffix) - i}
+}
+
+func (self SuffixAny) Len() int {
+	return lenNo
+}
+
+func (self SuffixAny) Match(s string) bool {
+	if !strings.HasSuffix(s, self.Suffix) {
+		return false
+	}
+	return sutil.IndexAnyRunes(s[:len(s)-len(self.Suffix)], self.Separators) == -1
+}
+
+func (self SuffixAny) String() string {
+	return fmt.Sprintf("<suffix_any:![%s]%s>", string(self.Separators), self.Suffix)
+}

--- a/vendor/github.com/gobwas/glob/match/super.go
+++ b/vendor/github.com/gobwas/glob/match/super.go
@@ -1,0 +1,33 @@
+package match
+
+import (
+	"fmt"
+)
+
+type Super struct{}
+
+func NewSuper() Super {
+	return Super{}
+}
+
+func (self Super) Match(s string) bool {
+	return true
+}
+
+func (self Super) Len() int {
+	return lenNo
+}
+
+func (self Super) Index(s string) (int, []int) {
+	segments := acquireSegments(len(s) + 1)
+	for i := range s {
+		segments = append(segments, i)
+	}
+	segments = append(segments, len(s))
+
+	return 0, segments
+}
+
+func (self Super) String() string {
+	return fmt.Sprintf("<super>")
+}

--- a/vendor/github.com/gobwas/glob/match/text.go
+++ b/vendor/github.com/gobwas/glob/match/text.go
@@ -1,0 +1,45 @@
+package match
+
+import (
+	"fmt"
+	"strings"
+	"unicode/utf8"
+)
+
+// raw represents raw string to match
+type Text struct {
+	Str         string
+	RunesLength int
+	BytesLength int
+	Segments    []int
+}
+
+func NewText(s string) Text {
+	return Text{
+		Str:         s,
+		RunesLength: utf8.RuneCountInString(s),
+		BytesLength: len(s),
+		Segments:    []int{len(s)},
+	}
+}
+
+func (self Text) Match(s string) bool {
+	return self.Str == s
+}
+
+func (self Text) Len() int {
+	return self.RunesLength
+}
+
+func (self Text) Index(s string) (int, []int) {
+	index := strings.Index(s, self.Str)
+	if index == -1 {
+		return -1, nil
+	}
+
+	return index, self.Segments
+}
+
+func (self Text) String() string {
+	return fmt.Sprintf("<text:`%v`>", self.Str)
+}

--- a/vendor/github.com/gobwas/glob/readme.md
+++ b/vendor/github.com/gobwas/glob/readme.md
@@ -1,0 +1,148 @@
+# glob.[go](https://golang.org)
+
+[![GoDoc][godoc-image]][godoc-url] [![Build Status][travis-image]][travis-url]
+
+> Go Globbing Library.
+
+## Install
+
+```shell
+    go get github.com/gobwas/glob
+```
+
+## Example
+
+```go
+
+package main
+
+import "github.com/gobwas/glob"
+
+func main() {
+    var g glob.Glob
+    
+    // create simple glob
+    g = glob.MustCompile("*.github.com")
+    g.Match("api.github.com") // true
+    
+    // quote meta characters and then create simple glob 
+    g = glob.MustCompile(glob.QuoteMeta("*.github.com"))
+    g.Match("*.github.com") // true
+    
+    // create new glob with set of delimiters as ["."]
+    g = glob.MustCompile("api.*.com", '.')
+    g.Match("api.github.com") // true
+    g.Match("api.gi.hub.com") // false
+    
+    // create new glob with set of delimiters as ["."]
+    // but now with super wildcard
+    g = glob.MustCompile("api.**.com", '.')
+    g.Match("api.github.com") // true
+    g.Match("api.gi.hub.com") // true
+        
+    // create glob with single symbol wildcard
+    g = glob.MustCompile("?at")
+    g.Match("cat") // true
+    g.Match("fat") // true
+    g.Match("at") // false
+    
+    // create glob with single symbol wildcard and delimiters ['f']
+    g = glob.MustCompile("?at", 'f')
+    g.Match("cat") // true
+    g.Match("fat") // false
+    g.Match("at") // false 
+    
+    // create glob with character-list matchers 
+    g = glob.MustCompile("[abc]at")
+    g.Match("cat") // true
+    g.Match("bat") // true
+    g.Match("fat") // false
+    g.Match("at") // false
+    
+    // create glob with character-list matchers 
+    g = glob.MustCompile("[!abc]at")
+    g.Match("cat") // false
+    g.Match("bat") // false
+    g.Match("fat") // true
+    g.Match("at") // false 
+    
+    // create glob with character-range matchers 
+    g = glob.MustCompile("[a-c]at")
+    g.Match("cat") // true
+    g.Match("bat") // true
+    g.Match("fat") // false
+    g.Match("at") // false
+    
+    // create glob with character-range matchers 
+    g = glob.MustCompile("[!a-c]at")
+    g.Match("cat") // false
+    g.Match("bat") // false
+    g.Match("fat") // true
+    g.Match("at") // false 
+    
+    // create glob with pattern-alternatives list 
+    g = glob.MustCompile("{cat,bat,[fr]at}")
+    g.Match("cat") // true
+    g.Match("bat") // true
+    g.Match("fat") // true
+    g.Match("rat") // true
+    g.Match("at") // false 
+    g.Match("zat") // false 
+}
+
+```
+
+## Performance
+
+This library is created for compile-once patterns. This means, that compilation could take time, but 
+strings matching is done faster, than in case when always parsing template.
+
+If you will not use compiled `glob.Glob` object, and do `g := glob.MustCompile(pattern); g.Match(...)` every time, then your code will be much more slower.
+
+Run `go test -bench=.` from source root to see the benchmarks:
+
+Pattern | Fixture | Match | Speed (ns/op)
+--------|---------|-------|--------------
+`[a-z][!a-x]*cat*[h][!b]*eyes*` | `my cat has very bright eyes` | `true` | 432
+`[a-z][!a-x]*cat*[h][!b]*eyes*` | `my dog has very bright eyes` | `false` | 199
+`https://*.google.*` | `https://account.google.com` | `true` | 96
+`https://*.google.*` | `https://google.com` | `false` | 66
+`{https://*.google.*,*yandex.*,*yahoo.*,*mail.ru}` | `http://yahoo.com` | `true` | 163
+`{https://*.google.*,*yandex.*,*yahoo.*,*mail.ru}` | `http://google.com` | `false` | 197
+`{https://*gobwas.com,http://exclude.gobwas.com}` | `https://safe.gobwas.com` | `true` | 22
+`{https://*gobwas.com,http://exclude.gobwas.com}` | `http://safe.gobwas.com` | `false` | 24
+`abc*` | `abcdef` | `true` | 8.15
+`abc*` | `af` | `false` | 5.68
+`*def` | `abcdef` | `true` | 8.84
+`*def` | `af` | `false` | 5.74
+`ab*ef` | `abcdef` | `true` | 15.2
+`ab*ef` | `af` | `false` | 10.4
+
+The same things with `regexp` package:
+
+Pattern | Fixture | Match | Speed (ns/op)
+--------|---------|-------|--------------
+`^[a-z][^a-x].*cat.*[h][^b].*eyes.*$` | `my cat has very bright eyes` | `true` | 2553
+`^[a-z][^a-x].*cat.*[h][^b].*eyes.*$` | `my dog has very bright eyes` | `false` | 1383
+`^https:\/\/.*\.google\..*$` | `https://account.google.com` | `true` | 1205
+`^https:\/\/.*\.google\..*$` | `https://google.com` | `false` | 767
+`^(https:\/\/.*\.google\..*|.*yandex\..*|.*yahoo\..*|.*mail\.ru)$` | `http://yahoo.com` | `true` | 1435
+`^(https:\/\/.*\.google\..*|.*yandex\..*|.*yahoo\..*|.*mail\.ru)$` | `http://google.com` | `false` | 1674
+`^(https:\/\/.*gobwas\.com|http://exclude.gobwas.com)$` | `https://safe.gobwas.com` | `true` | 1039
+`^(https:\/\/.*gobwas\.com|http://exclude.gobwas.com)$` | `http://safe.gobwas.com` | `false` | 272
+`^abc.*$` | `abcdef` | `true` | 237
+`^abc.*$` | `af` | `false` | 100
+`^.*def$` | `abcdef` | `true` | 464
+`^.*def$` | `af` | `false` | 265
+`^ab.*ef$` | `abcdef` | `true` | 375
+`^ab.*ef$` | `af` | `false` | 145
+
+[godoc-image]: https://godoc.org/github.com/gobwas/glob?status.svg
+[godoc-url]: https://godoc.org/github.com/gobwas/glob
+[travis-image]: https://travis-ci.org/gobwas/glob.svg?branch=master
+[travis-url]: https://travis-ci.org/gobwas/glob
+
+## Syntax
+
+Syntax is inspired by [standard wildcards](http://tldp.org/LDP/GNU-Linux-Tools-Summary/html/x11655.htm),
+except that `**` is aka super-asterisk, that do not sensitive for separators.

--- a/vendor/github.com/gobwas/glob/syntax/ast/ast.go
+++ b/vendor/github.com/gobwas/glob/syntax/ast/ast.go
@@ -1,0 +1,122 @@
+package ast
+
+import (
+	"bytes"
+	"fmt"
+)
+
+type Node struct {
+	Parent   *Node
+	Children []*Node
+	Value    interface{}
+	Kind     Kind
+}
+
+func NewNode(k Kind, v interface{}, ch ...*Node) *Node {
+	n := &Node{
+		Kind:  k,
+		Value: v,
+	}
+	for _, c := range ch {
+		Insert(n, c)
+	}
+	return n
+}
+
+func (a *Node) Equal(b *Node) bool {
+	if a.Kind != b.Kind {
+		return false
+	}
+	if a.Value != b.Value {
+		return false
+	}
+	if len(a.Children) != len(b.Children) {
+		return false
+	}
+	for i, c := range a.Children {
+		if !c.Equal(b.Children[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func (a *Node) String() string {
+	var buf bytes.Buffer
+	buf.WriteString(a.Kind.String())
+	if a.Value != nil {
+		buf.WriteString(" =")
+		buf.WriteString(fmt.Sprintf("%v", a.Value))
+	}
+	if len(a.Children) > 0 {
+		buf.WriteString(" [")
+		for i, c := range a.Children {
+			if i > 0 {
+				buf.WriteString(", ")
+			}
+			buf.WriteString(c.String())
+		}
+		buf.WriteString("]")
+	}
+	return buf.String()
+}
+
+func Insert(parent *Node, children ...*Node) {
+	parent.Children = append(parent.Children, children...)
+	for _, ch := range children {
+		ch.Parent = parent
+	}
+}
+
+type List struct {
+	Not   bool
+	Chars string
+}
+
+type Range struct {
+	Not    bool
+	Lo, Hi rune
+}
+
+type Text struct {
+	Text string
+}
+
+type Kind int
+
+const (
+	KindNothing Kind = iota
+	KindPattern
+	KindList
+	KindRange
+	KindText
+	KindAny
+	KindSuper
+	KindSingle
+	KindAnyOf
+)
+
+func (k Kind) String() string {
+	switch k {
+	case KindNothing:
+		return "Nothing"
+	case KindPattern:
+		return "Pattern"
+	case KindList:
+		return "List"
+	case KindRange:
+		return "Range"
+	case KindText:
+		return "Text"
+	case KindAny:
+		return "Any"
+	case KindSuper:
+		return "Super"
+	case KindSingle:
+		return "Single"
+	case KindAnyOf:
+		return "AnyOf"
+	default:
+		return ""
+	}
+}

--- a/vendor/github.com/gobwas/glob/syntax/ast/parser.go
+++ b/vendor/github.com/gobwas/glob/syntax/ast/parser.go
@@ -1,0 +1,157 @@
+package ast
+
+import (
+	"errors"
+	"fmt"
+	"github.com/gobwas/glob/syntax/lexer"
+	"unicode/utf8"
+)
+
+type Lexer interface {
+	Next() lexer.Token
+}
+
+type parseFn func(*Node, Lexer) (parseFn, *Node, error)
+
+func Parse(lexer Lexer) (*Node, error) {
+	var parser parseFn
+
+	root := NewNode(KindPattern, nil)
+
+	var (
+		tree *Node
+		err  error
+	)
+	for parser, tree = parserMain, root; parser != nil; {
+		parser, tree, err = parser(tree, lexer)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return root, nil
+}
+
+func parserMain(tree *Node, lex Lexer) (parseFn, *Node, error) {
+	for {
+		token := lex.Next()
+		switch token.Type {
+		case lexer.EOF:
+			return nil, tree, nil
+
+		case lexer.Error:
+			return nil, tree, errors.New(token.Raw)
+
+		case lexer.Text:
+			Insert(tree, NewNode(KindText, Text{token.Raw}))
+			return parserMain, tree, nil
+
+		case lexer.Any:
+			Insert(tree, NewNode(KindAny, nil))
+			return parserMain, tree, nil
+
+		case lexer.Super:
+			Insert(tree, NewNode(KindSuper, nil))
+			return parserMain, tree, nil
+
+		case lexer.Single:
+			Insert(tree, NewNode(KindSingle, nil))
+			return parserMain, tree, nil
+
+		case lexer.RangeOpen:
+			return parserRange, tree, nil
+
+		case lexer.TermsOpen:
+			a := NewNode(KindAnyOf, nil)
+			Insert(tree, a)
+
+			p := NewNode(KindPattern, nil)
+			Insert(a, p)
+
+			return parserMain, p, nil
+
+		case lexer.Separator:
+			p := NewNode(KindPattern, nil)
+			Insert(tree.Parent, p)
+
+			return parserMain, p, nil
+
+		case lexer.TermsClose:
+			return parserMain, tree.Parent.Parent, nil
+
+		default:
+			return nil, tree, fmt.Errorf("unexpected token: %s", token)
+		}
+	}
+	return nil, tree, fmt.Errorf("unknown error")
+}
+
+func parserRange(tree *Node, lex Lexer) (parseFn, *Node, error) {
+	var (
+		not   bool
+		lo    rune
+		hi    rune
+		chars string
+	)
+	for {
+		token := lex.Next()
+		switch token.Type {
+		case lexer.EOF:
+			return nil, tree, errors.New("unexpected end")
+
+		case lexer.Error:
+			return nil, tree, errors.New(token.Raw)
+
+		case lexer.Not:
+			not = true
+
+		case lexer.RangeLo:
+			r, w := utf8.DecodeRuneInString(token.Raw)
+			if len(token.Raw) > w {
+				return nil, tree, fmt.Errorf("unexpected length of lo character")
+			}
+			lo = r
+
+		case lexer.RangeBetween:
+			//
+
+		case lexer.RangeHi:
+			r, w := utf8.DecodeRuneInString(token.Raw)
+			if len(token.Raw) > w {
+				return nil, tree, fmt.Errorf("unexpected length of lo character")
+			}
+
+			hi = r
+
+			if hi < lo {
+				return nil, tree, fmt.Errorf("hi character '%s' should be greater than lo '%s'", string(hi), string(lo))
+			}
+
+		case lexer.Text:
+			chars = token.Raw
+
+		case lexer.RangeClose:
+			isRange := lo != 0 && hi != 0
+			isChars := chars != ""
+
+			if isChars == isRange {
+				return nil, tree, fmt.Errorf("could not parse range")
+			}
+
+			if isRange {
+				Insert(tree, NewNode(KindRange, Range{
+					Lo:  lo,
+					Hi:  hi,
+					Not: not,
+				}))
+			} else {
+				Insert(tree, NewNode(KindList, List{
+					Chars: chars,
+					Not:   not,
+				}))
+			}
+
+			return parserMain, tree, nil
+		}
+	}
+}

--- a/vendor/github.com/gobwas/glob/syntax/lexer/lexer.go
+++ b/vendor/github.com/gobwas/glob/syntax/lexer/lexer.go
@@ -1,0 +1,273 @@
+package lexer
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/gobwas/glob/util/runes"
+	"unicode/utf8"
+)
+
+const (
+	char_any           = '*'
+	char_comma         = ','
+	char_single        = '?'
+	char_escape        = '\\'
+	char_range_open    = '['
+	char_range_close   = ']'
+	char_terms_open    = '{'
+	char_terms_close   = '}'
+	char_range_not     = '!'
+	char_range_between = '-'
+)
+
+var specials = []byte{
+	char_any,
+	char_single,
+	char_escape,
+	char_range_open,
+	char_range_close,
+	char_terms_open,
+	char_terms_close,
+}
+
+func Special(c byte) bool {
+	return bytes.IndexByte(specials, c) != -1
+}
+
+type tokens []Token
+
+func (i *tokens) shift() (ret Token) {
+	ret = (*i)[0]
+	copy(*i, (*i)[1:])
+	*i = (*i)[:len(*i)-1]
+	return
+}
+
+func (i *tokens) push(v Token) {
+	*i = append(*i, v)
+}
+
+func (i *tokens) empty() bool {
+	return len(*i) == 0
+}
+
+var eof rune = 0
+
+type lexer struct {
+	data string
+	pos  int
+	err  error
+
+	tokens     tokens
+	termsLevel int
+
+	lastRune     rune
+	lastRuneSize int
+	hasRune      bool
+}
+
+func NewLexer(source string) *lexer {
+	l := &lexer{
+		data:   source,
+		tokens: tokens(make([]Token, 0, 4)),
+	}
+	return l
+}
+
+func (l *lexer) Next() Token {
+	if l.err != nil {
+		return Token{Error, l.err.Error()}
+	}
+	if !l.tokens.empty() {
+		return l.tokens.shift()
+	}
+
+	l.fetchItem()
+	return l.Next()
+}
+
+func (l *lexer) peek() (r rune, w int) {
+	if l.pos == len(l.data) {
+		return eof, 0
+	}
+
+	r, w = utf8.DecodeRuneInString(l.data[l.pos:])
+	if r == utf8.RuneError {
+		l.errorf("could not read rune")
+		r = eof
+		w = 0
+	}
+
+	return
+}
+
+func (l *lexer) read() rune {
+	if l.hasRune {
+		l.hasRune = false
+		l.seek(l.lastRuneSize)
+		return l.lastRune
+	}
+
+	r, s := l.peek()
+	l.seek(s)
+
+	l.lastRune = r
+	l.lastRuneSize = s
+
+	return r
+}
+
+func (l *lexer) seek(w int) {
+	l.pos += w
+}
+
+func (l *lexer) unread() {
+	if l.hasRune {
+		l.errorf("could not unread rune")
+		return
+	}
+	l.seek(-l.lastRuneSize)
+	l.hasRune = true
+}
+
+func (l *lexer) errorf(f string, v ...interface{}) {
+	l.err = fmt.Errorf(f, v...)
+}
+
+func (l *lexer) inTerms() bool {
+	return l.termsLevel > 0
+}
+
+func (l *lexer) termsEnter() {
+	l.termsLevel++
+}
+
+func (l *lexer) termsLeave() {
+	l.termsLevel--
+}
+
+var inTextBreakers = []rune{char_single, char_any, char_range_open, char_terms_open}
+var inTermsBreakers = append(inTextBreakers, char_terms_close, char_comma)
+
+func (l *lexer) fetchItem() {
+	r := l.read()
+	switch {
+	case r == eof:
+		l.tokens.push(Token{EOF, ""})
+
+	case r == char_terms_open:
+		l.termsEnter()
+		l.tokens.push(Token{TermsOpen, string(r)})
+
+	case r == char_comma && l.inTerms():
+		l.tokens.push(Token{Separator, string(r)})
+
+	case r == char_terms_close && l.inTerms():
+		l.tokens.push(Token{TermsClose, string(r)})
+		l.termsLeave()
+
+	case r == char_range_open:
+		l.tokens.push(Token{RangeOpen, string(r)})
+		l.fetchRange()
+
+	case r == char_single:
+		l.tokens.push(Token{Single, string(r)})
+
+	case r == char_any:
+		if l.read() == char_any {
+			l.tokens.push(Token{Super, string(r) + string(r)})
+		} else {
+			l.unread()
+			l.tokens.push(Token{Any, string(r)})
+		}
+
+	default:
+		l.unread()
+
+		var breakers []rune
+		if l.inTerms() {
+			breakers = inTermsBreakers
+		} else {
+			breakers = inTextBreakers
+		}
+		l.fetchText(breakers)
+	}
+}
+
+func (l *lexer) fetchRange() {
+	var wantHi bool
+	var wantClose bool
+	var seenNot bool
+	for {
+		r := l.read()
+		if r == eof {
+			l.errorf("unexpected end of input")
+			return
+		}
+
+		if wantClose {
+			if r != char_range_close {
+				l.errorf("expected close range character")
+			} else {
+				l.tokens.push(Token{RangeClose, string(r)})
+			}
+			return
+		}
+
+		if wantHi {
+			l.tokens.push(Token{RangeHi, string(r)})
+			wantClose = true
+			continue
+		}
+
+		if !seenNot && r == char_range_not {
+			l.tokens.push(Token{Not, string(r)})
+			seenNot = true
+			continue
+		}
+
+		if n, w := l.peek(); n == char_range_between {
+			l.seek(w)
+			l.tokens.push(Token{RangeLo, string(r)})
+			l.tokens.push(Token{RangeBetween, string(n)})
+			wantHi = true
+			continue
+		}
+
+		l.unread() // unread first peek and fetch as text
+		l.fetchText([]rune{char_range_close})
+		wantClose = true
+	}
+}
+
+func (l *lexer) fetchText(breakers []rune) {
+	var data []rune
+	var escaped bool
+
+reading:
+	for {
+		r := l.read()
+		if r == eof {
+			break
+		}
+
+		if !escaped {
+			if r == char_escape {
+				escaped = true
+				continue
+			}
+
+			if runes.IndexRune(breakers, r) != -1 {
+				l.unread()
+				break reading
+			}
+		}
+
+		escaped = false
+		data = append(data, r)
+	}
+
+	if len(data) > 0 {
+		l.tokens.push(Token{Text, string(data)})
+	}
+}

--- a/vendor/github.com/gobwas/glob/syntax/lexer/token.go
+++ b/vendor/github.com/gobwas/glob/syntax/lexer/token.go
@@ -1,0 +1,88 @@
+package lexer
+
+import "fmt"
+
+type TokenType int
+
+const (
+	EOF TokenType = iota
+	Error
+	Text
+	Char
+	Any
+	Super
+	Single
+	Not
+	Separator
+	RangeOpen
+	RangeClose
+	RangeLo
+	RangeHi
+	RangeBetween
+	TermsOpen
+	TermsClose
+)
+
+func (tt TokenType) String() string {
+	switch tt {
+	case EOF:
+		return "eof"
+
+	case Error:
+		return "error"
+
+	case Text:
+		return "text"
+
+	case Char:
+		return "char"
+
+	case Any:
+		return "any"
+
+	case Super:
+		return "super"
+
+	case Single:
+		return "single"
+
+	case Not:
+		return "not"
+
+	case Separator:
+		return "separator"
+
+	case RangeOpen:
+		return "range_open"
+
+	case RangeClose:
+		return "range_close"
+
+	case RangeLo:
+		return "range_lo"
+
+	case RangeHi:
+		return "range_hi"
+
+	case RangeBetween:
+		return "range_between"
+
+	case TermsOpen:
+		return "terms_open"
+
+	case TermsClose:
+		return "terms_close"
+
+	default:
+		return "undef"
+	}
+}
+
+type Token struct {
+	Type TokenType
+	Raw  string
+}
+
+func (t Token) String() string {
+	return fmt.Sprintf("%v<%q>", t.Type, t.Raw)
+}

--- a/vendor/github.com/gobwas/glob/syntax/syntax.go
+++ b/vendor/github.com/gobwas/glob/syntax/syntax.go
@@ -1,0 +1,14 @@
+package syntax
+
+import (
+	"github.com/gobwas/glob/syntax/ast"
+	"github.com/gobwas/glob/syntax/lexer"
+)
+
+func Parse(s string) (*ast.Node, error) {
+	return ast.Parse(lexer.NewLexer(s))
+}
+
+func Special(b byte) bool {
+	return lexer.Special(b)
+}

--- a/vendor/github.com/gobwas/glob/util/runes/runes.go
+++ b/vendor/github.com/gobwas/glob/util/runes/runes.go
@@ -1,0 +1,154 @@
+package runes
+
+func Index(s, needle []rune) int {
+	ls, ln := len(s), len(needle)
+
+	switch {
+	case ln == 0:
+		return 0
+	case ln == 1:
+		return IndexRune(s, needle[0])
+	case ln == ls:
+		if Equal(s, needle) {
+			return 0
+		}
+		return -1
+	case ln > ls:
+		return -1
+	}
+
+head:
+	for i := 0; i < ls && ls-i >= ln; i++ {
+		for y := 0; y < ln; y++ {
+			if s[i+y] != needle[y] {
+				continue head
+			}
+		}
+
+		return i
+	}
+
+	return -1
+}
+
+func LastIndex(s, needle []rune) int {
+	ls, ln := len(s), len(needle)
+
+	switch {
+	case ln == 0:
+		if ls == 0 {
+			return 0
+		}
+		return ls
+	case ln == 1:
+		return IndexLastRune(s, needle[0])
+	case ln == ls:
+		if Equal(s, needle) {
+			return 0
+		}
+		return -1
+	case ln > ls:
+		return -1
+	}
+
+head:
+	for i := ls - 1; i >= 0 && i >= ln; i-- {
+		for y := ln - 1; y >= 0; y-- {
+			if s[i-(ln-y-1)] != needle[y] {
+				continue head
+			}
+		}
+
+		return i - ln + 1
+	}
+
+	return -1
+}
+
+// IndexAny returns the index of the first instance of any Unicode code point
+// from chars in s, or -1 if no Unicode code point from chars is present in s.
+func IndexAny(s, chars []rune) int {
+	if len(chars) > 0 {
+		for i, c := range s {
+			for _, m := range chars {
+				if c == m {
+					return i
+				}
+			}
+		}
+	}
+	return -1
+}
+
+func Contains(s, needle []rune) bool {
+	return Index(s, needle) >= 0
+}
+
+func Max(s []rune) (max rune) {
+	for _, r := range s {
+		if r > max {
+			max = r
+		}
+	}
+
+	return
+}
+
+func Min(s []rune) rune {
+	min := rune(-1)
+	for _, r := range s {
+		if min == -1 {
+			min = r
+			continue
+		}
+
+		if r < min {
+			min = r
+		}
+	}
+
+	return min
+}
+
+func IndexRune(s []rune, r rune) int {
+	for i, c := range s {
+		if c == r {
+			return i
+		}
+	}
+	return -1
+}
+
+func IndexLastRune(s []rune, r rune) int {
+	for i := len(s) - 1; i >= 0; i-- {
+		if s[i] == r {
+			return i
+		}
+	}
+
+	return -1
+}
+
+func Equal(a, b []rune) bool {
+	if len(a) == len(b) {
+		for i := 0; i < len(a); i++ {
+			if a[i] != b[i] {
+				return false
+			}
+		}
+
+		return true
+	}
+
+	return false
+}
+
+// HasPrefix tests whether the string s begins with prefix.
+func HasPrefix(s, prefix []rune) bool {
+	return len(s) >= len(prefix) && Equal(s[0:len(prefix)], prefix)
+}
+
+// HasSuffix tests whether the string s ends with suffix.
+func HasSuffix(s, suffix []rune) bool {
+	return len(s) >= len(suffix) && Equal(s[len(s)-len(suffix):], suffix)
+}

--- a/vendor/github.com/gobwas/glob/util/strings/strings.go
+++ b/vendor/github.com/gobwas/glob/util/strings/strings.go
@@ -1,0 +1,39 @@
+package strings
+
+import (
+	"strings"
+	"unicode/utf8"
+)
+
+func IndexAnyRunes(s string, rs []rune) int {
+	for _, r := range rs {
+		if i := strings.IndexRune(s, r); i != -1 {
+			return i
+		}
+	}
+
+	return -1
+}
+
+func LastIndexAnyRunes(s string, rs []rune) int {
+	for _, r := range rs {
+		i := -1
+		if 0 <= r && r < utf8.RuneSelf {
+			i = strings.LastIndexByte(s, byte(r))
+		} else {
+			sub := s
+			for len(sub) > 0 {
+				j := strings.IndexRune(s, r)
+				if j == -1 {
+					break
+				}
+				i = j
+				sub = sub[i+1:]
+			}
+		}
+		if i != -1 {
+			return i
+		}
+	}
+	return -1
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -33,6 +33,15 @@ github.com/cespare/xxhash/v2
 github.com/cristalhq/jwt/v3
 # github.com/davecgh/go-spew v1.1.1
 github.com/davecgh/go-spew/spew
+# github.com/gobwas/glob v0.2.3
+github.com/gobwas/glob
+github.com/gobwas/glob/compiler
+github.com/gobwas/glob/match
+github.com/gobwas/glob/syntax
+github.com/gobwas/glob/syntax/ast
+github.com/gobwas/glob/syntax/lexer
+github.com/gobwas/glob/util/runes
+github.com/gobwas/glob/util/strings
 # github.com/gogo/protobuf v1.3.1
 github.com/gogo/protobuf/gogoproto
 github.com/gogo/protobuf/jsonpb


### PR DESCRIPTION
Add `allowed_origins` option.

This option allows setting an array of allowed origin patterns (array of strings) for WebSocket and SockJS endpoints to prevent [CSRF](https://en.wikipedia.org/wiki/Cross-site_request_forgery) attack. This is especially important when using [connect proxy](https://centrifugal.github.io/centrifugo/server/proxy/#connect-proxy) feature.

Originally cross-origin check was not too important due to JWT auth, now with connect proxy browser automatically passes cookies and origin check becomes necessary to secure an app. While it's already possible to validate origin on backend side looking at Origin header I think it's nice to have directly in Centrifugo.

If `allowed_origins` option not set at all then no origin check will be performed by Centrifugo.

As soon as `allowed_origins` defined every connection request will be checked against each pattern in an array until a match.

Centrifugo v3 may enforce same-origin strategy by default.
