### PR TITLE
Avoid proxying user limited channel

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -1,0 +1,16 @@
+package client
+
+import (
+	"context"
+
+	"github.com/centrifugal/centrifuge"
+)
+
+// Client represents client connection.
+type Client interface {
+	ID() string
+	UserID() string
+	IsSubscribed(string) bool
+	Context() context.Context
+	Transport() centrifuge.TransportInfo
+}

--- a/internal/client/handler.go
+++ b/internal/client/handler.go
@@ -24,7 +24,7 @@ import (
 var SkipUserCheckInSubscriptionToken bool
 
 // RPCExtensionFunc ...
-type RPCExtensionFunc func(c *centrifuge.Client, e centrifuge.RPCEvent) (centrifuge.RPCReply, error)
+type RPCExtensionFunc func(c Client, e centrifuge.RPCEvent) (centrifuge.RPCReply, error)
 
 // ProxyMap is a structure which contains all configured and already initialized
 // proxies which can be used from inside client event handlers.
@@ -437,7 +437,7 @@ type RefreshExtra struct {
 }
 
 // OnRefresh ...
-func (h *Handler) OnRefresh(c *centrifuge.Client, e centrifuge.RefreshEvent, refreshProxyHandler proxy.RefreshHandlerFunc, d proxy.PerCallData) (centrifuge.RefreshReply, RefreshExtra, error) {
+func (h *Handler) OnRefresh(c Client, e centrifuge.RefreshEvent, refreshProxyHandler proxy.RefreshHandlerFunc, d proxy.PerCallData) (centrifuge.RefreshReply, RefreshExtra, error) {
 	if refreshProxyHandler != nil {
 		r, extra, err := refreshProxyHandler(c, e, d)
 		return r, RefreshExtra{Meta: extra.Meta}, err
@@ -465,7 +465,7 @@ func (h *Handler) OnRefresh(c *centrifuge.Client, e centrifuge.RefreshEvent, ref
 }
 
 // OnRPC ...
-func (h *Handler) OnRPC(c *centrifuge.Client, e centrifuge.RPCEvent, rpcProxyHandler proxy.RPCHandlerFunc, d proxy.PerCallData) (centrifuge.RPCReply, error) {
+func (h *Handler) OnRPC(c Client, e centrifuge.RPCEvent, rpcProxyHandler proxy.RPCHandlerFunc, d proxy.PerCallData) (centrifuge.RPCReply, error) {
 	if handler, ok := h.rpcExtension[e.Method]; ok {
 		return handler(c, e)
 	}
@@ -479,7 +479,7 @@ type SubRefreshExtra struct {
 }
 
 // OnSubRefresh ...
-func (h *Handler) OnSubRefresh(c *centrifuge.Client, e centrifuge.SubRefreshEvent) (centrifuge.SubRefreshReply, SubRefreshExtra, error) {
+func (h *Handler) OnSubRefresh(c Client, e centrifuge.SubRefreshEvent) (centrifuge.SubRefreshReply, SubRefreshExtra, error) {
 	token, err := h.tokenVerifier.VerifySubscribeToken(e.Token)
 	if err != nil {
 		if err == jwtverify.ErrTokenExpired {
@@ -535,7 +535,7 @@ func (h *Handler) validChannelName(_ string, rest string, chOpts rule.ChannelOpt
 	return true, nil
 }
 
-func (h *Handler) validateChannelName(c *centrifuge.Client, nsName string, rest string, chOpts rule.ChannelOptions, channel string) error {
+func (h *Handler) validateChannelName(c Client, nsName string, rest string, chOpts rule.ChannelOptions, channel string) error {
 	ok, err := h.validChannelName(nsName, rest, chOpts, channel)
 	if err != nil {
 		h.node.Log(centrifuge.NewLogEntry(centrifuge.LogLevelInfo, "error checking channel name", map[string]interface{}{"channel": channel, "error": err.Error(), "client": c.ID(), "user": c.UserID()}))
@@ -552,7 +552,7 @@ type SubscribeExtra struct {
 }
 
 // OnSubscribe ...
-func (h *Handler) OnSubscribe(c *centrifuge.Client, e centrifuge.SubscribeEvent, subscribeProxyHandler proxy.SubscribeHandlerFunc, d proxy.PerCallData) (centrifuge.SubscribeReply, SubscribeExtra, error) {
+func (h *Handler) OnSubscribe(c Client, e centrifuge.SubscribeEvent, subscribeProxyHandler proxy.SubscribeHandlerFunc, d proxy.PerCallData) (centrifuge.SubscribeReply, SubscribeExtra, error) {
 	ruleConfig := h.ruleContainer.Config()
 
 	if e.Channel == "" {
@@ -655,7 +655,7 @@ func (h *Handler) OnSubscribe(c *centrifuge.Client, e centrifuge.SubscribeEvent,
 }
 
 // OnPublish ...
-func (h *Handler) OnPublish(c *centrifuge.Client, e centrifuge.PublishEvent, publishProxyHandler proxy.PublishHandlerFunc, d proxy.PerCallData) (centrifuge.PublishReply, error) {
+func (h *Handler) OnPublish(c Client, e centrifuge.PublishEvent, publishProxyHandler proxy.PublishHandlerFunc, d proxy.PerCallData) (centrifuge.PublishReply, error) {
 	ruleConfig := h.ruleContainer.Config()
 
 	nsName, rest, chOpts, found, err := h.ruleContainer.ChannelOptions(e.Channel)
@@ -703,7 +703,7 @@ func (h *Handler) OnPublish(c *centrifuge.Client, e centrifuge.PublishEvent, pub
 	return centrifuge.PublishReply{Result: &result}, err
 }
 
-func (h *Handler) hasAccessToPresence(c *centrifuge.Client, channel string, chOpts rule.ChannelOptions) bool {
+func (h *Handler) hasAccessToPresence(c Client, channel string, chOpts rule.ChannelOptions) bool {
 	if chOpts.PresenceForClient && (c.UserID() != "" || chOpts.PresenceForAnonymous) {
 		return true
 	} else if chOpts.PresenceForSubscriber && c.IsSubscribed(channel) && (c.UserID() != "" || chOpts.PresenceForAnonymous) {
@@ -715,7 +715,7 @@ func (h *Handler) hasAccessToPresence(c *centrifuge.Client, channel string, chOp
 }
 
 // OnPresence ...
-func (h *Handler) OnPresence(c *centrifuge.Client, e centrifuge.PresenceEvent) (centrifuge.PresenceReply, error) {
+func (h *Handler) OnPresence(c Client, e centrifuge.PresenceEvent) (centrifuge.PresenceReply, error) {
 	nsName, rest, chOpts, found, err := h.ruleContainer.ChannelOptions(e.Channel)
 	if err != nil {
 		h.node.Log(centrifuge.NewLogEntry(centrifuge.LogLevelError, "presence channel options error", map[string]interface{}{"error": err.Error(), "channel": e.Channel, "user": c.UserID(), "client": c.ID()}))
@@ -743,7 +743,7 @@ func (h *Handler) OnPresence(c *centrifuge.Client, e centrifuge.PresenceEvent) (
 }
 
 // OnPresenceStats ...
-func (h *Handler) OnPresenceStats(c *centrifuge.Client, e centrifuge.PresenceStatsEvent) (centrifuge.PresenceStatsReply, error) {
+func (h *Handler) OnPresenceStats(c Client, e centrifuge.PresenceStatsEvent) (centrifuge.PresenceStatsReply, error) {
 	nsName, rest, chOpts, found, err := h.ruleContainer.ChannelOptions(e.Channel)
 	if err != nil {
 		h.node.Log(centrifuge.NewLogEntry(centrifuge.LogLevelError, "presence stats channel options error", map[string]interface{}{"error": err.Error(), "channel": e.Channel, "user": c.UserID(), "client": c.ID()}))
@@ -770,7 +770,7 @@ func (h *Handler) OnPresenceStats(c *centrifuge.Client, e centrifuge.PresenceSta
 	return centrifuge.PresenceStatsReply{}, nil
 }
 
-func (h *Handler) hasAccessToHistory(c *centrifuge.Client, channel string, chOpts rule.ChannelOptions) bool {
+func (h *Handler) hasAccessToHistory(c Client, channel string, chOpts rule.ChannelOptions) bool {
 	if chOpts.HistoryForClient && (c.UserID() != "" || chOpts.HistoryForAnonymous) {
 		return true
 	} else if chOpts.HistoryForSubscriber && c.IsSubscribed(channel) && (c.UserID() != "" || chOpts.HistoryForAnonymous) {
@@ -782,7 +782,7 @@ func (h *Handler) hasAccessToHistory(c *centrifuge.Client, channel string, chOpt
 }
 
 // OnHistory ...
-func (h *Handler) OnHistory(c *centrifuge.Client, e centrifuge.HistoryEvent) (centrifuge.HistoryReply, error) {
+func (h *Handler) OnHistory(c Client, e centrifuge.HistoryEvent) (centrifuge.HistoryReply, error) {
 	nsName, rest, chOpts, found, err := h.ruleContainer.ChannelOptions(e.Channel)
 	if err != nil {
 		h.node.Log(centrifuge.NewLogEntry(centrifuge.LogLevelError, "history channel options error", map[string]interface{}{"error": err.Error(), "channel": e.Channel, "user": c.UserID(), "client": c.ID()}))

--- a/internal/proxy/client.go
+++ b/internal/proxy/client.go
@@ -1,0 +1,14 @@
+package proxy
+
+import (
+	"context"
+
+	"github.com/centrifugal/centrifuge"
+)
+
+type Client interface {
+	ID() string
+	UserID() string
+	Context() context.Context
+	Transport() centrifuge.TransportInfo
+}

--- a/internal/proxy/publish_handler.go
+++ b/internal/proxy/publish_handler.go
@@ -58,11 +58,11 @@ func NewPublishHandler(c PublishHandlerConfig) *PublishHandler {
 }
 
 // PublishHandlerFunc ...
-type PublishHandlerFunc func(*centrifuge.Client, centrifuge.PublishEvent, rule.ChannelOptions, PerCallData) (centrifuge.PublishReply, error)
+type PublishHandlerFunc func(Client, centrifuge.PublishEvent, rule.ChannelOptions, PerCallData) (centrifuge.PublishReply, error)
 
 // Handle Publish.
 func (h *PublishHandler) Handle(node *centrifuge.Node) PublishHandlerFunc {
-	return func(client *centrifuge.Client, e centrifuge.PublishEvent, chOpts rule.ChannelOptions, pcd PerCallData) (centrifuge.PublishReply, error) {
+	return func(client Client, e centrifuge.PublishEvent, chOpts rule.ChannelOptions, pcd PerCallData) (centrifuge.PublishReply, error) {
 		started := time.Now()
 
 		var p PublishProxy

--- a/internal/proxy/refresh_handler.go
+++ b/internal/proxy/refresh_handler.go
@@ -39,11 +39,11 @@ type RefreshExtra struct {
 }
 
 // RefreshHandlerFunc ...
-type RefreshHandlerFunc func(*centrifuge.Client, centrifuge.RefreshEvent, PerCallData) (centrifuge.RefreshReply, RefreshExtra, error)
+type RefreshHandlerFunc func(Client, centrifuge.RefreshEvent, PerCallData) (centrifuge.RefreshReply, RefreshExtra, error)
 
 // Handle refresh.
 func (h *RefreshHandler) Handle(node *centrifuge.Node) RefreshHandlerFunc {
-	return func(client *centrifuge.Client, e centrifuge.RefreshEvent, pcd PerCallData) (centrifuge.RefreshReply, RefreshExtra, error) {
+	return func(client Client, e centrifuge.RefreshEvent, pcd PerCallData) (centrifuge.RefreshReply, RefreshExtra, error) {
 		started := time.Now()
 		req := &proxyproto.RefreshRequest{
 			Client:    client.ID(),

--- a/internal/proxy/rpc_handler.go
+++ b/internal/proxy/rpc_handler.go
@@ -58,11 +58,11 @@ func NewRPCHandler(c RPCHandlerConfig) *RPCHandler {
 }
 
 // RPCHandlerFunc ...
-type RPCHandlerFunc func(*centrifuge.Client, centrifuge.RPCEvent, *rule.Container, PerCallData) (centrifuge.RPCReply, error)
+type RPCHandlerFunc func(Client, centrifuge.RPCEvent, *rule.Container, PerCallData) (centrifuge.RPCReply, error)
 
 // Handle RPC.
 func (h *RPCHandler) Handle(node *centrifuge.Node) RPCHandlerFunc {
-	return func(client *centrifuge.Client, e centrifuge.RPCEvent, ruleContainer *rule.Container, pcd PerCallData) (centrifuge.RPCReply, error) {
+	return func(client Client, e centrifuge.RPCEvent, ruleContainer *rule.Container, pcd PerCallData) (centrifuge.RPCReply, error) {
 		started := time.Now()
 
 		var p RPCProxy

--- a/internal/proxy/subscribe_handler.go
+++ b/internal/proxy/subscribe_handler.go
@@ -61,11 +61,11 @@ type SubscribeExtra struct {
 }
 
 // SubscribeHandlerFunc ...
-type SubscribeHandlerFunc func(*centrifuge.Client, centrifuge.SubscribeEvent, rule.ChannelOptions, PerCallData) (centrifuge.SubscribeReply, SubscribeExtra, error)
+type SubscribeHandlerFunc func(Client, centrifuge.SubscribeEvent, rule.ChannelOptions, PerCallData) (centrifuge.SubscribeReply, SubscribeExtra, error)
 
 // Handle Subscribe.
 func (h *SubscribeHandler) Handle(node *centrifuge.Node) SubscribeHandlerFunc {
-	return func(client *centrifuge.Client, e centrifuge.SubscribeEvent, chOpts rule.ChannelOptions, pcd PerCallData) (centrifuge.SubscribeReply, SubscribeExtra, error) {
+	return func(client Client, e centrifuge.SubscribeEvent, chOpts rule.ChannelOptions, pcd PerCallData) (centrifuge.SubscribeReply, SubscribeExtra, error) {
 		started := time.Now()
 
 		var p SubscribeProxy

--- a/internal/tools/test_helpers.go
+++ b/internal/tools/test_helpers.go
@@ -206,3 +206,46 @@ func (c *CommonGRPCProxyTestCase) Teardown() {
 	defer func() { _ = c.ClientCloseFunc() }()
 	c.Server.Stop()
 }
+
+type TestClientMock struct {
+	IDFunc           func() string
+	UserIDFunc       func() string
+	IsSubscribedFunc func(string) bool
+	ContextFunc      func() context.Context
+	TransportFunc    func() centrifuge.TransportInfo
+}
+
+func (m TestClientMock) ID() string {
+	if m.IDFunc != nil {
+		return m.IDFunc()
+	}
+	panic("not implemented")
+}
+
+func (m TestClientMock) UserID() string {
+	if m.UserIDFunc != nil {
+		return m.UserIDFunc()
+	}
+	panic("not implemented")
+}
+
+func (m TestClientMock) IsSubscribed(s string) bool {
+	if m.IsSubscribedFunc != nil {
+		return m.IsSubscribedFunc(s)
+	}
+	panic("not implemented")
+}
+
+func (m TestClientMock) Context() context.Context {
+	if m.ContextFunc != nil {
+		return m.ContextFunc()
+	}
+	panic("not implemented")
+}
+
+func (m TestClientMock) Transport() centrifuge.TransportInfo {
+	if m.TransportFunc != nil {
+		return m.TransportFunc()
+	}
+	panic("not implemented")
+}


### PR DESCRIPTION
## Proposed changes

According to subscribe proxy docs:

> Subscribe proxy does not proxy private and user-limited channels at the moment.

This worked in v3, but in Centrifugo v4 this behaviour is broken, Centrifugo proxies user-limited channels also. This PR fixes this. 


