### PR TITLE
Use constant time compare function to compare admin_password and api_key

### DIFF
--- a/internal/admin/handlers.go
+++ b/internal/admin/handlers.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/centrifugal/centrifugo/v3/internal/api"
 	"github.com/centrifugal/centrifugo/v3/internal/middleware"
+	"github.com/centrifugal/centrifugo/v3/internal/tools"
 
 	"github.com/centrifugal/centrifuge"
 	"github.com/gorilla/securecookie"
@@ -125,10 +126,8 @@ func (s *Handler) authHandler(w http.ResponseWriter, r *http.Request) {
 
 	if insecure {
 		w.Header().Set("Content-Type", "application/json")
-		resp := struct {
-			Token string `json:"token"`
-		}{
-			Token: "insecure",
+		resp := map[string]string{
+			"token": "insecure",
 		}
 		_ = json.NewEncoder(w).Encode(resp)
 		return
@@ -140,7 +139,7 @@ func (s *Handler) authHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if formPassword == password {
+	if tools.SecureCompareString(formPassword, password) {
 		w.Header().Set("Content-Type", "application/json")
 		token, err := generateSecureAdminToken(secret)
 		if err != nil {

--- a/internal/middleware/auth.go
+++ b/internal/middleware/auth.go
@@ -4,6 +4,8 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/centrifugal/centrifugo/v3/internal/tools"
+
 	"github.com/rs/zerolog/log"
 )
 
@@ -22,11 +24,15 @@ func APIKeyAuth(key string, h http.Handler) http.Handler {
 		authHeader := r.Header.Get("Authorization")
 		if authHeader != "" {
 			parts := strings.Fields(authHeader)
-			authValid = len(parts) == 2 && strings.ToLower(parts[0]) == "apikey" && parts[1] == key
+			if len(parts) == 2 && strings.ToLower(parts[0]) == "apikey" && tools.SecureCompareString(key, parts[1]) {
+				authValid = true
+			}
 		}
 		if !authValid && r.URL.RawQuery != "" {
 			// Check URL param.
-			authValid = r.URL.Query().Get("api_key") == key
+			if tools.SecureCompareString(key, r.URL.Query().Get("api_key")) {
+				authValid = true
+			}
 		}
 		if !authValid {
 			w.WriteHeader(http.StatusUnauthorized)

--- a/internal/tools/compare.go
+++ b/internal/tools/compare.go
@@ -5,10 +5,7 @@ import "crypto/subtle"
 // SecureCompare use constant time function to compare the two given array.
 func SecureCompare(given, actual []byte) bool {
 	if subtle.ConstantTimeEq(int32(len(given)), int32(len(actual))) == 1{
-		if subtle.ConstantTimeCompare(given, actual) == 1{
-			return true
-		}
-		return false
+		return subtle.ConstantTimeCompare(given, actual) == 1
 	}
 	// Securely compare actual to itself to keep constant time, but always return false
 	if subtle.ConstantTimeCompare(actual, actual) == 1 {
@@ -23,10 +20,7 @@ func SecureCompareString(given, actual string) bool {
 	// return SecureCompare([]byte(given), []byte(actual))
 
 	if subtle.ConstantTimeEq(int32(len(given)), int32(len(actual))) == 1 {
-		if subtle.ConstantTimeCompare([]byte(given), []byte(actual)) == 1 {
-			return true
-		}
-		return false
+		return subtle.ConstantTimeCompare([]byte(given), []byte(actual)) == 1
 	}
 	// Securely compare actual to itself to keep constant time, but always return false
 	if subtle.ConstantTimeCompare([]byte(actual), []byte(actual)) == 1 {

--- a/internal/tools/compare.go
+++ b/internal/tools/compare.go
@@ -1,0 +1,36 @@
+package tools
+
+import "crypto/subtle"
+
+// SecureCompare use constant time function to compare the two given array.
+func SecureCompare(given, actual []byte) bool {
+	if subtle.ConstantTimeEq(int32(len(given)), int32(len(actual))) == 1{
+		if subtle.ConstantTimeCompare(given, actual) == 1{
+			return true
+		}
+		return false
+	}
+	// Securely compare actual to itself to keep constant time, but always return false
+	if subtle.ConstantTimeCompare(actual, actual) == 1 {
+		return false
+	}
+	return false
+}
+
+// SecureCompareString use constant time function to compare the two given string.
+func SecureCompareString(given, actual string) bool {
+	// The following code is incorrect:
+	// return SecureCompare([]byte(given), []byte(actual))
+
+	if subtle.ConstantTimeEq(int32(len(given)), int32(len(actual))) == 1 {
+		if subtle.ConstantTimeCompare([]byte(given), []byte(actual)) == 1 {
+			return true
+		}
+		return false
+	}
+	// Securely compare actual to itself to keep constant time, but always return false
+	if subtle.ConstantTimeCompare([]byte(actual), []byte(actual)) == 1 {
+		return false
+	}
+	return false
+}


### PR DESCRIPTION
## Proposed changes
Add `SecureCompare` and `SecureCompareString` function to compare arrays/strings in constant time, avoiding timing side channel attack.