### PR TITLE
Reverse proxy to admin web UI app

### DIFF
--- a/internal/reverseproxy/proxy.go
+++ b/internal/reverseproxy/proxy.go
@@ -1,0 +1,29 @@
+package reverseproxy
+
+import (
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+
+	"github.com/rs/zerolog/log"
+)
+
+// New takes target host and creates a reverse proxy.
+func New(targetHost string) (*httputil.ReverseProxy, error) {
+	u, err := url.Parse(targetHost)
+	if err != nil {
+		return nil, err
+	}
+	p := httputil.NewSingleHostReverseProxy(u)
+	p.ErrorHandler = func(writer http.ResponseWriter, request *http.Request, err error) {
+		log.Error().Err(err).Msg("admin web proxy error")
+	}
+	return p, nil
+}
+
+// ProxyRequestHandler handles the http request using proxy
+func ProxyRequestHandler(proxy *httputil.ReverseProxy) func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		proxy.ServeHTTP(w, r)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -2036,6 +2036,7 @@ func adminHandlerConfig() admin.Config {
 	cfg := admin.Config{}
 	cfg.WebFS = webui.FS
 	cfg.WebPath = v.GetString("admin_web_path")
+	cfg.WebProxyAddress = v.GetString("admin_web_proxy_address")
 	cfg.Password = v.GetString("admin_password")
 	cfg.Secret = v.GetString("admin_secret")
 	cfg.Insecure = v.GetBool("admin_insecure")


### PR DESCRIPTION
## Proposed changes

This will allow running admin web UI app in development mode and serve it with Centrifugo – inheriting UI auto-reload feature. So we can serve UI without `dist` folder requirement.