### PR TITLE
v3 docs warning

### DIFF
--- a/docs/content/blog/index.md
+++ b/docs/content/blog/index.md
@@ -7,6 +7,10 @@ og_image_width: 960
 og_image_height: 960
 ---
 
+!!!danger
+
+    This blog has been transferred to the [centrifugal.dev/blog](https://centrifugal.dev/blog).
+
 Welcome to Centrifugo Dev Blog ❤️
 
 Here we are talking about real-time messaging topics – not only about Centrifugo server, but also about general related questions, about Centrifuge library, best practices on building real-time messaging servers, cool applications done with WebSocket technology etc.

--- a/docs/content/deploy/monitoring.md
+++ b/docs/content/deploy/monitoring.md
@@ -1,5 +1,9 @@
 # Monitoring
 
+!!!danger
+
+    This is a documentation for Centrifugo v2. The latest Centrifugo version is v3. Go to the [centrifugal.dev](https://centrifugal.dev) for v3 docs.
+
 Centrifugo supports reporting metrics in Prometheus format and can automatically export metrics to Graphite.
 
 ### Prometheus

--- a/docs/content/deploy/nginx.md
+++ b/docs/content/deploy/nginx.md
@@ -1,5 +1,9 @@
 # Nginx configuration
 
+!!!danger
+
+    This is a documentation for Centrifugo v2. The latest Centrifugo version is v3. Go to the [centrifugal.dev](https://centrifugal.dev) for v3 docs.
+
 Although it's possible to  use Centrifugo without any reverse proxy before it,
 it's still a good idea to keep Centrifugo behind mature reverse proxy to deal with
 edge cases when handling HTTP/Websocket connections from the wild. Also you probably

--- a/docs/content/deploy/tls.md
+++ b/docs/content/deploy/tls.md
@@ -1,5 +1,9 @@
 # TLS
 
+!!!danger
+
+    This is a documentation for Centrifugo v2. The latest Centrifugo version is v3. Go to the [centrifugal.dev](https://centrifugal.dev) for v3 docs.
+
 TLS/SSL layer is very important not only for securing your connections but also to increase a
 chance to establish Websocket connection. **In most situations you will put TLS termination task
 on your reverse proxy/load balancing software such as Nginx**.

--- a/docs/content/deploy/tuning.md
+++ b/docs/content/deploy/tuning.md
@@ -1,5 +1,9 @@
 # Tuning infrastructure to handle persistent connections
 
+!!!danger
+
+    This is a documentation for Centrifugo v2. The latest Centrifugo version is v3. Go to the [centrifugal.dev](https://centrifugal.dev) for v3 docs.
+
 As Centrifugo deals with lots of persistent connections your operating system and server infrastructure must be ready for it.
 
 ### Open files limit

--- a/docs/content/faq.md
+++ b/docs/content/faq.md
@@ -1,5 +1,9 @@
 # Frequently Asked Questions
 
+!!!danger
+
+    This is a documentation for Centrifugo v2. The latest Centrifugo version is v3. Go to the [centrifugal.dev](https://centrifugal.dev) for v3 docs.
+
 Answers on various questions here.
 
 ### How many connections can one Centrifugo instance handle?

--- a/docs/content/getting_started.md
+++ b/docs/content/getting_started.md
@@ -1,5 +1,9 @@
 # What is Centrifugo
 
+!!!danger
+
+    This is a documentation for Centrifugo v2. The latest Centrifugo version is v3. Go to the [centrifugal.dev](https://centrifugal.dev) for v3 docs.
+
 Centrifugo is a scalable real-time messaging server in language-agnostic way.
 
 The term `language-agnostic` in this definition means that it does not matter which programming language your application uses on a frontend or backend sides – Centrifugo works in conjunction with any. 

--- a/docs/content/guide.md
+++ b/docs/content/guide.md
@@ -1,5 +1,9 @@
 # Centrifugo integration guide
 
+!!!danger
+
+    This is a documentation for Centrifugo v2. The latest Centrifugo version is v3. Go to the [centrifugal.dev](https://centrifugal.dev) for v3 docs.
+
 This chapter aims to help you get started with Centrifugo. We will look at a step-by-step workflow of integrating your application with Centrifugo providing links to relevant parts of this documentation.
 
 As Centrifugo is language-agnostic and can be used together with any language/framework we won't be specific here about any backend or frontend technology your application can be built with. Only abstract steps which you can extrapolate to your application stack.

--- a/docs/content/libraries/api.md
+++ b/docs/content/libraries/api.md
@@ -1,5 +1,9 @@
 # HTTP API clients
 
+!!!danger
+
+    This is a documentation for Centrifugo v2. The latest Centrifugo version is v3. Go to the [centrifugal.dev](https://centrifugal.dev) for v3 docs.
+
 Sending an API request to Centrifugo is a simple task to do in any programming language - this is just a POST request with JSON payload in body and `Authorization` header. See more in [special chapter](../server/http_api.md) in server section.
 
 We have several official client libraries for different languages, so you don't have to construct proper HTTP requests manually:

--- a/docs/content/libraries/client.md
+++ b/docs/content/libraries/client.md
@@ -1,5 +1,9 @@
 # Client libraries
 
+!!!danger
+
+    This is a documentation for Centrifugo v2. The latest Centrifugo version is v3. Go to the [centrifugal.dev](https://centrifugal.dev) for v3 docs.
+
 These libraries allow your users to connect to Centrifugo from application frontend.
 
 * [centrifuge-js](https://github.com/centrifugal/centrifuge-js) – for browser, NodeJS and React Native

--- a/docs/content/misc/benchmark.md
+++ b/docs/content/misc/benchmark.md
@@ -1,5 +1,9 @@
 # Benchmark
 
+!!!danger
+
+    This is a documentation for Centrifugo v2. The latest Centrifugo version is v3. Go to the [centrifugal.dev](https://centrifugal.dev) for v3 docs.
+
 In order to get an understanding about possible hardware requirements for reasonably massive Centrifugo setup we made a test stand inside Kubernetes.
 
 Our goal was to run server based on Centrifuge library (the core of Centrifugo server) with one million WebSocket connections and send many messages to connected clients. While sending many messages we have been looking at delivery time latency. In fact we will see that about 30 million messages per minute (500k messages per second) will be delivered to connected clients and latency won't be larger than 200ms in 99 percentile.

--- a/docs/content/misc/insecure_modes.md
+++ b/docs/content/misc/insecure_modes.md
@@ -1,5 +1,9 @@
 # Insecure modes
 
+!!!danger
+
+    This is a documentation for Centrifugo v2. The latest Centrifugo version is v3. Go to the [centrifugal.dev](https://centrifugal.dev) for v3 docs.
+
 This chapter describes several insecure options that enable several insecure modes in Centrifugo.
 
 ### Insecure client connection

--- a/docs/content/misc/migrate.md
+++ b/docs/content/misc/migrate.md
@@ -1,5 +1,9 @@
 # Migration notes from Centrifugo v1
 
+!!!danger
+
+    This is a documentation for Centrifugo v2. The latest Centrifugo version is v3. Go to the [centrifugal.dev](https://centrifugal.dev) for v3 docs.
+
 In version 2 of Centrifugo many things changed in backwards incompatible way comparing to version 1. This document aims to help Centrifugo v1 users to migrate their projects to version 2 (if they want to).
 
 ### New client protocol and client libraries

--- a/docs/content/pro/index.md
+++ b/docs/content/pro/index.md
@@ -1,5 +1,9 @@
 # Centrifugo PRO
 
+!!!danger
+
+    This is a documentation for Centrifugo v2. The latest Centrifugo version is v3. Go to the [centrifugal.dev](https://centrifugal.dev) for v3 docs.
+
 Centrifugo becomes more popular and is used in many projects over the world. Since it's rather big project I need more and more time to maintain it healthy, improve client libraries and introduce new features.
 
 I am considering to create a PRO version of Centrifugo. It may include some additional features on top of open-source Centrifugo version. This version will have some model of monetization, I am still evaluating whether it's reasonable to have and will be in demand.

--- a/docs/content/quick_start.md
+++ b/docs/content/quick_start.md
@@ -1,5 +1,9 @@
 # Quick start
 
+!!!danger
+
+    This is a documentation for Centrifugo v2. The latest Centrifugo version is v3. Go to the [centrifugal.dev](https://centrifugal.dev) for v3 docs.
+
 Here we will build a very simple browser application with Centrifugo. It works in a way that users connect to Centrifugo over WebSocket, subscribe to channel and start receiving all messages published to that channel. In our case we will send a counter value to all channel subscribers to update it in all open browser tabs in real-time.
 
 First you need to [install Centrifugo](server/install.md). Below in this example we will use binary file release for simplicity. We can generate minimal required configuration file with the following command:

--- a/docs/content/server/admin.md
+++ b/docs/content/server/admin.md
@@ -1,5 +1,9 @@
 # Admin web interface
 
+!!!danger
+
+    This is a documentation for Centrifugo v2. The latest Centrifugo version is v3. Go to the [centrifugal.dev](https://centrifugal.dev) for v3 docs.
+
 Centrifugo comes with builtin admin web interface.
 
 It can:

--- a/docs/content/server/authentication.md
+++ b/docs/content/server/authentication.md
@@ -1,5 +1,9 @@
 # Authentication
 
+!!!danger
+
+    This is a documentation for Centrifugo v2. The latest Centrifugo version is v3. Go to the [centrifugal.dev](https://centrifugal.dev) for v3 docs.
+
 When you are using [centrifuge](https://github.com/centrifugal/centrifuge) library from Go language you can implement any user authentication using middleware. In Centrifugo case you need to tell a server who is connecting in well-known predefined way. This chapter describes a mechanism of authenticating user over JSON Web Token (JWT).
 
 !!!note

--- a/docs/content/server/channels.md
+++ b/docs/content/server/channels.md
@@ -1,5 +1,9 @@
 # Channels
 
+!!!danger
+
+    This is a documentation for Centrifugo v2. The latest Centrifugo version is v3. Go to the [centrifugal.dev](https://centrifugal.dev) for v3 docs.
+
 Channel is a route for publication messages. Clients can be subscribed to a channel to receive messages published to this channel – new publications, join/leave events (if enabled for a channel namespace) etc. Channel subscriber can also ask for channel presence or channel history information (if enabled for a channel namespace).
 
 Channel is just a string - `news`, `comments` are valid channel names. Though this string has some predefined rules as we will see below.

--- a/docs/content/server/client_api.md
+++ b/docs/content/server/client_api.md
@@ -1,5 +1,9 @@
 # Client API
 
+!!!danger
+
+    This is a documentation for Centrifugo v2. The latest Centrifugo version is v3. Go to the [centrifugal.dev](https://centrifugal.dev) for v3 docs.
+
 This chapter describes client Centrifugo API – i.e. **primitives to communicate with a server from an application front-end** (i.e. browser or mobile device).
 
 This is a formal description – refer to each specific client implementation for concrete method names and possibilities. See [full list of Centrifugo client connectors](../libraries/client.md).

--- a/docs/content/server/commands.md
+++ b/docs/content/server/commands.md
@@ -1,5 +1,9 @@
 # Console commands
 
+!!!danger
+
+    This is a documentation for Centrifugo v2. The latest Centrifugo version is v3. Go to the [centrifugal.dev](https://centrifugal.dev) for v3 docs.
+
 Here is a list of console commands that come with Centrifugo executable.
 
 ## version command

--- a/docs/content/server/configuration.md
+++ b/docs/content/server/configuration.md
@@ -1,5 +1,9 @@
 # Configuration
 
+!!!danger
+
+    This is a documentation for Centrifugo v2. The latest Centrifugo version is v3. Go to the [centrifugal.dev](https://centrifugal.dev) for v3 docs.
+
 Here we will look at how Centrifugo can be configured.
 
 ## Configuration ways

--- a/docs/content/server/connection_expiration.md
+++ b/docs/content/server/connection_expiration.md
@@ -1,5 +1,9 @@
 # Connection expiration
 
+!!!danger
+
+    This is a documentation for Centrifugo v2. The latest Centrifugo version is v3. Go to the [centrifugal.dev](https://centrifugal.dev) for v3 docs.
+
 In authentication chapter we mentioned `exp` claim in connection token that allows to expire client connection at some point of time. In this chapter we will look at details on what happens when Centrifugo detects that connection is going to expire.
 
 So first you should do is enable client expiration mechanism in Centrifugo providing connection token with expiration:

--- a/docs/content/server/engines.md
+++ b/docs/content/server/engines.md
@@ -1,5 +1,9 @@
 # Engines
 
+!!!danger
+
+    This is a documentation for Centrifugo v2. The latest Centrifugo version is v3. Go to the [centrifugal.dev](https://centrifugal.dev) for v3 docs.
+
 * [Memory engine](#memory-engine)
 * [Redis engine](#redis-engine)
 * [Nats broker](#nats-broker)

--- a/docs/content/server/grpc_api.md
+++ b/docs/content/server/grpc_api.md
@@ -1,5 +1,9 @@
 # Server GRPC API
 
+!!!danger
+
+    This is a documentation for Centrifugo v2. The latest Centrifugo version is v3. Go to the [centrifugal.dev](https://centrifugal.dev) for v3 docs.
+
 Centrifugo also supports [GRPC](https://grpc.io/) API. With GRPC it's possible to communicate with Centrifugo using more compact binary representation of commands and use the power of HTTP/2 which is the transport behind GRPC.
 
 GRPC API is also useful if you want to publish binary data to Centrifugo channels.

--- a/docs/content/server/http_api.md
+++ b/docs/content/server/http_api.md
@@ -1,5 +1,9 @@
 # Server HTTP API
 
+!!!danger
+
+    This is a documentation for Centrifugo v2. The latest Centrifugo version is v3. Go to the [centrifugal.dev](https://centrifugal.dev) for v3 docs.
+
 HTTP API is a way to send commands to Centrifugo. For example, server API allows publishing messages to channels. 
 
 Server HTTP API works on `/api` endpoint. It has very simple request format: this is a HTTP POST request with `application/json` Content-Type and with JSON command body.

--- a/docs/content/server/install.md
+++ b/docs/content/server/install.md
@@ -1,5 +1,9 @@
 # Server overview and installation
 
+!!!danger
+
+    This is a documentation for Centrifugo v2. The latest Centrifugo version is v3. Go to the [centrifugal.dev](https://centrifugal.dev) for v3 docs.
+
 Centrifugo server written in Go language. It's an open-source software, the source code is available [on Github](https://github.com/centrifugal/centrifugo).
 
 Centrifugo is built around [Centrifuge](https://github.com/centrifugal/centrifuge) library for Go language. That library defines custom protocol and message types which must be sent over various transports (Websocket, SockJS). Server clients use that protocol internally and provide simple API to features - making persistent connection, subscribing on channels, calling RPC commands and more.

--- a/docs/content/server/private_channels.md
+++ b/docs/content/server/private_channels.md
@@ -1,5 +1,9 @@
 # Private channels
 
+!!!danger
+
+    This is a documentation for Centrifugo v2. The latest Centrifugo version is v3. Go to the [centrifugal.dev](https://centrifugal.dev) for v3 docs.
+
 In [channels](channels.md) chapter we mentioned private channels. This chapter has more information about private channel mechanism in Centrifugo.
 
 All channels starting with `$` considered private. In this case **your backend should additionally provide token for every subscription request to such a channel**. This way you can control subscription permissions and only allow certain users to subscribe to a channel.

--- a/docs/content/server/proxy.md
+++ b/docs/content/server/proxy.md
@@ -1,5 +1,9 @@
 # Proxy calls to app backend
 
+!!!danger
+
+    This is a documentation for Centrifugo v2. The latest Centrifugo version is v3. Go to the [centrifugal.dev](https://centrifugal.dev) for v3 docs.
+
 It's possible to proxy some client connection events over HTTP to application backend and react to them in a way you need. For example, you can authenticate connection via request from Centrifugo to your app backend, refresh client sessions and answer to RPC calls sent by client over WebSocket or SockJS connections.
 
 ### Proxy request structure

--- a/docs/content/server/server_subs.md
+++ b/docs/content/server/server_subs.md
@@ -1,5 +1,9 @@
 # Server-side subscriptions
 
+!!!danger
+
+    This is a documentation for Centrifugo v2. The latest Centrifugo version is v3. Go to the [centrifugal.dev](https://centrifugal.dev) for v3 docs.
+
 Starting from v2.4.0 Centrifugo supports server-side subscriptions.
 
 ### Overview

--- a/docs/content/transports/index.md
+++ b/docs/content/transports/index.md
@@ -1,3 +1,7 @@
+!!!danger
+
+    This is a documentation for Centrifugo v2. The latest Centrifugo version is v3. Go to the [centrifugal.dev](https://centrifugal.dev) for v3 docs.
+
 This section describes client-server transports that Centrifugo supports and its specifics. Client-server transports used to connect to Centrifugo from a frontend of your application.
 
 At moment Centrifugo supports the following client-server transports:

--- a/docs/content/transports/protobuf.md
+++ b/docs/content/transports/protobuf.md
@@ -1,5 +1,9 @@
 # Protobuf binary protocol
 
+!!!danger
+
+    This is a documentation for Centrifugo v2. The latest Centrifugo version is v3. Go to the [centrifugal.dev](https://centrifugal.dev) for v3 docs.
+
 In most cases you will use Centrifugo with JSON protocol which is used by default. It consists of simple human-readable frames that can be easily inspected. Also it's a very simple task to publish JSON encoded data to HTTP API endpoint. You may want to use binary Protobuf client protocol if:
 
 * you want less traffic on wire as Protobuf is very compact

--- a/docs/content/transports/protocol.md
+++ b/docs/content/transports/protocol.md
@@ -1,5 +1,9 @@
 # Client protocol
 
+!!!danger
+
+    This is a documentation for Centrifugo v2. The latest Centrifugo version is v3. Go to the [centrifugal.dev](https://centrifugal.dev) for v3 docs.
+
 This chapter describes internal client-server protocol in details to help developers build new client libraries and understand how existing client libraries work.
 
 Note that you can always look at [existing client implementations](../libraries/client.md) in case of any questions. Not all clients support all available server features though.

--- a/docs/content/transports/recovery.md
+++ b/docs/content/transports/recovery.md
@@ -1,5 +1,9 @@
 # How message recovery works
 
+!!!danger
+
+    This is a documentation for Centrifugo v2. The latest Centrifugo version is v3. Go to the [centrifugal.dev](https://centrifugal.dev) for v3 docs.
+
 This description uses `offset` field available since Centrifugo v2.5.0 which replaced two `uint32` fields `seq` and `gen` in client protocol schema. This means that here we describe a case when Centrifugo config contains `v3_use_offset` option enabled:
 
 ```json

--- a/docs/content/transports/sockjs.md
+++ b/docs/content/transports/sockjs.md
@@ -1,5 +1,9 @@
 # SockJS
 
+!!!danger
+
+    This is a documentation for Centrifugo v2. The latest Centrifugo version is v3. Go to the [centrifugal.dev](https://centrifugal.dev) for v3 docs.
+
 SockJS is a polyfill browser library which provides HTTP-based fallback transports in case when it's not possible to establish Websocket connection. This can happen in old client browsers or because of some proxy behind client and server that cuts of Websocket traffic. You can find more information on [SockJS project Github page](https://github.com/sockjs/sockjs-client).
 
 If you have a requirement to work everywhere SockJS is the solution. SockJS will automatically choose best fallback transport if Websocket connection failed for some reason. Some of the fallback transports are:

--- a/docs/content/transports/websocket.md
+++ b/docs/content/transports/websocket.md
@@ -1,5 +1,9 @@
 # Websocket
 
+!!!danger
+
+    This is a documentation for Centrifugo v2. The latest Centrifugo version is v3. Go to the [centrifugal.dev](https://centrifugal.dev) for v3 docs.
+
 [Websocket](https://en.wikipedia.org/wiki/WebSocket) is the main transport in Centrifugo. It's a very efficient low-overhead protocol on top of TCP.
 
 The biggest advantage is that Websocket works out of the box in all modern browsers and almost all programming languages have Websocket implementations. This makes Websocket a pretty universal transport that can even be used to connect to Centrifugo from web apps and mobile apps and other environments.

--- a/docs/material/overrides/home.html
+++ b/docs/material/overrides/home.html
@@ -358,6 +358,7 @@
             <!-- Hero content -->
             <div class="tx-hero__content">
                 <h1>CENTRIFUGO</h1>
+                <p style="color: red">This is a documentation for Centrifugo v2. The latest Centrifugo version is v3: see <a href="https://centrifugal.dev">centrifugal.dev</a></p>
                 <p>{{ config.site_description }}. Set up once and forever.</p>
                 <a
                         href="{{ page.next_page.url | url }}"


### PR DESCRIPTION
The documentation site for Centrifugo v2 will continue to work, but all pages will have a link to centrifugal.dev.
