### PR TITLE
Update systemd service

### DIFF
--- a/misc/packaging/centrifugo.service
+++ b/misc/packaging/centrifugo.service
@@ -2,7 +2,7 @@
 Description=Centrifugo real-time messaging server
 Documentation=https://github.com/centrifugal/centrifugo
 # start once the network and logging subsystems available
-After=network.target syslog.target
+After=network.target
 
 [Service]
 User=centrifugo
@@ -18,9 +18,6 @@ TimeoutStopSec=10
 KillMode=control-group
 RestartSec=1
 Restart=on-failure
-StandardOutput=syslog
-StandardError=syslog
-SyslogIdentifier=centrifugo
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Proposed changes

Fixes warning:

```
/lib/systemd/system/centrifugo.service:22: Standard output type syslog is obsolete, automatically updating to journal. Please update your unit file, and consider removing the setting altogether.
```

This is now equivalent to StandardOutput=journal, and recent versions of systemd log a warning for it. Instead of updating it to journal, remove it: the default if not specified is to respect the DefaultStandardOutput setting from /etc/systemd/system.conf, which in turn defaults to journal.

Also, syslog.target is deprecated.

