### PR TITLE
Support checking token aud and iss claims

### DIFF
--- a/internal/jwtverify/token_verifier.go
+++ b/internal/jwtverify/token_verifier.go
@@ -14,7 +14,7 @@ type Verifier interface {
 type ConnectToken struct {
 	// UserID tells library an ID of connecting user.
 	UserID string
-	// ExpireAt allows to set time in future when connection must be validated.
+	// ExpireAt allows setting time in future when connection must be validated.
 	// Validation can be server-side using On().Refresh callback or client-side
 	// if On().Refresh not set.
 	ExpireAt int64
@@ -28,9 +28,7 @@ type ConnectToken struct {
 	// for connection inspection. Never sent in a client protocol and accessible
 	// from a backend-side only.
 	Meta json.RawMessage
-	// Subs is a map of channels to subscribe server-side with options. This is a
-	// more advanced version of Channels actually. If Subs map is not empty then we
-	// don't look at Channels at all.
+	// Subs is a map of channels to subscribe server-side with options.
 	Subs map[string]centrifuge.SubscribeOptions
 }
 

--- a/internal/jwtverify/token_verifier_jwt_test.go
+++ b/internal/jwtverify/token_verifier_jwt_test.go
@@ -98,7 +98,9 @@ func getRSAConnToken(user string, exp int64, rsaPrivateKey *rsa.PrivateKey, opts
 	claims := &ConnectTokenClaims{
 		Base64Info: "e30=",
 		StandardClaims: jwt.StandardClaims{
-			Subject: user,
+			Subject:  user,
+			Audience: []string{"test"},
+			Issuer:   "test",
 		},
 	}
 	if exp > 0 {
@@ -199,7 +201,7 @@ func Test_tokenVerifierJWT_Signer(t *testing.T) {
 func Test_tokenVerifierJWT_Valid(t *testing.T) {
 	ruleConfig := rule.DefaultConfig
 	ruleContainer := rule.NewContainer(ruleConfig)
-	verifier := NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, ""}, ruleContainer)
+	verifier := NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, "", "", ""}, ruleContainer)
 	ct, err := verifier.VerifyConnectToken(jwtValid)
 	require.NoError(t, err)
 	require.Equal(t, "2694", ct.UserID)
@@ -207,10 +209,56 @@ func Test_tokenVerifierJWT_Valid(t *testing.T) {
 	require.Equal(t, `{"first_name":"Alexander","last_name":"Emelin"}`, string(ct.Info))
 }
 
+func Test_tokenVerifierJWT_Audience(t *testing.T) {
+	ruleConfig := rule.DefaultConfig
+	ruleContainer := rule.NewContainer(ruleConfig)
+	verifier := NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, "", "test2", ""}, ruleContainer)
+
+	// Token without aud.
+	_, err := verifier.VerifyConnectToken(jwtValid)
+	require.ErrorIs(t, err, ErrInvalidToken)
+
+	// Generate token with aud.
+	token := getRSAConnToken("user", time.Now().Add(time.Hour).Unix(), nil)
+
+	// Verifier with audience which does not match aud in token.
+	verifier = NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, "", "test2", ""}, ruleContainer)
+	_, err = verifier.VerifyConnectToken(token)
+	require.ErrorIs(t, err, ErrInvalidToken)
+
+	// Verifier with token audience.
+	verifier = NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, "", "test", ""}, ruleContainer)
+	_, err = verifier.VerifyConnectToken(token)
+	require.NoError(t, err)
+}
+
+func Test_tokenVerifierJWT_Issuer(t *testing.T) {
+	ruleConfig := rule.DefaultConfig
+	ruleContainer := rule.NewContainer(ruleConfig)
+	verifier := NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, "", "", "test2"}, ruleContainer)
+
+	// Token without iss.
+	_, err := verifier.VerifyConnectToken(jwtValid)
+	require.ErrorIs(t, err, ErrInvalidToken)
+
+	// Generate token with iss.
+	token := getRSAConnToken("user", time.Now().Add(time.Hour).Unix(), nil)
+
+	// Verifier with issuer which does not match token iss.
+	verifier = NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, "", "", "test2"}, ruleContainer)
+	_, err = verifier.VerifyConnectToken(token)
+	require.ErrorIs(t, err, ErrInvalidToken)
+
+	// Verifier with token issuer.
+	verifier = NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, "", "", "test"}, ruleContainer)
+	_, err = verifier.VerifyConnectToken(token)
+	require.NoError(t, err)
+}
+
 func Test_tokenVerifierJWT_Expired(t *testing.T) {
 	ruleConfig := rule.DefaultConfig
 	ruleContainer := rule.NewContainer(ruleConfig)
-	verifier := NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, ""}, ruleContainer)
+	verifier := NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, "", "", ""}, ruleContainer)
 	_, err := verifier.VerifyConnectToken(jwtExpired)
 	require.Error(t, err)
 	require.Equal(t, ErrTokenExpired, err)
@@ -219,7 +267,7 @@ func Test_tokenVerifierJWT_Expired(t *testing.T) {
 func Test_tokenVerifierJWT_DisabledAlgorithm(t *testing.T) {
 	ruleConfig := rule.DefaultConfig
 	ruleContainer := rule.NewContainer(ruleConfig)
-	verifier := NewTokenVerifierJWT(VerifierConfig{"", nil, nil, ""}, ruleContainer)
+	verifier := NewTokenVerifierJWT(VerifierConfig{"", nil, nil, "", "", ""}, ruleContainer)
 	_, err := verifier.VerifyConnectToken(jwtExpired)
 	require.Error(t, err)
 	require.True(t, errors.Is(err, ErrInvalidToken), err.Error())
@@ -228,7 +276,7 @@ func Test_tokenVerifierJWT_DisabledAlgorithm(t *testing.T) {
 func Test_tokenVerifierJWT_InvalidSignature(t *testing.T) {
 	ruleConfig := rule.DefaultConfig
 	ruleContainer := rule.NewContainer(ruleConfig)
-	verifier := NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, ""}, ruleContainer)
+	verifier := NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, "", "", ""}, ruleContainer)
 	_, err := verifier.VerifyConnectToken(jwtInvalidSignature)
 	require.Error(t, err)
 }
@@ -236,7 +284,7 @@ func Test_tokenVerifierJWT_InvalidSignature(t *testing.T) {
 func Test_tokenVerifierJWT_WithNotBefore(t *testing.T) {
 	ruleConfig := rule.DefaultConfig
 	ruleContainer := rule.NewContainer(ruleConfig)
-	verifier := NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, ""}, ruleContainer)
+	verifier := NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, "", "", ""}, ruleContainer)
 	_, err := verifier.VerifyConnectToken(jwtNotBefore)
 	require.Error(t, err)
 }
@@ -244,7 +292,7 @@ func Test_tokenVerifierJWT_WithNotBefore(t *testing.T) {
 func Test_tokenVerifierJWT_StringAudience(t *testing.T) {
 	ruleConfig := rule.DefaultConfig
 	ruleContainer := rule.NewContainer(ruleConfig)
-	verifier := NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, ""}, ruleContainer)
+	verifier := NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, "", "", ""}, ruleContainer)
 	ct, err := verifier.VerifyConnectToken(jwtStringAud)
 	require.NoError(t, err)
 	require.Equal(t, "2694", ct.UserID)
@@ -253,7 +301,7 @@ func Test_tokenVerifierJWT_StringAudience(t *testing.T) {
 func Test_tokenVerifierJWT_ArrayAudience(t *testing.T) {
 	ruleConfig := rule.DefaultConfig
 	ruleContainer := rule.NewContainer(ruleConfig)
-	verifier := NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, ""}, ruleContainer)
+	verifier := NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, "", "", ""}, ruleContainer)
 	ct, err := verifier.VerifyConnectToken(jwtArrayAud)
 	require.NoError(t, err)
 	require.Equal(t, "2694", ct.UserID)
@@ -270,7 +318,7 @@ func Test_tokenVerifierJWT_VerifyConnectToken(t *testing.T) {
 	ruleConfig := rule.DefaultConfig
 	ruleContainer := rule.NewContainer(ruleConfig)
 
-	verifierJWT := NewTokenVerifierJWT(VerifierConfig{"secret", rsaPubKey, ecdsaPubKey, ""}, ruleContainer)
+	verifierJWT := NewTokenVerifierJWT(VerifierConfig{"secret", rsaPubKey, ecdsaPubKey, "", "", ""}, ruleContainer)
 	_time := time.Now()
 	tests := []struct {
 		name     string
@@ -429,7 +477,7 @@ func Test_tokenVerifierJWT_VerifyConnectTokenWithJWK(t *testing.T) {
 			ruleConfig := rule.DefaultConfig
 			ruleContainer := rule.NewContainer(ruleConfig)
 
-			verifier := NewTokenVerifierJWT(VerifierConfig{"", nil, nil, ts.URL}, ruleContainer)
+			verifier := NewTokenVerifierJWT(VerifierConfig{"", nil, nil, ts.URL, "", ""}, ruleContainer)
 			token := getRSAConnToken(tt.token.user, tt.token.exp, privKey, jwt.WithKeyID(tt.jwk.kid))
 
 			got, err := verifier.VerifyConnectToken(token)
@@ -460,7 +508,7 @@ func Test_tokenVerifierJWT_VerifySubscribeToken(t *testing.T) {
 	ruleConfig := rule.DefaultConfig
 	ruleContainer := rule.NewContainer(ruleConfig)
 
-	verifierJWT := NewTokenVerifierJWT(VerifierConfig{"secret", rsaPubKey, ecdsaPubKey, ""}, ruleContainer)
+	verifierJWT := NewTokenVerifierJWT(VerifierConfig{"secret", rsaPubKey, ecdsaPubKey, "", "", ""}, ruleContainer)
 	_time := time.Now()
 	tests := []struct {
 		name     string
@@ -565,7 +613,7 @@ func Test_tokenVerifierJWT_VerifySubscribeToken(t *testing.T) {
 func BenchmarkConnectTokenVerify_Valid(b *testing.B) {
 	ruleConfig := rule.DefaultConfig
 	ruleContainer := rule.NewContainer(ruleConfig)
-	verifierJWT := NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, ""}, ruleContainer)
+	verifierJWT := NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, "", "", ""}, ruleContainer)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_, err := verifierJWT.VerifyConnectToken(jwtValid)
@@ -580,7 +628,7 @@ func BenchmarkConnectTokenVerify_Valid(b *testing.B) {
 func BenchmarkConnectTokenVerify_Expired(b *testing.B) {
 	ruleConfig := rule.DefaultConfig
 	ruleContainer := rule.NewContainer(ruleConfig)
-	verifier := NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, ""}, ruleContainer)
+	verifier := NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, "", "", ""}, ruleContainer)
 	for i := 0; i < b.N; i++ {
 		_, err := verifier.VerifyConnectToken(jwtExpired)
 		if err != ErrTokenExpired {

--- a/main.go
+++ b/main.go
@@ -87,6 +87,8 @@ func bindCentrifugoConfig() {
 		"token_rsa_public_key":       "",
 		"token_ecdsa_public_key":     "",
 		"token_jwks_public_endpoint": "",
+		"token_audience":             "",
+		"token_issuer":               "",
 
 		"protected":                   false,
 		"publish":                     false,
@@ -1188,6 +1190,8 @@ func jwtVerifierConfig() jwtverify.VerifierConfig {
 	}
 
 	cfg.JWKSPublicEndpoint = v.GetString("token_jwks_public_endpoint")
+	cfg.Audience = v.GetString("token_audience")
+	cfg.Issuer = v.GetString("token_issuer")
 
 	return cfg
 }


### PR DESCRIPTION
## Proposed changes

Two new string options `token_issuer` and `token_audience` which when set will enable [aud](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3) and [iss](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.1) JWT checks. 

 
