### PR TITLE
Client connection limit

### DIFF
--- a/internal/client/handler.go
+++ b/internal/client/handler.go
@@ -86,6 +86,11 @@ func (h *Handler) Setup() error {
 	}
 
 	h.node.OnConnecting(func(ctx context.Context, e centrifuge.ConnectEvent) (centrifuge.ConnectReply, error) {
+		connLimit := h.ruleContainer.Config().ClientConnectionLimit
+		if connLimit > 0 && h.node.Hub().NumClients() >= connLimit {
+			h.node.Log(centrifuge.NewLogEntry(centrifuge.LogLevelWarn, "node connection limit reached", map[string]interface{}{"limit": connLimit}))
+			return centrifuge.ConnectReply{}, centrifuge.DisconnectForceReconnect
+		}
 		reply, err := h.OnClientConnecting(ctx, e, connectProxyHandler, refreshProxyHandler != nil)
 		if err != nil {
 			return centrifuge.ConnectReply{}, err

--- a/internal/client/handler.go
+++ b/internal/client/handler.go
@@ -86,11 +86,6 @@ func (h *Handler) Setup() error {
 	}
 
 	h.node.OnConnecting(func(ctx context.Context, e centrifuge.ConnectEvent) (centrifuge.ConnectReply, error) {
-		connLimit := h.ruleContainer.Config().ClientConnectionLimit
-		if connLimit > 0 && h.node.Hub().NumClients() >= connLimit {
-			h.node.Log(centrifuge.NewLogEntry(centrifuge.LogLevelWarn, "node connection limit reached", map[string]interface{}{"limit": connLimit}))
-			return centrifuge.ConnectReply{}, centrifuge.DisconnectForceReconnect
-		}
 		reply, err := h.OnClientConnecting(ctx, e, connectProxyHandler, refreshProxyHandler != nil)
 		if err != nil {
 			return centrifuge.ConnectReply{}, err

--- a/internal/middleware/connlimit.go
+++ b/internal/middleware/connlimit.go
@@ -3,14 +3,31 @@ package middleware
 import (
 	"net/http"
 
-	"github.com/centrifugal/centrifuge"
 	"github.com/centrifugal/centrifugo/v4/internal/rule"
+
+	"github.com/centrifugal/centrifuge"
+	"github.com/prometheus/client_golang/prometheus"
 )
+
+var (
+	connLimitReached prometheus.Counter
+)
+
+func init() {
+	connLimitReached = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: "centrifugo",
+		Subsystem: "node",
+		Name:      "client_connection_limit",
+		Help:      "Number of refused requests due to node client connection limit.",
+	})
+	_ = prometheus.DefaultRegisterer.Register(connLimitReached)
+}
 
 func ConnLimit(node *centrifuge.Node, ruleContainer *rule.Container, h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		connLimit := ruleContainer.Config().ClientConnectionLimit
 		if connLimit > 0 && node.Hub().NumClients() >= connLimit {
+			connLimitReached.Inc()
 			node.Log(centrifuge.NewLogEntry(centrifuge.LogLevelWarn, "node connection limit reached", map[string]interface{}{"limit": connLimit}))
 			return
 		}

--- a/internal/middleware/connlimit.go
+++ b/internal/middleware/connlimit.go
@@ -1,0 +1,19 @@
+package middleware
+
+import (
+	"net/http"
+
+	"github.com/centrifugal/centrifuge"
+	"github.com/centrifugal/centrifugo/v4/internal/rule"
+)
+
+func ConnLimit(node *centrifuge.Node, ruleContainer *rule.Container, h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		connLimit := ruleContainer.Config().ClientConnectionLimit
+		if connLimit > 0 && node.Hub().NumClients() >= connLimit {
+			node.Log(centrifuge.NewLogEntry(centrifuge.LogLevelWarn, "node connection limit reached", map[string]interface{}{"limit": connLimit}))
+			return
+		}
+		h.ServeHTTP(w, r)
+	})
+}

--- a/internal/rule/rule.go
+++ b/internal/rule/rule.go
@@ -63,6 +63,9 @@ type Config struct {
 	// with provided concurrency level. By default, commands processed sequentially
 	// one after another.
 	ClientConcurrency int
+	// ClientConnectionLimit sets the maximum number of concurrent clients a single Centrifugo
+	// node will accept.
+	ClientConnectionLimit int
 }
 
 // DefaultConfig has default config options.

--- a/main.go
+++ b/main.go
@@ -547,7 +547,7 @@ func main() {
 				log.Info().Msgf("serving unidirectional GRPC on %s", grpcUniAddr)
 			}
 
-			servers, err := runHTTPServers(node, httpAPIExecutor, proxyEnabled)
+			servers, err := runHTTPServers(node, ruleContainer, httpAPIExecutor, proxyEnabled)
 			if err != nil {
 				log.Fatal().Msgf("error running HTTP server: %v", err)
 			}
@@ -1122,7 +1122,7 @@ func (w *httpErrorLogWriter) Write(data []byte) (int, error) {
 	return len(data), nil
 }
 
-func runHTTPServers(n *centrifuge.Node, apiExecutor *api.Executor, proxyEnabled bool) ([]*http.Server, error) {
+func runHTTPServers(n *centrifuge.Node, ruleContainer *rule.Container, apiExecutor *api.Executor, proxyEnabled bool) ([]*http.Server, error) {
 	debug := viper.GetBool("debug")
 	useAdmin := viper.GetBool("admin")
 	usePrometheus := viper.GetBool("prometheus")
@@ -1244,7 +1244,7 @@ func runHTTPServers(n *centrifuge.Node, apiExecutor *api.Executor, proxyEnabled 
 			}
 		}
 
-		mux := Mux(n, apiExecutor, handlerFlags, proxyEnabled, wtServer)
+		mux := Mux(n, ruleContainer, apiExecutor, handlerFlags, proxyEnabled, wtServer)
 
 		if useHTTP3 {
 			wtServer.H3 = http3.Server{
@@ -2368,7 +2368,7 @@ func (flags HandlerFlag) String() string {
 }
 
 // Mux returns a mux including set of default handlers for Centrifugo server.
-func Mux(n *centrifuge.Node, apiExecutor *api.Executor, flags HandlerFlag, proxyEnabled bool, wtServer *webtransport.Server) *http.ServeMux {
+func Mux(n *centrifuge.Node, ruleContainer *rule.Container, apiExecutor *api.Executor, flags HandlerFlag, proxyEnabled bool, wtServer *webtransport.Server) *http.ServeMux {
 	mux := http.NewServeMux()
 	v := viper.GetViper()
 
@@ -2386,7 +2386,7 @@ func Mux(n *centrifuge.Node, apiExecutor *api.Executor, flags HandlerFlag, proxy
 		if wsPrefix == "" {
 			wsPrefix = "/"
 		}
-		mux.Handle(wsPrefix, middleware.LogRequest(middleware.HeadersToContext(proxyEnabled, centrifuge.NewWebsocketHandler(n, websocketHandlerConfig()))))
+		mux.Handle(wsPrefix, middleware.ConnLimit(n, ruleContainer, middleware.LogRequest(middleware.HeadersToContext(proxyEnabled, centrifuge.NewWebsocketHandler(n, websocketHandlerConfig())))))
 	}
 
 	if flags&HandlerWebtransport != 0 {
@@ -2395,7 +2395,7 @@ func Mux(n *centrifuge.Node, apiExecutor *api.Executor, flags HandlerFlag, proxy
 		if wtPrefix == "" {
 			wtPrefix = "/"
 		}
-		mux.Handle(wtPrefix, middleware.LogRequest(middleware.HeadersToContext(proxyEnabled, wt.NewHandler(n, wtServer, webTransportHandlerConfig()))))
+		mux.Handle(wtPrefix, middleware.ConnLimit(n, ruleContainer, middleware.LogRequest(middleware.HeadersToContext(proxyEnabled, wt.NewHandler(n, wtServer, webTransportHandlerConfig())))))
 	}
 
 	if flags&HandlerHTTPStream != 0 {
@@ -2404,7 +2404,7 @@ func Mux(n *centrifuge.Node, apiExecutor *api.Executor, flags HandlerFlag, proxy
 		if streamPrefix == "" {
 			streamPrefix = "/"
 		}
-		mux.Handle(streamPrefix, middleware.LogRequest(middleware.HeadersToContext(proxyEnabled, middleware.CORS(getCheckOrigin(), centrifuge.NewHTTPStreamHandler(n, httpStreamHandlerConfig())))))
+		mux.Handle(streamPrefix, middleware.ConnLimit(n, ruleContainer, middleware.LogRequest(middleware.HeadersToContext(proxyEnabled, middleware.CORS(getCheckOrigin(), centrifuge.NewHTTPStreamHandler(n, httpStreamHandlerConfig()))))))
 	}
 	if flags&HandlerSSE != 0 {
 		// register bidirectional SSE connection endpoint.
@@ -2412,7 +2412,7 @@ func Mux(n *centrifuge.Node, apiExecutor *api.Executor, flags HandlerFlag, proxy
 		if ssePrefix == "" {
 			ssePrefix = "/"
 		}
-		mux.Handle(ssePrefix, middleware.LogRequest(middleware.HeadersToContext(proxyEnabled, middleware.CORS(getCheckOrigin(), centrifuge.NewSSEHandler(n, sseHandlerConfig())))))
+		mux.Handle(ssePrefix, middleware.ConnLimit(n, ruleContainer, middleware.LogRequest(middleware.HeadersToContext(proxyEnabled, middleware.CORS(getCheckOrigin(), centrifuge.NewSSEHandler(n, sseHandlerConfig()))))))
 	}
 	if flags&HandlerEmulation != 0 {
 		// register bidirectional SSE connection endpoint.
@@ -2420,7 +2420,7 @@ func Mux(n *centrifuge.Node, apiExecutor *api.Executor, flags HandlerFlag, proxy
 		if emulationPrefix == "" {
 			emulationPrefix = "/"
 		}
-		mux.Handle(emulationPrefix, middleware.LogRequest(middleware.CORS(getCheckOrigin(), centrifuge.NewEmulationHandler(n, emulationHandlerConfig()))))
+		mux.Handle(emulationPrefix, middleware.ConnLimit(n, ruleContainer, middleware.LogRequest(middleware.CORS(getCheckOrigin(), centrifuge.NewEmulationHandler(n, emulationHandlerConfig())))))
 	}
 
 	if flags&HandlerSockJS != 0 {
@@ -2428,7 +2428,7 @@ func Mux(n *centrifuge.Node, apiExecutor *api.Executor, flags HandlerFlag, proxy
 		sockjsConfig := sockjsHandlerConfig()
 		sockjsPrefix := strings.TrimRight(v.GetString("sockjs_handler_prefix"), "/")
 		sockjsConfig.HandlerPrefix = sockjsPrefix
-		mux.Handle(sockjsPrefix+"/", middleware.LogRequest(middleware.HeadersToContext(proxyEnabled, centrifuge.NewSockjsHandler(n, sockjsConfig))))
+		mux.Handle(sockjsPrefix+"/", middleware.ConnLimit(n, ruleContainer, middleware.LogRequest(middleware.HeadersToContext(proxyEnabled, centrifuge.NewSockjsHandler(n, sockjsConfig)))))
 	}
 
 	if flags&HandlerUniWebsocket != 0 {
@@ -2437,7 +2437,7 @@ func Mux(n *centrifuge.Node, apiExecutor *api.Executor, flags HandlerFlag, proxy
 		if wsPrefix == "" {
 			wsPrefix = "/"
 		}
-		mux.Handle(wsPrefix, middleware.LogRequest(middleware.HeadersToContext(proxyEnabled, uniws.NewHandler(n, uniWebsocketHandlerConfig()))))
+		mux.Handle(wsPrefix, middleware.ConnLimit(n, ruleContainer, middleware.LogRequest(middleware.HeadersToContext(proxyEnabled, uniws.NewHandler(n, uniWebsocketHandlerConfig())))))
 	}
 
 	if flags&HandlerUniSSE != 0 {
@@ -2446,7 +2446,7 @@ func Mux(n *centrifuge.Node, apiExecutor *api.Executor, flags HandlerFlag, proxy
 		if ssePrefix == "" {
 			ssePrefix = "/"
 		}
-		mux.Handle(ssePrefix, middleware.LogRequest(middleware.HeadersToContext(proxyEnabled, middleware.CORS(getCheckOrigin(), unisse.NewHandler(n, uniSSEHandlerConfig())))))
+		mux.Handle(ssePrefix, middleware.ConnLimit(n, ruleContainer, middleware.LogRequest(middleware.HeadersToContext(proxyEnabled, middleware.CORS(getCheckOrigin(), unisse.NewHandler(n, uniSSEHandlerConfig()))))))
 	}
 
 	if flags&HandlerUniHTTPStream != 0 {
@@ -2455,7 +2455,7 @@ func Mux(n *centrifuge.Node, apiExecutor *api.Executor, flags HandlerFlag, proxy
 		if streamPrefix == "" {
 			streamPrefix = "/"
 		}
-		mux.Handle(streamPrefix, middleware.LogRequest(middleware.HeadersToContext(proxyEnabled, middleware.CORS(getCheckOrigin(), unihttpstream.NewHandler(n, uniStreamHandlerConfig())))))
+		mux.Handle(streamPrefix, middleware.ConnLimit(n, ruleContainer, middleware.LogRequest(middleware.HeadersToContext(proxyEnabled, middleware.CORS(getCheckOrigin(), unihttpstream.NewHandler(n, uniStreamHandlerConfig()))))))
 	}
 
 	if flags&HandlerAPI != 0 {

--- a/main.go
+++ b/main.go
@@ -1421,6 +1421,7 @@ func ruleConfig() rule.Config {
 	cfg.RpcNamespaceBoundary = v.GetString("rpc_namespace_boundary")
 	cfg.RpcProxyName = v.GetString("rpc_proxy_name")
 	cfg.RpcNamespaces = rpcNamespacesFromConfig(v)
+	cfg.ClientConnectionLimit = v.GetInt("client_connection_limit")
 	return cfg
 }
 


### PR DESCRIPTION
## Proposed changes

Add an integer option `client_connection_limit` that (when set to a value > 0) limits the max number of connections single Centrifugo node can handle. It acts on HTTP middleware level and stops processing request if the condition met. It logs a warning into logs in this case and increments `centrifugo_node_client_connection_limit` Prometheus counter. Client SDKs will attempt reconnecting.

Relates #544 

