### PR TITLE
Tests for http and grpc refresh handlers

### DIFF
--- a/internal/proxy/test_grpc_server.go
+++ b/internal/proxy/test_grpc_server.go
@@ -72,7 +72,23 @@ func (p proxyGRPCTestServer) Connect(ctx context.Context, request *proxyproto.Co
 }
 
 func (p proxyGRPCTestServer) Refresh(ctx context.Context, request *proxyproto.RefreshRequest) (*proxyproto.RefreshResponse, error) {
-	panic("it will be implemented later")
+	switch p.flag {
+	case "with credentials":
+		return &proxyproto.RefreshResponse{
+			Result: &proxyproto.RefreshResult{
+				B64Info:  p.opts.B64Data,
+				ExpireAt: p.opts.ExpireAt,
+			},
+		}, nil
+	case "expired":
+		return &proxyproto.RefreshResponse{
+			Result: &proxyproto.RefreshResult{
+				Expired: true,
+			},
+		}, nil
+	default:
+		return &proxyproto.RefreshResponse{}, nil
+	}
 }
 
 func (p proxyGRPCTestServer) Subscribe(ctx context.Context, request *proxyproto.SubscribeRequest) (*proxyproto.SubscribeResponse, error) {


### PR DESCRIPTION
Added tests for joint testing http/grpc refresh handlers.
Also refactored connect/publish handlers to reduce code duplication and improve readability
https://github.com/centrifugal/centrifugo/commit/f756155939446588dee88227a8dc81a24f755de3