### PR TITLE
Per namespace history_meta_ttl

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -145,6 +145,7 @@ func (h *Executor) Publish(_ context.Context, cmd *PublishRequest) *PublishRespo
 
 	historySize := chOpts.HistorySize
 	historyTTL := chOpts.HistoryTTL
+	historyMetaTTL := chOpts.HistoryMetaTTL
 	if cmd.SkipHistory {
 		historySize = 0
 		historyTTL = 0
@@ -152,7 +153,7 @@ func (h *Executor) Publish(_ context.Context, cmd *PublishRequest) *PublishRespo
 
 	result, err := h.node.Publish(
 		cmd.Channel, data,
-		centrifuge.WithHistory(historySize, time.Duration(historyTTL)),
+		centrifuge.WithHistory(historySize, time.Duration(historyTTL), time.Duration(historyMetaTTL)),
 		centrifuge.WithTags(cmd.GetTags()),
 	)
 	if err != nil {
@@ -225,6 +226,7 @@ func (h *Executor) Broadcast(_ context.Context, cmd *BroadcastRequest) *Broadcas
 
 			historySize := chOpts.HistorySize
 			historyTTL := chOpts.HistoryTTL
+			historyMetaTTL := chOpts.HistoryMetaTTL
 			if cmd.SkipHistory {
 				historySize = 0
 				historyTTL = 0
@@ -232,7 +234,7 @@ func (h *Executor) Broadcast(_ context.Context, cmd *BroadcastRequest) *Broadcas
 
 			result, err := h.node.Publish(
 				ch, data,
-				centrifuge.WithHistory(historySize, time.Duration(historyTTL)),
+				centrifuge.WithHistory(historySize, time.Duration(historyTTL), time.Duration(historyMetaTTL)),
 				centrifuge.WithTags(cmd.GetTags()),
 			)
 			resp := &PublishResponse{}
@@ -549,8 +551,11 @@ func (h *Executor) History(_ context.Context, cmd *HistoryRequest) *HistoryRespo
 		}
 	}
 
+	historyMetaTTL := chOpts.HistoryMetaTTL
+
 	history, err := h.node.History(
 		ch,
+		centrifuge.WithHistoryMetaTTL(time.Duration(historyMetaTTL)),
 		centrifuge.WithLimit(int(cmd.Limit)),
 		centrifuge.WithSince(sp),
 		centrifuge.WithReverse(cmd.Reverse),

--- a/internal/client/handler.go
+++ b/internal/client/handler.go
@@ -419,6 +419,7 @@ func (h *Handler) OnClientConnecting(
 			EnableRecovery:    chOpts.ForceRecovery,
 			EnablePositioning: chOpts.ForcePositioning,
 			Source:            subsource.UserPersonal,
+			HistoryMetaTTL:    time.Duration(chOpts.HistoryMetaTTL),
 		}
 	}
 
@@ -469,6 +470,7 @@ func (h *Handler) OnClientConnecting(
 						EnableRecovery:    chOpts.ForceRecovery,
 						EnablePositioning: chOpts.ForcePositioning,
 						Source:            subsource.UniConnect,
+						HistoryMetaTTL:    time.Duration(chOpts.HistoryMetaTTL),
 					}
 				}
 			} else {
@@ -656,6 +658,7 @@ func (h *Handler) OnSubscribe(c Client, e centrifuge.SubscribeEvent, subscribePr
 	options.PushJoinLeave = chOpts.ForcePushJoinLeave
 	options.EnablePositioning = chOpts.ForcePositioning
 	options.EnableRecovery = chOpts.ForceRecovery
+	options.HistoryMetaTTL = time.Duration(chOpts.HistoryMetaTTL)
 
 	isPrivateChannel := h.ruleContainer.IsPrivateChannel(e.Channel)
 	isUserLimitedChannel := chOpts.UserLimitedChannels && h.ruleContainer.IsUserLimited(e.Channel)
@@ -776,7 +779,7 @@ func (h *Handler) OnPublish(c Client, e centrifuge.PublishEvent, publishProxyHan
 	result, err := h.node.Publish(
 		e.Channel, e.Data,
 		centrifuge.WithClientInfo(e.ClientInfo),
-		centrifuge.WithHistory(chOpts.HistorySize, time.Duration(chOpts.HistoryTTL)),
+		centrifuge.WithHistory(chOpts.HistorySize, time.Duration(chOpts.HistoryTTL), time.Duration(chOpts.HistoryMetaTTL)),
 	)
 	if err != nil {
 		h.node.Log(centrifuge.NewLogEntry(centrifuge.LogLevelError, "publish error", map[string]interface{}{"channel": e.Channel, "user": c.UserID(), "client": c.ID(), "error": err.Error()}))

--- a/internal/jwtverify/token_verifier_jwt.go
+++ b/internal/jwtverify/token_verifier_jwt.go
@@ -423,6 +423,7 @@ func (verifier *VerifierJWT) VerifyConnectToken(t string) (ConnectToken, error) 
 				EnablePositioning: positioning,
 				Data:              data,
 				Source:            subsource.ConnectionToken,
+				HistoryMetaTTL:    time.Duration(chOpts.HistoryMetaTTL),
 			}
 		}
 	} else if len(claims.Channels) > 0 {
@@ -441,6 +442,7 @@ func (verifier *VerifierJWT) VerifyConnectToken(t string) (ConnectToken, error) 
 				EnableRecovery:    chOpts.ForceRecovery,
 				EnablePositioning: chOpts.ForcePositioning,
 				Source:            subsource.ConnectionToken,
+				HistoryMetaTTL:    time.Duration(chOpts.HistoryMetaTTL),
 			}
 		}
 	}

--- a/internal/proxy/connect_handler.go
+++ b/internal/proxy/connect_handler.go
@@ -144,6 +144,7 @@ func (h *ConnectHandler) Handle(node *centrifuge.Node) ConnectingHandlerFunc {
 					EnableRecovery:    chOpts.ForceRecovery,
 					EnablePositioning: chOpts.ForcePositioning,
 					Source:            subsource.ConnectProxy,
+					HistoryMetaTTL:    time.Duration(chOpts.HistoryMetaTTL),
 				}
 			}
 			reply.Subscriptions = subscriptions

--- a/internal/proxy/publish_handler.go
+++ b/internal/proxy/publish_handler.go
@@ -132,6 +132,7 @@ func (h *PublishHandler) Handle(node *centrifuge.Node) PublishHandlerFunc {
 
 		historySize := chOpts.HistorySize
 		historyTTL := chOpts.HistoryTTL
+		historyMetaTTL := chOpts.HistoryMetaTTL
 
 		data := e.Data
 		if publishRep.Result != nil {
@@ -155,7 +156,7 @@ func (h *PublishHandler) Handle(node *centrifuge.Node) PublishHandlerFunc {
 		result, err := node.Publish(
 			e.Channel, data,
 			centrifuge.WithClientInfo(e.ClientInfo),
-			centrifuge.WithHistory(historySize, time.Duration(historyTTL)),
+			centrifuge.WithHistory(historySize, time.Duration(historyTTL), time.Duration(historyMetaTTL)),
 		)
 		return centrifuge.PublishReply{Result: &result}, err
 	}

--- a/internal/proxy/subscribe_handler.go
+++ b/internal/proxy/subscribe_handler.go
@@ -194,6 +194,7 @@ func (h *SubscribeHandler) Handle(node *centrifuge.Node) SubscribeHandlerFunc {
 				EnablePositioning: positioning,
 				Data:              data,
 				Source:            subsource.SubscribeProxy,
+				HistoryMetaTTL:    time.Duration(chOpts.HistoryMetaTTL),
 			},
 			ClientSideRefresh: true,
 		}, extra, nil

--- a/internal/rule/namespace.go
+++ b/internal/rule/namespace.go
@@ -52,6 +52,11 @@ type ChannelOptions struct {
 	// grows it's important to remove history for inactive channels.
 	HistoryTTL tools.Duration `mapstructure:"history_ttl" json:"history_ttl"`
 
+	// HistoryMetaTTL is a time to live for history stream meta information. Must be
+	// much larger than HistoryTTL in common scenario. If zero, then we use global value
+	// set over default_history_meta_ttl on configuration top level.
+	HistoryMetaTTL tools.Duration `mapstructure:"history_meta_ttl" json:"history_meta_ttl"`
+
 	// ForcePositioning enables client positioning. This means that StreamPosition
 	// will be exposed to the client and server will look that no messages from
 	// PUB/SUB layer lost. In the loss found – client is disconnected (or unsubscribed)

--- a/main.go
+++ b/main.go
@@ -98,11 +98,15 @@ func bindCentrifugoConfig() {
 		"token_audience":             "",
 		"token_issuer":               "",
 
+		"default_history_meta_ttl": 90 * 24 * time.Hour,
+		"default_presence_ttl":     60 * time.Second,
+
 		"presence":                      false,
 		"join_leave":                    false,
 		"force_push_join_leave":         false,
 		"history_size":                  0,
 		"history_ttl":                   0,
+		"history_meta_ttl":              0,
 		"force_positioning":             false,
 		"allow_positioning":             false,
 		"force_recovery":                false,
@@ -203,9 +207,6 @@ func bindCentrifugoConfig() {
 		"redis_prefix":          "centrifugo",
 		"redis_connect_timeout": time.Second,
 		"redis_io_timeout":      4 * time.Second,
-
-		"history_meta_ttl": 90 * 24 * time.Hour,
-		"presence_ttl":     60 * time.Second,
 
 		"grpc_api":         false,
 		"grpc_api_address": "",
@@ -1363,6 +1364,7 @@ func ruleConfig() rule.Config {
 	cfg.ForcePushJoinLeave = v.GetBool("force_push_join_leave")
 	cfg.HistorySize = v.GetInt("history_size")
 	cfg.HistoryTTL = tools.Duration(GetDuration("history_ttl", true))
+	cfg.HistoryMetaTTL = tools.Duration(GetDuration("history_meta_ttl", true))
 	cfg.ForcePositioning = v.GetBool("force_positioning")
 	cfg.AllowPositioning = v.GetBool("allow_positioning")
 	cfg.AllowRecovery = v.GetBool("allow_recovery")
@@ -1793,7 +1795,7 @@ func nodeConfig(version string) centrifuge.Config {
 	cfg.NodeInfoMetricsAggregateInterval = GetDuration("node_info_metrics_aggregate_interval")
 	cfg.HistoryMaxPublicationLimit = v.GetInt("client_history_max_publication_limit")
 	cfg.RecoveryMaxPublicationLimit = v.GetInt("client_recovery_max_publication_limit")
-	cfg.HistoryMetaTTL = GetDuration("history_meta_ttl", true)
+	cfg.HistoryMetaTTL = GetDuration("default_history_meta_ttl", true)
 
 	level, ok := logStringToLevel[strings.ToLower(v.GetString("log_level"))]
 	if !ok {
@@ -2207,7 +2209,7 @@ func redisEngine(n *centrifuge.Node) (centrifuge.Broker, centrifuge.PresenceMana
 	presenceManager, err := centrifuge.NewRedisPresenceManager(n, centrifuge.RedisPresenceManagerConfig{
 		Shards:      redisShards,
 		Prefix:      viper.GetString("redis_prefix"),
-		PresenceTTL: GetDuration("presence_ttl", true),
+		PresenceTTL: GetDuration("default_presence_ttl", true),
 	})
 	if err != nil {
 		return nil, nil, "", err
@@ -2287,7 +2289,7 @@ func tarantoolEngine(n *centrifuge.Node) (centrifuge.Broker, centrifuge.Presence
 	}
 	presenceManager, err := tntengine.NewPresenceManager(n, tntengine.PresenceManagerConfig{
 		Shards:      tarantoolShards,
-		PresenceTTL: GetDuration("presence_ttl", true),
+		PresenceTTL: GetDuration("default_presence_ttl", true),
 	})
 	if err != nil {
 		return nil, nil, "", err


### PR DESCRIPTION
## Proposed changes

This introduces a duration option `history_meta_ttl` for channel namespace.

Global meta TTL can be set over `default_history_meta_ttl` duration option (it's 90 days if not explicitly set).

Also renamed `presence_ttl` to `default_presence_ttl` – seems at some point in the future we may want making presence TTL configurable on namespace level also.

Relates #599