### PR TITLE
Sending anonymous usage stats

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,9 @@ jobs:
 
       - name: Build DEB and RPM packages
         run: misc/scripts/release_package.sh
+        env:
+          STATS_ENDPOINT: ${{ secrets.STATS_ENDPOINT }}
+          STATS_TOKEN: ${{ secrets.STATS_TOKEN }}
 
       - name: Release on Github
         uses: goreleaser/goreleaser-action@v2
@@ -51,13 +54,10 @@ jobs:
         env:
           # note custom secret here since we need access to Centrifugo Homebrew repo.
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-          UNIX_NOW: ${{ env.UNIX_NOW }}
           STATS_ENDPOINT: ${{ secrets.STATS_ENDPOINT }}
           STATS_TOKEN: ${{ secrets.STATS_TOKEN }}
 
       - name: Release on Packagecloud
         env:
           PACKAGECLOUD_TOKEN: ${{ secrets.PACKAGECLOUD_TOKEN }}
-          STATS_ENDPOINT: ${{ secrets.STATS_ENDPOINT }}
-          STATS_TOKEN: ${{ secrets.STATS_TOKEN }}
         run: misc/scripts/release_packagecloud.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,8 +52,12 @@ jobs:
           # note custom secret here since we need access to Centrifugo Homebrew repo.
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           UNIX_NOW: ${{ env.UNIX_NOW }}
+          STATS_ENDPOINT: ${{ secrets.STATS_ENDPOINT }}
+          STATS_TOKEN: ${{ secrets.STATS_TOKEN }}
 
       - name: Release on Packagecloud
         env:
           PACKAGECLOUD_TOKEN: ${{ secrets.PACKAGECLOUD_TOKEN }}
+          STATS_ENDPOINT: ${{ secrets.STATS_ENDPOINT }}
+          STATS_TOKEN: ${{ secrets.STATS_TOKEN }}
         run: misc/scripts/release_packagecloud.sh

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -50,7 +50,7 @@ builds:
     - goos: freebsd
       goarch: arm64
   main: .
-  ldflags: -s -w -X github.com/centrifugal/centrifugo/v3/internal/build.Version={{.Version}}
+  ldflags: -s -w -X github.com/centrifugal/centrifugo/v3/internal/build.Version={{.Version}} -X github.com/centrifugal/centrifugo/v3/internal/build.UsageStatsEndpoint={{ .Env.STATS_ENDPOINT }} -X github.com/centrifugal/centrifugo/v3/internal/build.UsageStatsToken={{ .Env.STATS_TOKEN }}
   binary: centrifugo
   env:
     # https://github.com/goreleaser/goreleaser/issues/225

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -1,4 +1,10 @@
 package build
 
-// Version of server. Set to tag during release.
+// Version of server. Set to tag in CI during release.
 var Version = "0.0.0"
+
+// UsageStatsEndpoint is where we send stats. Set in CI during release.
+var UsageStatsEndpoint string
+
+// UsageStatsToken used for usage stats request auth. Set in CI during release.
+var UsageStatsToken string

--- a/internal/notify/notify.go
+++ b/internal/notify/notify.go
@@ -1,0 +1,25 @@
+package notify
+
+import (
+	"github.com/centrifugal/centrifuge"
+	"github.com/centrifugal/centrifugo/v3/internal/usage"
+)
+
+func RegisterHandlers(node *centrifuge.Node, statsSender *usage.Sender) {
+	handlers := map[string]centrifuge.NotificationHandler{
+		usage.LastSentUpdateNotificationOp: func(event centrifuge.NotificationEvent) {
+			if statsSender == nil {
+				// Different configurations on different nodes.
+				return
+			}
+			statsSender.UpdateLastSentAt(event.Data)
+		},
+	}
+	node.OnNotification(func(event centrifuge.NotificationEvent) {
+		h, ok := handlers[event.Op]
+		if !ok {
+			return
+		}
+		go h(event)
+	})
+}

--- a/internal/rule/rule.go
+++ b/internal/rule/rule.go
@@ -223,6 +223,13 @@ func (n *Container) ChannelOptions(ch string) (string, ChannelOptions, bool, err
 	return nsName, chOpts, ok, err
 }
 
+// NumNamespaces returns number of configured namespaces.
+func (n *Container) NumNamespaces() int {
+	n.mu.RLock()
+	defer n.mu.RUnlock()
+	return len(n.config.Namespaces)
+}
+
 // channelOpts searches for channel options for specified namespace key.
 func (c *Config) channelOpts(namespaceName string) (ChannelOptions, bool, error) {
 	if namespaceName == "" {
@@ -316,6 +323,13 @@ func (n *Container) RpcOptions(method string) (RpcOptions, bool, error) {
 	n.mu.RLock()
 	defer n.mu.RUnlock()
 	return n.config.rpcOpts(n.rpcNamespaceName(method))
+}
+
+// NumRpcNamespaces returns number of configured rpc namespaces.
+func (n *Container) NumRpcNamespaces() int {
+	n.mu.RLock()
+	defer n.mu.RUnlock()
+	return len(n.config.RpcNamespaces)
 }
 
 // rpcOpts searches for channel options for specified namespace key.

--- a/internal/tntengine/multi_conn.go
+++ b/internal/tntengine/multi_conn.go
@@ -9,15 +9,15 @@ import (
 	"github.com/FZambia/tarantool"
 )
 
-type ConnectionMode int
+type ConnectionMode string
 
 const (
 	// ConnectionModeSingleInstance means single Tarantool (single leader).
-	ConnectionModeSingleInstance ConnectionMode = 0
+	ConnectionModeSingleInstance ConnectionMode = "standalone"
 	// ConnectionModeLeaderFollower means Tarantool with replica and automatic failover configured.
-	ConnectionModeLeaderFollower ConnectionMode = 1
+	ConnectionModeLeaderFollower ConnectionMode = "leader_follower"
 	// ConnectionModeLeaderFollowerRaft means Tarantool with Raft.
-	ConnectionModeLeaderFollowerRaft ConnectionMode = 2
+	ConnectionModeLeaderFollowerRaft ConnectionMode = "leader_follower_raft"
 )
 
 type MultiConnection struct {

--- a/internal/tntengine/multi_conn.go
+++ b/internal/tntengine/multi_conn.go
@@ -160,7 +160,9 @@ func (c *MultiConnection) IsLeader(conn *tarantool.Connection) (bool, error) {
 func (c *MultiConnection) checkLeaderOnce() bool {
 	for addr, conn := range c.conns {
 		if len(c.conns) == 1 {
+			c.leaderMu.Lock()
 			c.leaderAddr = addr
+			c.leaderMu.Unlock()
 			return true
 		}
 		isLeader, err := c.IsLeader(conn)

--- a/internal/usage/metric.go
+++ b/internal/usage/metric.go
@@ -1,0 +1,42 @@
+package usage
+
+import (
+	"bytes"
+	"crypto/md5"
+	"fmt"
+	"sort"
+)
+
+// MetricData contains all metric metadata (some as fields, some as tags) and a datapoint
+type MetricData struct {
+	Id       string   `json:"id"`
+	OrgId    int      `json:"org_id"`
+	Name     string   `json:"name"`
+	Metric   string   `json:"metric"`
+	Interval int      `json:"interval"`
+	Value    float64  `json:"value"`
+	Unit     string   `json:"unit"`
+	Time     int64    `json:"time"`
+	Type     string   `json:"mtype"`
+	Tags     []string `json:"tags"`
+}
+
+func (m *MetricData) SetId() {
+	sort.Strings(m.Tags)
+
+	buffer := bytes.NewBufferString(m.Metric)
+	buffer.WriteByte(0)
+	buffer.WriteString(m.Unit)
+	buffer.WriteByte(0)
+	buffer.WriteString(m.Type)
+	buffer.WriteByte(0)
+	_, _ = fmt.Fprintf(buffer, "%d", m.Interval)
+
+	for _, k := range m.Tags {
+		buffer.WriteByte(0)
+		buffer.WriteString(k)
+	}
+	m.Id = fmt.Sprintf("%d.%x", m.OrgId, md5.Sum(buffer.Bytes()))
+}
+
+type MetricDataArray []*MetricData

--- a/internal/usage/metric.go
+++ b/internal/usage/metric.go
@@ -7,8 +7,8 @@ import (
 	"sort"
 )
 
-// MetricData contains all metric metadata (some as fields, some as tags) and a datapoint
-type MetricData struct {
+// metric represents stats point.
+type metric struct {
 	Id       string   `json:"id"`
 	OrgId    int      `json:"org_id"`
 	Name     string   `json:"name"`
@@ -21,7 +21,7 @@ type MetricData struct {
 	Tags     []string `json:"tags"`
 }
 
-func (m *MetricData) SetId() {
+func (m *metric) SetId() {
 	sort.Strings(m.Tags)
 
 	buffer := bytes.NewBufferString(m.Metric)
@@ -38,5 +38,3 @@ func (m *MetricData) SetId() {
 	}
 	m.Id = fmt.Sprintf("%d.%x", m.OrgId, md5.Sum(buffer.Bytes()))
 }
-
-type MetricDataArray []*MetricData

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -1,0 +1,507 @@
+package usage
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"math/rand"
+	"net/http"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/centrifugal/centrifugo/v3/internal/build"
+	"github.com/centrifugal/centrifugo/v3/internal/rule"
+
+	"github.com/centrifugal/centrifuge"
+)
+
+var statsRand *rand.Rand
+
+var initialDelay time.Duration
+var tickInterval time.Duration
+var sendInterval time.Duration
+var metricsPrefix string
+
+func init() {
+	statsRand = rand.New(rand.NewSource(time.Now().Unix()))
+
+	// Initial delay in between 24-48h. Using minute resolution here
+	// is intentional to get a better time spread.
+	initialDelay = time.Duration(statsRand.Intn(24*60)+24*60) * time.Minute
+	tickInterval = time.Hour
+	sendInterval = 24 * time.Hour
+	metricsPrefix = "centrifugo."
+
+	// Uncomment during development (for faster timings and test prefix).
+	//initialDelay = time.Duration(statsRand.Intn(30)+1) * time.Second
+	//tickInterval = 10 * time.Second
+	//sendInterval = time.Minute
+	//metricsPrefix = "test."
+}
+
+// Sender can send anonymous usage stats.
+type Sender struct {
+	mu             sync.RWMutex
+	node           *centrifuge.Node
+	rules          *rule.Container
+	features       Features
+	maxNumNodes    int
+	maxNumClients  int
+	maxNumChannels int
+	lastSentAt     int64
+}
+
+type Features struct {
+	// Build info.
+	Version string
+	Edition string
+
+	// Engine used.
+	Engine string
+
+	// Transports.
+	Websocket     bool
+	HTTPStream    bool
+	SSE           bool
+	SockJS        bool
+	UniWebsocket  bool
+	UniGRPC       bool
+	UniSSE        bool
+	UniHTTPStream bool
+
+	// Proxies.
+	ConnectProxy   bool
+	RefreshProxy   bool
+	SubscribeProxy bool
+	PublishProxy   bool
+	RPCProxy       bool
+
+	// Uses GRPC server API.
+	GrpcAPI bool
+
+	// PRO features.
+	Clickhouse        bool
+	UserStatus        bool
+	Throttling        bool
+	UserBlocking      bool
+	TokenRevoking     bool
+	TokenInvalidation bool
+	Singleflight      bool
+}
+
+// NewSender creates usage stats sender.
+func NewSender(node *centrifuge.Node, rules *rule.Container, features Features) *Sender {
+	return &Sender{
+		node:     node,
+		rules:    rules,
+		features: features,
+	}
+}
+
+const (
+	// LastSentUpdateNotificationOp is an op for Centrifuge Notification in which we
+	// send last sent time to all nodes.
+	LastSentUpdateNotificationOp = "usage_stats.last_sent_at"
+)
+
+func (s *Sender) isDev() bool {
+	return s.features.Version == "0.0.0"
+}
+
+// Start sending usage stats. How it works:
+// First send in between 24-48h from node start.
+// After the initial delay has passed: every hour check last time stats were sent by all
+// the nodes in a Centrifugo cluster. If no points were sent in last 24h, then push metrics
+// and update push time on all nodes (broadcast current time). There is still a chance of
+// duplicate data sending – but should be rare and tolerable for the purpose.
+func (s *Sender) Start(ctx context.Context) {
+	firstTimeSend := time.Now().Add(initialDelay)
+	if s.isDev() {
+		s.node.Log(centrifuge.NewLogEntry(centrifuge.LogLevelDebug, "schedule next send", map[string]interface{}{"delay": fmt.Sprintf("%s", initialDelay)}))
+	}
+
+	// Wait half of a delay to randomize hourly ticks on different nodes.
+	select {
+	case <-ctx.Done():
+		return
+	case <-time.After(initialDelay / 2):
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(tickInterval):
+			if s.isDev() {
+				s.node.Log(centrifuge.NewLogEntry(centrifuge.LogLevelDebug, "updating max values", map[string]interface{}{}))
+			}
+			_ = s.updateMaxValues()
+
+			if time.Now().Before(firstTimeSend) {
+				if s.isDev() {
+					s.node.Log(centrifuge.NewLogEntry(centrifuge.LogLevelDebug, "too early to send first time", map[string]interface{}{}))
+				}
+				continue
+			}
+
+			s.mu.RLock()
+			lastSentAt := s.lastSentAt
+			s.mu.RUnlock()
+			if lastSentAt > 0 {
+				s.broadcastLastSentAt()
+			}
+
+			if lastSentAt > 0 && time.Now().Unix() <= lastSentAt+int64(sendInterval.Seconds()) {
+				if s.isDev() {
+					s.node.Log(centrifuge.NewLogEntry(centrifuge.LogLevelDebug, "too early to send", map[string]interface{}{}))
+				}
+				continue
+			}
+
+			if s.isDev() {
+				s.node.Log(centrifuge.NewLogEntry(centrifuge.LogLevelDebug, "sending usage stats", map[string]interface{}{}))
+			}
+			err := s.sendUsageStats()
+			if err != nil {
+				if s.isDev() {
+					s.node.Log(centrifuge.NewLogEntry(centrifuge.LogLevelError, "error sending usage stats", map[string]interface{}{"error": err.Error()}))
+				}
+				continue
+			}
+			s.mu.Lock()
+			s.lastSentAt = time.Now().Unix()
+			s.mu.Unlock()
+			s.broadcastLastSentAt()
+		}
+	}
+}
+
+type LastSentAtEnvelope struct {
+	LastSentAt int64 `json:"lastSentAt"`
+}
+
+func (s *Sender) broadcastLastSentAt() {
+	s.mu.RLock()
+	envelope := LastSentAtEnvelope{
+		LastSentAt: s.lastSentAt,
+	}
+	data, _ := json.Marshal(envelope)
+	s.mu.RUnlock()
+	err := s.node.Notify(LastSentUpdateNotificationOp, data, "")
+	if err != nil {
+		s.node.Log(centrifuge.NewLogEntry(centrifuge.LogLevelError, "error broadcasting stats lastSentAt", map[string]interface{}{"error": err.Error()}))
+	}
+}
+
+func (s *Sender) UpdateLastSentAt(data []byte) {
+	var envelope LastSentAtEnvelope
+	err := json.Unmarshal(data, &envelope)
+	if err != nil {
+		s.node.Log(centrifuge.NewLogEntry(centrifuge.LogLevelError, "error decoding LastSentAtEnvelope", map[string]interface{}{"error": err.Error()}))
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if envelope.LastSentAt > s.lastSentAt {
+		if s.isDev() {
+			s.node.Log(centrifuge.NewLogEntry(centrifuge.LogLevelDebug, "updating stats last sent", map[string]interface{}{}))
+		}
+		s.lastSentAt = envelope.LastSentAt
+	}
+}
+
+func (s *Sender) updateMaxValues() error {
+	info, err := s.node.Info()
+	if err != nil {
+		return fmt.Errorf("error getting info: %w", err)
+	}
+
+	numNodes := len(info.Nodes)
+
+	numClients := 0
+	for _, node := range info.Nodes {
+		numClients += int(node.NumClients)
+	}
+
+	numChannels := 0
+	for _, node := range info.Nodes {
+		numChannels += int(node.NumChannels)
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if numNodes > s.maxNumNodes {
+		s.maxNumNodes = numNodes
+	}
+
+	if numClients > s.maxNumClients {
+		s.maxNumClients = numClients
+	}
+
+	if numChannels > s.maxNumChannels {
+		s.maxNumChannels = numChannels
+	}
+
+	return nil
+}
+
+func getHistogramMetric(val int, bounds []int, metricPrefix string) string {
+	for _, bound := range bounds {
+		if val <= bound {
+			boundStr := strconv.Itoa(bound)
+			if strings.HasSuffix(boundStr, "000000") {
+				boundStr = strings.TrimSuffix(boundStr, "000000")
+				boundStr += "m"
+			} else if strings.HasSuffix(boundStr, "000") {
+				boundStr = strings.TrimSuffix(boundStr, "000")
+				boundStr += "k"
+			}
+			return metricPrefix + "le_" + boundStr
+		}
+	}
+	return metricPrefix + "le_inf"
+}
+
+func (s *Sender) sendUsageStats() error {
+	now := time.Now().Unix()
+
+	// createPoint creates a datapoint, i.e. a MetricData structure, and makes sure the id is set.
+	createPoint := func(name string) *MetricData {
+		md := MetricData{
+			Name:     metricsPrefix + name,
+			Metric:   metricsPrefix + name,
+			Interval: int(sendInterval.Seconds()),
+			Value:    1,
+			Time:     now,
+			Type:     "count",
+		}
+		md.SetId()
+		return &md
+	}
+
+	metrics := MetricDataArray{}
+
+	metrics = append(metrics, createPoint("stats.reports.total"))
+	metrics = append(metrics, createPoint("stats.version."+strings.Replace(s.features.Version, ".", "_", -1)))
+	metrics = append(metrics, createPoint("stats.edition."+strings.ToLower(s.features.Edition)))
+	metrics = append(metrics, createPoint("stats.arch."+runtime.GOOS+"_"+runtime.GOARCH))
+	metrics = append(metrics, createPoint("stats.engine."+s.features.Engine))
+
+	if s.features.Websocket {
+		metrics = append(metrics, createPoint("stats.transports_enabled.websocket"))
+	}
+	if s.features.HTTPStream {
+		metrics = append(metrics, createPoint("stats.transports_enabled.http_stream"))
+	}
+	if s.features.SSE {
+		metrics = append(metrics, createPoint("stats.transports_enabled.sse"))
+	}
+	if s.features.SockJS {
+		metrics = append(metrics, createPoint("stats.transports_enabled.sockjs"))
+	}
+	if s.features.UniWebsocket {
+		metrics = append(metrics, createPoint("stats.transports_enabled.uni_websocket"))
+	}
+	if s.features.UniHTTPStream {
+		metrics = append(metrics, createPoint("stats.transports_enabled.uni_http_stream"))
+	}
+	if s.features.UniSSE {
+		metrics = append(metrics, createPoint("stats.transports_enabled.uni_sse"))
+	}
+	if s.features.UniGRPC {
+		metrics = append(metrics, createPoint("stats.transports_enabled.uni_grpc"))
+	}
+	if s.features.ConnectProxy {
+		metrics = append(metrics, createPoint("stats.proxies_enabled.connect"))
+	}
+	if s.features.RefreshProxy {
+		metrics = append(metrics, createPoint("stats.proxies_enabled.refresh"))
+	}
+	if s.features.SubscribeProxy {
+		metrics = append(metrics, createPoint("stats.proxies_enabled.subscribe"))
+	}
+	if s.features.PublishProxy {
+		metrics = append(metrics, createPoint("stats.proxies_enabled.publish"))
+	}
+	if s.features.RPCProxy {
+		metrics = append(metrics, createPoint("stats.proxies_enabled.rpc"))
+	}
+	if s.features.GrpcAPI {
+		metrics = append(metrics, createPoint("stats.features_enabled.grpc_api"))
+	}
+	if s.features.Clickhouse {
+		metrics = append(metrics, createPoint("stats.features_enabled.clickhouse"))
+	}
+	if s.features.UserStatus {
+		metrics = append(metrics, createPoint("stats.features_enabled.user_status"))
+	}
+	if s.features.Throttling {
+		metrics = append(metrics, createPoint("stats.features_enabled.throttling"))
+	}
+	if s.features.UserBlocking {
+		metrics = append(metrics, createPoint("stats.features_enabled.user_blocking"))
+	}
+	if s.features.TokenRevoking {
+		metrics = append(metrics, createPoint("stats.features_enabled.token_revoking"))
+	}
+	if s.features.TokenInvalidation {
+		metrics = append(metrics, createPoint("stats.features_enabled.user_token_invalidation"))
+	}
+	if s.features.Singleflight {
+		metrics = append(metrics, createPoint("stats.features_enabled.singleflight"))
+	}
+
+	var usesHistory bool
+	var usesPresence bool
+	var usesJoinLeave bool
+
+	namespaces := s.rules.Config().Namespaces
+	chOpts := s.rules.Config().ChannelOptions
+	if chOpts.HistoryTTL > 0 && chOpts.HistorySize > 0 {
+		usesHistory = true
+	}
+	if chOpts.Presence {
+		usesPresence = true
+	}
+	if chOpts.JoinLeave {
+		usesJoinLeave = true
+	}
+	for _, ns := range namespaces {
+		chOpts = ns.ChannelOptions
+		if chOpts.HistoryTTL > 0 && chOpts.HistorySize > 0 {
+			usesHistory = true
+		}
+		if chOpts.Presence {
+			usesPresence = true
+		}
+		if chOpts.JoinLeave {
+			usesJoinLeave = true
+		}
+	}
+
+	if usesHistory {
+		metrics = append(metrics, createPoint("stats.features_enabled.history"))
+	}
+	if usesPresence {
+		metrics = append(metrics, createPoint("stats.features_enabled.presence"))
+	}
+	if usesJoinLeave {
+		metrics = append(metrics, createPoint("stats.features_enabled.join_leave"))
+	}
+
+	numNamespaces := s.rules.NumNamespaces()
+	numRpcNamespaces := s.rules.NumRpcNamespaces()
+
+	s.mu.RLock()
+	numNodesMetric := getHistogramMetric(
+		s.maxNumNodes,
+		[]int{1, 2, 3, 5, 10, 20, 50, 100, 200, 500, 1000, 2000, 5000},
+		"stats.num_nodes.",
+	)
+	metrics = append(metrics, createPoint(numNodesMetric))
+
+	numClientsMetric := getHistogramMetric(
+		s.maxNumClients,
+		[]int{
+			0, 5, 10, 100, 1000, 10000, 50000, 100000,
+			500000, 1000000, 5000000, 10000000, 50000000,
+			100000000,
+		},
+		"stats.num_clients.",
+	)
+	metrics = append(metrics, createPoint(numClientsMetric))
+
+	numChannelsMetric := getHistogramMetric(
+		s.maxNumChannels,
+		[]int{
+			0, 5, 10, 100, 1000, 10000, 50000, 100000,
+			500000, 1000000, 5000000, 10000000, 50000000,
+			100000000,
+		},
+		"stats.num_channels.",
+	)
+	metrics = append(metrics, createPoint(numChannelsMetric))
+	s.mu.RUnlock()
+
+	numNamespacesMetric := getHistogramMetric(
+		numNamespaces,
+		[]int{0, 1, 2, 5, 10, 50, 100, 500, 1000},
+		"stats.num_namespaces.",
+	)
+	metrics = append(metrics, createPoint(numNamespacesMetric))
+
+	numRpcNamespacesMetric := getHistogramMetric(
+		numRpcNamespaces,
+		[]int{0, 1, 2, 5, 10, 50, 100, 500, 1000},
+		"stats.num_rpc_namespaces.",
+	)
+	metrics = append(metrics, createPoint(numRpcNamespacesMetric))
+
+	data, err := json.Marshal(metrics)
+	if err != nil {
+		return err
+	}
+
+	if s.isDev() {
+		s.node.Log(centrifuge.NewLogEntry(centrifuge.LogLevelDebug, "sending usage stats", map[string]interface{}{"payload": string(data)}))
+	} else {
+		s.node.Log(centrifuge.NewLogEntry(centrifuge.LogLevelTrace, "sending usage stats", map[string]interface{}{"payload": string(data)}))
+	}
+
+	client := &http.Client{
+		Timeout: 60 * time.Second,
+	}
+
+	statsEndpoints := build.UsageStatsEndpoint
+	if statsEndpoints == "" {
+		return nil
+	}
+
+	statsToken := build.UsageStatsToken
+	if statsToken == "" {
+		return nil
+	}
+
+	endpoints := strings.Split(statsEndpoints, ",")
+
+	for _, endpoint := range endpoints {
+		if endpoint == "" {
+			continue
+		}
+
+		req, err := http.NewRequest("POST", endpoint, bytes.NewBuffer(data))
+		if err != nil {
+			if s.isDev() {
+				s.node.Log(centrifuge.NewLogEntry(centrifuge.LogLevelDebug, "can't create stats request", map[string]interface{}{"error": err.Error()}))
+			}
+			continue
+		}
+
+		req.Header.Add("Authorization", "Bearer "+statsToken)
+		req.Header.Add("Content-Type", "application/json")
+		resp, err := client.Do(req)
+		if err != nil {
+			if s.isDev() {
+				s.node.Log(centrifuge.NewLogEntry(centrifuge.LogLevelDebug, "error sending stats request", map[string]interface{}{"error": err.Error()}))
+			}
+			continue
+		}
+		_, _ = io.Copy(ioutil.Discard, resp.Body)
+		_ = resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			if s.isDev() {
+				s.node.Log(centrifuge.NewLogEntry(centrifuge.LogLevelDebug, "unexpected stats response status code", map[string]interface{}{"status": resp.StatusCode}))
+			}
+		}
+	}
+
+	return nil
+}

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -93,13 +93,13 @@ type Features struct {
 	SubscribeToPersonal bool
 
 	// PRO features.
-	Clickhouse        bool
-	UserStatus        bool
-	Throttling        bool
-	UserBlocking      bool
-	TokenRevoking     bool
-	TokenInvalidation bool
-	Singleflight      bool
+	ClickhouseAnalytics bool
+	UserStatus          bool
+	Throttling          bool
+	UserBlocking        bool
+	TokenRevoking       bool
+	TokenInvalidation   bool
+	Singleflight        bool
 }
 
 // NewSender creates usage stats sender.
@@ -365,7 +365,7 @@ func (s *Sender) prepareMetrics() []*metric {
 	if s.features.Admin {
 		metrics = append(metrics, createPoint("stats.features_enabled.admin_ui"))
 	}
-	if s.features.Clickhouse {
+	if s.features.ClickhouseAnalytics {
 		metrics = append(metrics, createPoint("stats.features_enabled.clickhouse_analytics"))
 	}
 	if s.features.UserStatus {
@@ -494,11 +494,17 @@ func (s *Sender) sendUsageStats() error {
 
 	statsEndpoints := build.UsageStatsEndpoint
 	if statsEndpoints == "" {
+		if s.isDev() {
+			s.node.Log(centrifuge.NewLogEntry(centrifuge.LogLevelDebug, "usage stats: skip sending due to empty endpoint", map[string]interface{}{}))
+		}
 		return nil
 	}
 
 	statsToken := build.UsageStatsToken
 	if statsToken == "" {
+		if s.isDev() {
+			s.node.Log(centrifuge.NewLogEntry(centrifuge.LogLevelDebug, "usage stats: skip sending due to empty token", map[string]interface{}{}))
+		}
 		return nil
 	}
 

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -279,7 +279,7 @@ func getHistogramMetric(val int, bounds []int, metricPrefix string) string {
 	return metricPrefix + "le_inf"
 }
 
-func (s *Sender) sendUsageStats() error {
+func (s *Sender) prepareMetrics() MetricDataArray {
 	now := time.Now().Unix()
 
 	// createPoint creates a datapoint, i.e. a MetricData structure, and makes sure the id is set.
@@ -463,7 +463,11 @@ func (s *Sender) sendUsageStats() error {
 		"stats.num_rpc_namespaces.",
 	)
 	metrics = append(metrics, createPoint(numRpcNamespacesMetric))
+	return metrics
+}
 
+func (s *Sender) sendUsageStats() error {
+	metrics := s.prepareMetrics()
 	data, err := json.Marshal(metrics)
 	if err != nil {
 		return err

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -130,7 +130,7 @@ func (s *Sender) isDev() bool {
 func (s *Sender) Start(ctx context.Context) {
 	firstTimeSend := time.Now().Add(initialDelay)
 	if s.isDev() {
-		s.node.Log(centrifuge.NewLogEntry(centrifuge.LogLevelDebug, "schedule next send", map[string]interface{}{"delay": fmt.Sprintf("%s", initialDelay)}))
+		s.node.Log(centrifuge.NewLogEntry(centrifuge.LogLevelDebug, "schedule next send", map[string]interface{}{"delay": initialDelay.String()}))
 	}
 
 	// Wait half of a delay to randomize hourly ticks on different nodes.

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -562,8 +562,9 @@ func (s *Sender) sendUsageStats() error {
 			if s.isDev() {
 				s.node.Log(centrifuge.NewLogEntry(centrifuge.LogLevelDebug, "usage stats: unexpected response status code", map[string]interface{}{"status": resp.StatusCode}))
 			}
+			continue
 		}
-		// At least one of the endpoints received data.
+		// If at least one of the endpoints received data it means success for us.
 		success = true
 	}
 

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -514,6 +515,8 @@ func (s *Sender) sendUsageStats() error {
 
 	endpoints := strings.Split(statsEndpoints, ",")
 
+	var success bool
+
 	for _, endpoint := range endpoints {
 		if endpoint == "" {
 			continue
@@ -544,6 +547,12 @@ func (s *Sender) sendUsageStats() error {
 				s.node.Log(centrifuge.NewLogEntry(centrifuge.LogLevelDebug, "usage stats: unexpected response status code", map[string]interface{}{"status": resp.StatusCode}))
 			}
 		}
+		// At least one of the endpoints received data.
+		success = true
+	}
+
+	if !success {
+		return errors.New("all endpoints failed")
 	}
 
 	return nil

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -130,14 +130,18 @@ func (s *Sender) isDev() bool {
 func (s *Sender) Start(ctx context.Context) {
 	firstTimeSend := time.Now().Add(initialDelay)
 	if s.isDev() {
-		s.node.Log(centrifuge.NewLogEntry(centrifuge.LogLevelDebug, "schedule next send", map[string]interface{}{"delay": initialDelay.String()}))
+		s.node.Log(centrifuge.NewLogEntry(centrifuge.LogLevelDebug, "usage stats: schedule next send", map[string]interface{}{"delay": initialDelay.String()}))
 	}
 
-	// Wait half of a delay to randomize hourly ticks on different nodes.
+	// Wait 1/4 of a delay to randomize hourly ticks on different nodes.
 	select {
 	case <-ctx.Done():
 		return
-	case <-time.After(initialDelay / 2):
+	case <-time.After(initialDelay / 4):
+	}
+
+	if s.isDev() {
+		s.node.Log(centrifuge.NewLogEntry(centrifuge.LogLevelDebug, "usage stats: start periodic ticks", map[string]interface{}{}))
 	}
 
 	for {

--- a/internal/usage/usage_test.go
+++ b/internal/usage/usage_test.go
@@ -1,0 +1,50 @@
+package usage
+
+import "testing"
+
+func Test_getHistogramMetric(t *testing.T) {
+	type args struct {
+		val          int
+		bounds       []int
+		metricPrefix string
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			"1",
+			args{0, []int{0, 10, 100, 1000, 10000, 100000}, "users."},
+			"users.le_0",
+		},
+		{
+			"2",
+			args{10, []int{0, 10, 100, 1000, 10000, 100000}, "users."},
+			"users.le_10",
+		},
+		{
+			"3",
+			args{30000, []int{0, 10, 100, 1000, 10000, 100000}, "users."},
+			"users.le_100k",
+		},
+		{
+			"4",
+			args{3000000, []int{0, 10, 100, 1000, 10000, 100000, 10000000}, "users."},
+			"users.le_10m",
+		},
+		{
+			"5",
+			args{300000, []int{0, 10, 100, 1000, 10000, 100000}, "users."},
+			"users.le_inf",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getHistogramMetric(tt.args.val, tt.args.bounds, tt.args.metricPrefix); got != tt.want {
+				t.Errorf("getHistogramMetric() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -362,12 +362,14 @@ func main() {
 			var broker centrifuge.Broker
 			var presenceManager centrifuge.PresenceManager
 
+			var engineMode string
+
 			if engineName == "memory" {
-				broker, presenceManager, err = memoryEngine(node)
+				broker, presenceManager, engineMode, err = memoryEngine(node)
 			} else if engineName == "redis" {
-				broker, presenceManager, err = redisEngine(node)
+				broker, presenceManager, engineMode, err = redisEngine(node)
 			} else if engineName == "tarantool" {
-				broker, presenceManager, err = tarantoolEngine(node)
+				broker, presenceManager, engineMode, err = tarantoolEngine(node)
 			} else {
 				log.Fatal().Msgf("unknown engine: %s", engineName)
 			}
@@ -546,10 +548,12 @@ func main() {
 			var statsSender *usage.Sender
 			if !viper.GetBool("anonymous_stats_disable") {
 				statsSender = usage.NewSender(node, ruleContainer, usage.Features{
-					Edition: edition,
-					Version: build.Version,
-					Engine:  engineName,
-					Broker:  brokerName,
+					Edition:    edition,
+					Version:    build.Version,
+					Engine:     engineName,
+					EngineMode: engineMode,
+					Broker:     brokerName,
+					BrokerMode: "",
 
 					Websocket:     !viper.GetBool("websocket_disable"),
 					HTTPStream:    viper.GetBool("http_stream"),
@@ -1776,24 +1780,24 @@ func adminHandlerConfig() admin.Config {
 	return cfg
 }
 
-func memoryEngine(n *centrifuge.Node) (centrifuge.Broker, centrifuge.PresenceManager, error) {
+func memoryEngine(n *centrifuge.Node) (centrifuge.Broker, centrifuge.PresenceManager, string, error) {
 	brokerConf, err := memoryBrokerConfig()
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, "", err
 	}
 	broker, err := centrifuge.NewMemoryBroker(n, *brokerConf)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, "", err
 	}
 	presenceManagerConf, err := memoryPresenceManagerConfig()
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, "", err
 	}
 	presenceManager, err := centrifuge.NewMemoryPresenceManager(n, *presenceManagerConf)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, "", err
 	}
-	return broker, presenceManager, nil
+	return broker, presenceManager, "", nil
 }
 
 func memoryBrokerConfig() (*centrifuge.MemoryBrokerConfig, error) {
@@ -1818,7 +1822,7 @@ func addRedisShardCommonSettings(shardConf *centrifuge.RedisShardConfig) {
 	shardConf.WriteTimeout = GetDuration("redis_write_timeout")
 }
 
-func getRedisShardConfigs() ([]centrifuge.RedisShardConfig, error) {
+func getRedisShardConfigs() ([]centrifuge.RedisShardConfig, string, error) {
 	var shardConfigs []centrifuge.RedisShardConfig
 
 	clusterShards := viper.GetStringSlice("redis_cluster_address")
@@ -1832,7 +1836,7 @@ func getRedisShardConfigs() ([]centrifuge.RedisShardConfig, error) {
 			clusterAddresses := strings.Split(clusterAddress, ",")
 			for _, address := range clusterAddresses {
 				if _, _, err := net.SplitHostPort(address); err != nil {
-					return nil, fmt.Errorf("malformed Redis Cluster address: %s", address)
+					return nil, "", fmt.Errorf("malformed Redis Cluster address: %s", address)
 				}
 			}
 			conf := &centrifuge.RedisShardConfig{
@@ -1841,7 +1845,7 @@ func getRedisShardConfigs() ([]centrifuge.RedisShardConfig, error) {
 			addRedisShardCommonSettings(conf)
 			shardConfigs = append(shardConfigs, *conf)
 		}
-		return shardConfigs, nil
+		return shardConfigs, "cluster", nil
 	}
 
 	sentinelShards := viper.GetStringSlice("redis_sentinel_address")
@@ -1855,7 +1859,7 @@ func getRedisShardConfigs() ([]centrifuge.RedisShardConfig, error) {
 			sentinelAddresses := strings.Split(sentinelAddress, ",")
 			for _, address := range sentinelAddresses {
 				if _, _, err := net.SplitHostPort(address); err != nil {
-					return nil, fmt.Errorf("malformed Redis Sentinel address: %s", address)
+					return nil, "", fmt.Errorf("malformed Redis Sentinel address: %s", address)
 				}
 			}
 			conf := &centrifuge.RedisShardConfig{
@@ -1866,11 +1870,11 @@ func getRedisShardConfigs() ([]centrifuge.RedisShardConfig, error) {
 			conf.SentinelPassword = viper.GetString("redis_sentinel_password")
 			conf.SentinelMasterName = viper.GetString("redis_sentinel_master_name")
 			if conf.SentinelMasterName == "" {
-				return nil, fmt.Errorf("master name must be set when using Redis Sentinel")
+				return nil, "", fmt.Errorf("master name must be set when using Redis Sentinel")
 			}
 			shardConfigs = append(shardConfigs, *conf)
 		}
-		return shardConfigs, nil
+		return shardConfigs, "sentinel", nil
 	}
 
 	redisAddresses := viper.GetStringSlice("redis_address")
@@ -1884,30 +1888,36 @@ func getRedisShardConfigs() ([]centrifuge.RedisShardConfig, error) {
 		addRedisShardCommonSettings(conf)
 		shardConfigs = append(shardConfigs, *conf)
 	}
-	return shardConfigs, nil
+
+	return shardConfigs, "standalone", nil
 }
 
-func getRedisShards(n *centrifuge.Node) ([]*centrifuge.RedisShard, error) {
-	redisShardConfigs, err := getRedisShardConfigs()
+func getRedisShards(n *centrifuge.Node) ([]*centrifuge.RedisShard, string, error) {
+	redisShardConfigs, mode, err := getRedisShardConfigs()
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	redisShards := make([]*centrifuge.RedisShard, 0, len(redisShardConfigs))
 
 	for _, redisConf := range redisShardConfigs {
 		redisShard, err := centrifuge.NewRedisShard(n, redisConf)
 		if err != nil {
-			return nil, err
+			return nil, "", err
 		}
 		redisShards = append(redisShards, redisShard)
 	}
-	return redisShards, nil
+
+	if len(redisShards) > 1 {
+		mode += "_sharded"
+	}
+
+	return redisShards, mode, nil
 }
 
-func redisEngine(n *centrifuge.Node) (centrifuge.Broker, centrifuge.PresenceManager, error) {
-	redisShards, err := getRedisShards(n)
+func redisEngine(n *centrifuge.Node) (centrifuge.Broker, centrifuge.PresenceManager, string, error) {
+	redisShards, mode, err := getRedisShards(n)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, "", err
 	}
 
 	broker, err := centrifuge.NewRedisBroker(n, centrifuge.RedisBrokerConfig{
@@ -1917,7 +1927,7 @@ func redisEngine(n *centrifuge.Node) (centrifuge.Broker, centrifuge.PresenceMana
 		HistoryMetaTTL: GetDuration("history_meta_ttl", true),
 	})
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, "", err
 	}
 
 	presenceManager, err := centrifuge.NewRedisPresenceManager(n, centrifuge.RedisPresenceManagerConfig{
@@ -1926,13 +1936,13 @@ func redisEngine(n *centrifuge.Node) (centrifuge.Broker, centrifuge.PresenceMana
 		PresenceTTL: GetDuration("presence_ttl", true),
 	})
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, "", err
 	}
 
-	return broker, presenceManager, nil
+	return broker, presenceManager, mode, nil
 }
 
-func getTarantoolShardConfigs() ([]tntengine.ShardConfig, error) {
+func getTarantoolShardConfigs() ([]tntengine.ShardConfig, string, error) {
 	var shardConfigs []tntengine.ShardConfig
 
 	mode := tntengine.ConnectionModeSingleInstance
@@ -1945,7 +1955,7 @@ func getTarantoolShardConfigs() ([]tntengine.ShardConfig, error) {
 		case "leader-follower-raft":
 			mode = tntengine.ConnectionModeLeaderFollowerRaft
 		default:
-			return nil, fmt.Errorf("unknown Tarantool mode: %s", viper.GetString("tarantool_mode"))
+			return nil, "", fmt.Errorf("unknown Tarantool mode: %s", viper.GetString("tarantool_mode"))
 		}
 	}
 
@@ -1965,46 +1975,51 @@ func getTarantoolShardConfigs() ([]tntengine.ShardConfig, error) {
 		}
 		shardConfigs = append(shardConfigs, *conf)
 	}
-	return shardConfigs, nil
+	return shardConfigs, string(mode), nil
 }
 
-func getTarantoolShards() ([]*tntengine.Shard, error) {
-	tarantoolShardConfigs, err := getTarantoolShardConfigs()
+func getTarantoolShards() ([]*tntengine.Shard, string, error) {
+	tarantoolShardConfigs, mode, err := getTarantoolShardConfigs()
 	if err != nil {
-		return nil, err
+		return nil, mode, err
 	}
 	tarantoolShards := make([]*tntengine.Shard, 0, len(tarantoolShardConfigs))
 
 	for _, tarantoolConf := range tarantoolShardConfigs {
 		tarantoolShard, err := tntengine.NewShard(tarantoolConf)
 		if err != nil {
-			return nil, err
+			return nil, mode, err
 		}
 		tarantoolShards = append(tarantoolShards, tarantoolShard)
 	}
-	return tarantoolShards, nil
+
+	if len(tarantoolShards) > 1 {
+		mode += "_sharded"
+	}
+
+	return tarantoolShards, mode, nil
 }
 
-func tarantoolEngine(n *centrifuge.Node) (centrifuge.Broker, centrifuge.PresenceManager, error) {
-	tarantoolShards, err := getTarantoolShards()
+func tarantoolEngine(n *centrifuge.Node) (centrifuge.Broker, centrifuge.PresenceManager, string, error) {
+	tarantoolShards, mode, err := getTarantoolShards()
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, "", err
 	}
 	broker, err := tntengine.NewBroker(n, tntengine.BrokerConfig{
 		Shards:         tarantoolShards,
 		HistoryMetaTTL: GetDuration("history_meta_ttl", true),
 	})
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, "", err
 	}
 	presenceManager, err := tntengine.NewPresenceManager(n, tntengine.PresenceManagerConfig{
 		Shards:      tarantoolShards,
 		PresenceTTL: GetDuration("presence_ttl", true),
 	})
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, "", err
 	}
-	return broker, presenceManager, nil
+	return broker, presenceManager, mode, nil
 }
 
 type logHandler struct {

--- a/main.go
+++ b/main.go
@@ -548,6 +548,7 @@ func main() {
 					Edition: "OSS",
 					Version: build.Version,
 					Engine:  engineName,
+					Broker:  brokerName,
 
 					Websocket:     !viper.GetBool("websocket_disable"),
 					HTTPStream:    viper.GetBool("http_stream"),
@@ -558,7 +559,9 @@ func main() {
 					UniSSE:        viper.GetBool("uni_sse"),
 					UniGRPC:       viper.GetBool("uni_grpc"),
 
-					GrpcAPI: viper.GetBool("grpc_api"),
+					GrpcAPI:             viper.GetBool("grpc_api"),
+					SubscribeToPersonal: viper.GetBool("user_subscribe_to_personal"),
+					Admin:               viper.GetBool("admin"),
 
 					ConnectProxy:   proxyMap.ConnectProxy != nil,
 					RefreshProxy:   proxyMap.RefreshProxy != nil,

--- a/main.go
+++ b/main.go
@@ -570,13 +570,13 @@ func main() {
 					PublishProxy:   len(proxyMap.PublishProxies) > 0,
 					RPCProxy:       len(proxyMap.RpcProxies) > 0,
 
-					Clickhouse:        false,
-					UserStatus:        false,
-					Throttling:        false,
-					UserBlocking:      false,
-					TokenRevoking:     false,
-					TokenInvalidation: false,
-					Singleflight:      false,
+					ClickhouseAnalytics: false,
+					UserStatus:          false,
+					Throttling:          false,
+					UserBlocking:        false,
+					TokenRevoking:       false,
+					TokenInvalidation:   false,
+					Singleflight:        false,
 				})
 				go statsSender.Start(context.Background())
 			}

--- a/main.go
+++ b/main.go
@@ -34,8 +34,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/centrifugal/centrifugo/v3/internal/notify"
-
 	"github.com/centrifugal/centrifugo/v3/internal/admin"
 	"github.com/centrifugal/centrifugo/v3/internal/api"
 	"github.com/centrifugal/centrifugo/v3/internal/build"
@@ -48,6 +46,7 @@ import (
 	"github.com/centrifugal/centrifugo/v3/internal/metrics/graphite"
 	"github.com/centrifugal/centrifugo/v3/internal/middleware"
 	"github.com/centrifugal/centrifugo/v3/internal/natsbroker"
+	"github.com/centrifugal/centrifugo/v3/internal/notify"
 	"github.com/centrifugal/centrifugo/v3/internal/origin"
 	"github.com/centrifugal/centrifugo/v3/internal/proxy"
 	"github.com/centrifugal/centrifugo/v3/internal/rule"
@@ -250,6 +249,8 @@ func bindCentrifugoConfig() {
 	viper.SetEnvKeyReplacer(replacer)
 	viper.AutomaticEnv()
 }
+
+const edition = "oss"
 
 func main() {
 	var configFile string
@@ -545,7 +546,7 @@ func main() {
 			var statsSender *usage.Sender
 			if !viper.GetBool("anonymous_stats_disable") {
 				statsSender = usage.NewSender(node, ruleContainer, usage.Features{
-					Edition: "OSS",
+					Edition: edition,
 					Version: build.Version,
 					Engine:  engineName,
 					Broker:  brokerName,

--- a/misc/scripts/package.sh
+++ b/misc/scripts/package.sh
@@ -89,7 +89,24 @@ make_dir_tree() {
 # do_build builds the code. The version and commit must be passed in.
 do_build() {
     echo "Start building binary"
-    gox -os="linux" -ldflags="-X github.com/centrifugal/centrifugo/v3/internal/build.Version=$VERSION" -arch="amd64" -output="$TMP_BINARIES_DIR/{{.OS}}-{{.Arch}}/centrifugo"
+
+    if [ -z "$STATS_ENDPOINT" ]
+    then
+        echo "STATS_ENDPOINT not defined"
+        cleanup_exit 1
+    else
+        echo "STATS_ENDPOINT found"
+    fi
+
+    if [ -z "$STATS_TOKEN" ]
+    then
+        echo "STATS_TOKEN not defined"
+        cleanup_exit 1
+    else
+        echo "STATS_TOKEN found"
+    fi
+
+    gox -os="linux" -ldflags="-X github.com/centrifugal/centrifugo/v3/internal/build.Version=$VERSION -X github.com/centrifugal/centrifugo/v3/internal/build.UsageStatsEndpoint=$STATS_ENDPOINT -X github.com/centrifugal/centrifugo/v3/internal/build.UsageStatsToken=$STATS_TOKEN" -arch="amd64" -output="$TMP_BINARIES_DIR/{{.OS}}-{{.Arch}}/centrifugo"
     echo "Binary build completed successfully"
 }
 


### PR DESCRIPTION
## Proposed changes

This pr allows collecting anonymous Centrifugo usage stats.

Important things:
* We send stats once in 24 hours
* Data is impersonal – no ip, hostname, any identifiers are sent.  Only impersonal counters to estimate installation size distribution and feature use.
* Enabled by default, possible to disable using `"anonymous_stats_disable": true`.