### PR TITLE
Update index.html

### DIFF
--- a/deploy/nginx/index.html
+++ b/deploy/nginx/index.html
@@ -1229,8 +1229,7 @@ server {
 
     listen 80;
 
-    #listen 443;
-    #ssl on;
+    #listen 443 ssl;
     #ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
     #ssl_ciphers AES128-SHA:AES256-SHA:RC4-SHA:DES-CBC3-SHA:RC4-MD5;
     #ssl_certificate /etc/nginx/ssl/wildcard.example.com.crt;


### PR DESCRIPTION
the "ssl" directive is deprecated, the preferred syntax is "listen ... ssl" directive

## Proposed changes

A slight fix of the default nginx config
