### PR TITLE
migrate from ioutil to io, os.

### DIFF
--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -3,7 +3,6 @@ package api
 import (
 	"context"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 
@@ -40,7 +39,7 @@ func (s *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	var data []byte
 	var err error
 
-	data, err = ioutil.ReadAll(r.Body)
+	data, err = io.ReadAll(r.Body)
 	if err != nil {
 		s.node.Log(centrifuge.NewLogEntry(centrifuge.LogLevelError, "error reading API request body", map[string]interface{}{"error": err.Error()}))
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/internal/health/health_test.go
+++ b/internal/health/health_test.go
@@ -1,7 +1,7 @@
 package health
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -24,7 +24,7 @@ func TestHealthHandler(t *testing.T) {
 
 	require.Equal(t, "application/json", res.Header.Get("Content-Type"))
 
-	data, err := ioutil.ReadAll(res.Body)
+	data, err := io.ReadAll(res.Body)
 	require.NoError(t, err)
 	require.Equal(t, []byte(`{}`), data)
 }

--- a/internal/jwks/manager.go
+++ b/internal/jwks/manager.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"time"
@@ -119,7 +119,7 @@ func (m *Manager) loadData(req *http.Request) ([]byte, error) {
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("%w: %d", errUnexpectedStatusCode, resp.StatusCode)
 	}
-	return ioutil.ReadAll(resp.Body)
+	return io.ReadAll(resp.Body)
 }
 
 func (m *Manager) fetchKey(ctx context.Context, kid string) (*JWK, error) {

--- a/internal/proxy/http.go
+++ b/internal/proxy/http.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 )
 
@@ -58,7 +58,7 @@ func (c *httpCaller) CallHTTP(ctx context.Context, header http.Header, reqData [
 	if resp.StatusCode != http.StatusOK {
 		return nil, &statusCodeError{resp.StatusCode}
 	}
-	respData, err := ioutil.ReadAll(resp.Body)
+	respData, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("error reading HTTP body: %w", err)
 	}

--- a/internal/tools/config.go
+++ b/internal/tools/config.go
@@ -3,7 +3,6 @@ package tools
 import (
 	"bytes"
 	"errors"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -107,5 +106,5 @@ func GenerateConfig(f string) error {
 		uuid.New().String(),
 	})
 
-	return ioutil.WriteFile(f, output.Bytes(), 0644)
+	return os.WriteFile(f, output.Bytes(), 0644)
 }

--- a/main.go
+++ b/main.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	stdlog "log"
 	"net"
 	"net/http"
@@ -666,7 +665,7 @@ func writePidFile(pidFile string) error {
 		return nil
 	}
 	pid := []byte(strconv.Itoa(os.Getpid()) + "\n")
-	return ioutil.WriteFile(pidFile, pid, 0644)
+	return os.WriteFile(pidFile, pid, 0644)
 }
 
 var logLevelMatches = map[string]zerolog.Level{


### PR DESCRIPTION
## Proposed changes

in Go 1.16 [ioutil](https://golang.org/pkg/io/ioutil) became deprecated ([release notes 1.16](https://golang.org/doc/go1.16#ioutil)) I think migrate to io.  
