### PR TITLE
Dynamic jwks Keycloak endpoint

### DIFF
--- a/internal/jwks/manager.go
+++ b/internal/jwks/manager.go
@@ -142,6 +142,9 @@ func keycloakPublicKeyEndpoint(keycloakBaseURL string, iss string) (string, erro
 		return "", fmt.Errorf("invalid issuer: no keycloak path in iss %s", iss)
 	}
 	realm := strings.TrimPrefix(u.Path, "/auth/realms/")
+	if realm == "" {
+		return "", fmt.Errorf("invalid issuer: no realm in iss path %s", iss)
+	}
 	return keycloakBaseURL + "/" + realm + "/protocol/openid-connect/certs", nil
 }
 

--- a/internal/jwks/manager_test.go
+++ b/internal/jwks/manager_test.go
@@ -217,6 +217,15 @@ func Test_keycloakPublicKeyEndpoint(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "invalid issuer no realm",
+			args: args{
+				keycloakBaseURL: "https://example.com",
+				iss:             "https://example.com/auth/realms/",
+			},
+			want:    "",
+			wantErr: true,
+		},
+		{
 			name: "valid issuer",
 			args: args{
 				keycloakBaseURL: "https://example.com",

--- a/internal/jwtverify/token_verifier_jwt_test.go
+++ b/internal/jwtverify/token_verifier_jwt_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 // Use https://jwt.io to look at token contents.
-//noinspection ALL
+// noinspection ALL
 const (
 	jwtValid            = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIyNjk0IiwiaW5mbyI6eyJmaXJzdF9uYW1lIjoiQWxleGFuZGVyIiwibGFzdF9uYW1lIjoiRW1lbGluIn19.m-TaS80RxkAiP9jH_s_h2NrKS_TDuPxJ8-z6gI7UewI"
 	jwtExpired          = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIyNjk0IiwiaW5mbyI6eyJmaXJzdF9uYW1lIjoiQWxleGFuZGVyIiwibGFzdF9uYW1lIjoiRW1lbGluIn0sImV4cCI6MTU4ODM1MTcwNH0.LTc0p5YlrwJcxXPETrjhm9qyYUBKCR5fSROmfCE4TD8"
@@ -202,7 +202,7 @@ func Test_tokenVerifierJWT_Valid(t *testing.T) {
 	ruleConfig := rule.DefaultConfig
 	ruleContainer, err := rule.NewContainer(ruleConfig)
 	require.NoError(t, err)
-	verifier := NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, "", "", ""}, ruleContainer)
+	verifier := NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, "", "", "", ""}, ruleContainer)
 	ct, err := verifier.VerifyConnectToken(jwtValid)
 	require.NoError(t, err)
 	require.Equal(t, "2694", ct.UserID)
@@ -214,7 +214,7 @@ func Test_tokenVerifierJWT_Audience(t *testing.T) {
 	ruleConfig := rule.DefaultConfig
 	ruleContainer, err := rule.NewContainer(ruleConfig)
 	require.NoError(t, err)
-	verifier := NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, "", "test2", ""}, ruleContainer)
+	verifier := NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, "", "", "test2", ""}, ruleContainer)
 
 	// Token without aud.
 	_, err = verifier.VerifyConnectToken(jwtValid)
@@ -224,12 +224,12 @@ func Test_tokenVerifierJWT_Audience(t *testing.T) {
 	token := getRSAConnToken("user", time.Now().Add(time.Hour).Unix(), nil)
 
 	// Verifier with audience which does not match aud in token.
-	verifier = NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, "", "test2", ""}, ruleContainer)
+	verifier = NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, "", "", "test2", ""}, ruleContainer)
 	_, err = verifier.VerifyConnectToken(token)
 	require.ErrorIs(t, err, ErrInvalidToken)
 
 	// Verifier with token audience.
-	verifier = NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, "", "test", ""}, ruleContainer)
+	verifier = NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, "", "", "test", ""}, ruleContainer)
 	_, err = verifier.VerifyConnectToken(token)
 	require.NoError(t, err)
 }
@@ -238,7 +238,7 @@ func Test_tokenVerifierJWT_Issuer(t *testing.T) {
 	ruleConfig := rule.DefaultConfig
 	ruleContainer, err := rule.NewContainer(ruleConfig)
 	require.NoError(t, err)
-	verifier := NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, "", "", "test2"}, ruleContainer)
+	verifier := NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, "", "", "", "test2"}, ruleContainer)
 
 	// Token without iss.
 	_, err = verifier.VerifyConnectToken(jwtValid)
@@ -248,12 +248,12 @@ func Test_tokenVerifierJWT_Issuer(t *testing.T) {
 	token := getRSAConnToken("user", time.Now().Add(time.Hour).Unix(), nil)
 
 	// Verifier with issuer which does not match token iss.
-	verifier = NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, "", "", "test2"}, ruleContainer)
+	verifier = NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, "", "", "", "test2"}, ruleContainer)
 	_, err = verifier.VerifyConnectToken(token)
 	require.ErrorIs(t, err, ErrInvalidToken)
 
 	// Verifier with token issuer.
-	verifier = NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, "", "", "test"}, ruleContainer)
+	verifier = NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, "", "", "", "test"}, ruleContainer)
 	_, err = verifier.VerifyConnectToken(token)
 	require.NoError(t, err)
 }
@@ -262,7 +262,7 @@ func Test_tokenVerifierJWT_Expired(t *testing.T) {
 	ruleConfig := rule.DefaultConfig
 	ruleContainer, err := rule.NewContainer(ruleConfig)
 	require.NoError(t, err)
-	verifier := NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, "", "", ""}, ruleContainer)
+	verifier := NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, "", "", "", ""}, ruleContainer)
 	_, err = verifier.VerifyConnectToken(jwtExpired)
 	require.Error(t, err)
 	require.Equal(t, ErrTokenExpired, err)
@@ -272,7 +272,7 @@ func Test_tokenVerifierJWT_DisabledAlgorithm(t *testing.T) {
 	ruleConfig := rule.DefaultConfig
 	ruleContainer, err := rule.NewContainer(ruleConfig)
 	require.NoError(t, err)
-	verifier := NewTokenVerifierJWT(VerifierConfig{"", nil, nil, "", "", ""}, ruleContainer)
+	verifier := NewTokenVerifierJWT(VerifierConfig{"", nil, nil, "", "", "", ""}, ruleContainer)
 	_, err = verifier.VerifyConnectToken(jwtExpired)
 	require.Error(t, err)
 	require.True(t, errors.Is(err, ErrInvalidToken), err.Error())
@@ -282,7 +282,7 @@ func Test_tokenVerifierJWT_InvalidSignature(t *testing.T) {
 	ruleConfig := rule.DefaultConfig
 	ruleContainer, err := rule.NewContainer(ruleConfig)
 	require.NoError(t, err)
-	verifier := NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, "", "", ""}, ruleContainer)
+	verifier := NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, "", "", "", ""}, ruleContainer)
 	_, err = verifier.VerifyConnectToken(jwtInvalidSignature)
 	require.Error(t, err)
 }
@@ -291,7 +291,7 @@ func Test_tokenVerifierJWT_WithNotBefore(t *testing.T) {
 	ruleConfig := rule.DefaultConfig
 	ruleContainer, err := rule.NewContainer(ruleConfig)
 	require.NoError(t, err)
-	verifier := NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, "", "", ""}, ruleContainer)
+	verifier := NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, "", "", "", ""}, ruleContainer)
 	_, err = verifier.VerifyConnectToken(jwtNotBefore)
 	require.Error(t, err)
 }
@@ -300,7 +300,7 @@ func Test_tokenVerifierJWT_StringAudience(t *testing.T) {
 	ruleConfig := rule.DefaultConfig
 	ruleContainer, err := rule.NewContainer(ruleConfig)
 	require.NoError(t, err)
-	verifier := NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, "", "", ""}, ruleContainer)
+	verifier := NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, "", "", "", ""}, ruleContainer)
 	ct, err := verifier.VerifyConnectToken(jwtStringAud)
 	require.NoError(t, err)
 	require.Equal(t, "2694", ct.UserID)
@@ -310,7 +310,7 @@ func Test_tokenVerifierJWT_ArrayAudience(t *testing.T) {
 	ruleConfig := rule.DefaultConfig
 	ruleContainer, err := rule.NewContainer(ruleConfig)
 	require.NoError(t, err)
-	verifier := NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, "", "", ""}, ruleContainer)
+	verifier := NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, "", "", "", ""}, ruleContainer)
 	ct, err := verifier.VerifyConnectToken(jwtArrayAud)
 	require.NoError(t, err)
 	require.Equal(t, "2694", ct.UserID)
@@ -328,7 +328,7 @@ func Test_tokenVerifierJWT_VerifyConnectToken(t *testing.T) {
 	ruleContainer, err := rule.NewContainer(ruleConfig)
 	require.NoError(t, err)
 
-	verifierJWT := NewTokenVerifierJWT(VerifierConfig{"secret", rsaPubKey, ecdsaPubKey, "", "", ""}, ruleContainer)
+	verifierJWT := NewTokenVerifierJWT(VerifierConfig{"secret", rsaPubKey, ecdsaPubKey, "", "", "", ""}, ruleContainer)
 	_time := time.Now()
 	tests := []struct {
 		name     string
@@ -488,7 +488,7 @@ func Test_tokenVerifierJWT_VerifyConnectTokenWithJWK(t *testing.T) {
 			ruleContainer, err := rule.NewContainer(ruleConfig)
 			require.NoError(t, err)
 
-			verifier := NewTokenVerifierJWT(VerifierConfig{"", nil, nil, ts.URL, "", ""}, ruleContainer)
+			verifier := NewTokenVerifierJWT(VerifierConfig{"", nil, nil, ts.URL, "", "", ""}, ruleContainer)
 			token := getRSAConnToken(tt.token.user, tt.token.exp, privKey, jwt.WithKeyID(tt.jwk.kid))
 
 			got, err := verifier.VerifyConnectToken(token)
@@ -520,7 +520,7 @@ func Test_tokenVerifierJWT_VerifySubscribeToken(t *testing.T) {
 	ruleContainer, err := rule.NewContainer(ruleConfig)
 	require.NoError(t, err)
 
-	verifierJWT := NewTokenVerifierJWT(VerifierConfig{"secret", rsaPubKey, ecdsaPubKey, "", "", ""}, ruleContainer)
+	verifierJWT := NewTokenVerifierJWT(VerifierConfig{"secret", rsaPubKey, ecdsaPubKey, "", "", "", ""}, ruleContainer)
 	_time := time.Now()
 	tests := []struct {
 		name     string
@@ -626,7 +626,7 @@ func BenchmarkConnectTokenVerify_Valid(b *testing.B) {
 	ruleConfig := rule.DefaultConfig
 	ruleContainer, err := rule.NewContainer(ruleConfig)
 	require.NoError(b, err)
-	verifierJWT := NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, "", "", ""}, ruleContainer)
+	verifierJWT := NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, "", "", "", ""}, ruleContainer)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_, err := verifierJWT.VerifyConnectToken(jwtValid)
@@ -642,7 +642,7 @@ func BenchmarkConnectTokenVerify_Expired(b *testing.B) {
 	ruleConfig := rule.DefaultConfig
 	ruleContainer, err := rule.NewContainer(ruleConfig)
 	require.NoError(b, err)
-	verifier := NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, "", "", ""}, ruleContainer)
+	verifier := NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, "", "", "", ""}, ruleContainer)
 	for i := 0; i < b.N; i++ {
 		_, err := verifier.VerifyConnectToken(jwtExpired)
 		if err != ErrTokenExpired {

--- a/main.go
+++ b/main.go
@@ -1442,6 +1442,7 @@ func jwtVerifierConfig() jwtverify.VerifierConfig {
 	}
 
 	cfg.JWKSPublicEndpoint = v.GetString("token_jwks_public_endpoint")
+	cfg.JWKSKeycloakBaseEndpoint = v.GetString("token_jwks_keycloak_base_endpoint")
 	cfg.Audience = v.GetString("token_audience")
 	cfg.Issuer = v.GetString("token_issuer")
 


### PR DESCRIPTION
## Proposed changes

String option `token_jwks_keycloak_base_endpoint`.

Relates https://github.com/centrifugal/centrifuge-js/issues/216

When set tells Centrifugo that JWKS is managed by Keycloak. In this case Centrifugo expects `iss` claim to be `http(s)://<hostname>/auth/realms/<realm>`. Then upon validating a token Centrifugo constructs JWKS public endpoint on the fly in this way: `<token_jwks_keycloak_base_endpoint>/<realm>/protocol/openid-connect/certs`.