### PR TITLE
Headers are now fully in lowercase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 centrifugo
+config.yaml
 config.json
 config.json.*
 BUILDS

--- a/internal/proxy/grpc.go
+++ b/internal/proxy/grpc.go
@@ -86,7 +86,7 @@ func requestMetadata(ctx context.Context, allowedHeaders []string, allowedMetaKe
 	requestMD := metadata.MD{}
 	if headers, ok := middleware.GetHeadersFromContext(ctx); ok {
 		for k, vv := range headers {
-			if stringInSlice(k, allowedHeaders) {
+			if stringInSlice(strings.ToLower(k), allowedHeaders) {
 				requestMD.Set(k, vv...)
 			}
 		}

--- a/internal/proxy/http.go
+++ b/internal/proxy/http.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/centrifugal/centrifugo/v4/internal/proxyproto"
@@ -88,7 +89,7 @@ func getProxyHeader(allHeader http.Header, extraHeaders []string) http.Header {
 
 func copyHeader(dst, src http.Header, extraHeaders []string) {
 	for k, vv := range src {
-		if !stringInSlice(k, extraHeaders) {
+		if !stringInSlice(strings.ToLower(k), extraHeaders) {
 			continue
 		}
 		dst[k] = vv

--- a/main.go
+++ b/main.go
@@ -1487,6 +1487,11 @@ func proxyMapConfig() (*client.ProxyMap, bool) {
 	p := proxy.Proxy{}
 	p.GrpcMetadata = v.GetStringSlice("proxy_grpc_metadata")
 	p.HttpHeaders = v.GetStringSlice("proxy_http_headers")
+	if len(p.HttpHeaders) > 0 {
+		for i, header := range p.HttpHeaders {
+			p.HttpHeaders[i] = strings.ToLower(header)
+		}
+	}
 	p.BinaryEncoding = v.GetBool("proxy_binary_encoding")
 	p.IncludeConnectionMeta = v.GetBool("proxy_include_connection_meta")
 	p.GrpcCertFile = v.GetString("proxy_grpc_cert_file")


### PR DESCRIPTION
Hi!

## Proposed changes
Headers config in proxies should be case-insensitive because in the [RFC](https://www.rfc-editor.org/rfc/rfc9110.html#name-header-fields) they are. 

Current flow can lead to some bugs, ex. when you set `Authorization` header in the config, but your client sends it like `authorization`

