### PR TITLE
Swagger spec generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ web:
 	./misc/scripts/update_web.sh
 
 swagger-web:
+	make generate
 	./misc/scripts/update_swagger_web.sh
 
 package:

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,9 @@ generate:
 web:
 	./misc/scripts/update_web.sh
 
+swagger-web:
+	./misc/scripts/update_swagger_web.sh
+
 package:
 	./misc/scripts/package.sh $(VERSION) $(ITERATION)
 

--- a/internal/apiproto/api.proto
+++ b/internal/apiproto/api.proto
@@ -4,16 +4,9 @@ package centrifugal.centrifugo.api;
 
 option go_package = "./;apiproto";
 
-import "google/api/annotations.proto";
-
 service CentrifugoApi {
     rpc Batch(BatchRequest) returns (BatchResponse) {}
-    rpc Publish (PublishRequest) returns (PublishResponse) {
-        option (google.api.http) = {
-            post: "/publish",
-            body: "*"
-        };
-    }
+    rpc Publish (PublishRequest) returns (PublishResponse) {}
     rpc Broadcast (BroadcastRequest) returns (BroadcastResponse) {}
     rpc Subscribe (SubscribeRequest) returns (SubscribeResponse) {}
     rpc Unsubscribe (UnsubscribeRequest) returns (UnsubscribeResponse) {}

--- a/internal/apiproto/api.proto
+++ b/internal/apiproto/api.proto
@@ -4,9 +4,16 @@ package centrifugal.centrifugo.api;
 
 option go_package = "./;apiproto";
 
+import "google/api/annotations.proto";
+
 service CentrifugoApi {
     rpc Batch(BatchRequest) returns (BatchResponse) {}
-    rpc Publish (PublishRequest) returns (PublishResponse) {}
+    rpc Publish (PublishRequest) returns (PublishResponse) {
+        option (google.api.http) = {
+            post: "/publish",
+            body: "*"
+        };
+    }
     rpc Broadcast (BroadcastRequest) returns (BroadcastResponse) {}
     rpc Subscribe (SubscribeRequest) returns (SubscribeResponse) {}
     rpc Unsubscribe (UnsubscribeRequest) returns (UnsubscribeResponse) {}

--- a/internal/apiproto/api.swagger.json
+++ b/internal/apiproto/api.swagger.json
@@ -6,9 +6,6 @@
   },
   "tags": [
     {
-      "name": "CentrifugoApi"
-    },
-    {
       "name": "publication"
     },
     {
@@ -37,12 +34,6 @@
     },
     {
       "name": "batch"
-    },
-    {
-      "name": "oss"
-    },
-    {
-      "name": "pro"
     }
   ],
   "basePath": "/api",
@@ -61,14 +52,20 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/apiBatchResponse"
+              "$ref": "#/definitions/centrifugal.centrifugo.api.BatchResponse"
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
+          "400": {
+            "description": "Returned in case of invalid request.",
+            "schema": {}
+          },
+          "401": {
+            "description": "Returned in case of missing auth.",
+            "schema": {}
+          },
+          "500": {
+            "description": "Returned in case of internal server error.",
+            "schema": {}
           }
         },
         "parameters": [
@@ -77,13 +74,12 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/apiBatchRequest"
+              "$ref": "#/definitions/centrifugal.centrifugo.api.BatchRequest"
             }
           }
         ],
         "tags": [
-          "batch",
-          "oss"
+          "batch"
         ]
       }
     },
@@ -95,14 +91,20 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/apiBlockUserResponse"
+              "$ref": "#/definitions/centrifugal.centrifugo.api.BlockUserResponse"
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
+          "400": {
+            "description": "Returned in case of invalid request.",
+            "schema": {}
+          },
+          "401": {
+            "description": "Returned in case of missing auth.",
+            "schema": {}
+          },
+          "500": {
+            "description": "Returned in case of internal server error.",
+            "schema": {}
           }
         },
         "parameters": [
@@ -111,13 +113,12 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/apiBlockUserRequest"
+              "$ref": "#/definitions/centrifugal.centrifugo.api.BlockUserRequest"
             }
           }
         ],
         "tags": [
-          "user block",
-          "pro"
+          "user block"
         ]
       }
     },
@@ -129,14 +130,20 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/apiBroadcastResponse"
+              "$ref": "#/definitions/centrifugal.centrifugo.api.BroadcastResponse"
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
+          "400": {
+            "description": "Returned in case of invalid request.",
+            "schema": {}
+          },
+          "401": {
+            "description": "Returned in case of missing auth.",
+            "schema": {}
+          },
+          "500": {
+            "description": "Returned in case of internal server error.",
+            "schema": {}
           }
         },
         "parameters": [
@@ -145,13 +152,12 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/apiBroadcastRequest"
+              "$ref": "#/definitions/centrifugal.centrifugo.api.BroadcastRequest"
             }
           }
         ],
         "tags": [
-          "publication",
-          "oss"
+          "publication"
         ]
       }
     },
@@ -163,14 +169,20 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/apiChannelsResponse"
+              "$ref": "#/definitions/centrifugal.centrifugo.api.ChannelsResponse"
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
+          "400": {
+            "description": "Returned in case of invalid request.",
+            "schema": {}
+          },
+          "401": {
+            "description": "Returned in case of missing auth.",
+            "schema": {}
+          },
+          "500": {
+            "description": "Returned in case of internal server error.",
+            "schema": {}
           }
         },
         "parameters": [
@@ -179,13 +191,12 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/apiChannelsRequest"
+              "$ref": "#/definitions/centrifugal.centrifugo.api.ChannelsRequest"
             }
           }
         ],
         "tags": [
-          "stats",
-          "oss"
+          "stats"
         ]
       }
     },
@@ -197,14 +208,20 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/apiConnectionsResponse"
+              "$ref": "#/definitions/centrifugal.centrifugo.api.ConnectionsResponse"
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
+          "400": {
+            "description": "Returned in case of invalid request.",
+            "schema": {}
+          },
+          "401": {
+            "description": "Returned in case of missing auth.",
+            "schema": {}
+          },
+          "500": {
+            "description": "Returned in case of internal server error.",
+            "schema": {}
           }
         },
         "parameters": [
@@ -213,13 +230,12 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/apiConnectionsRequest"
+              "$ref": "#/definitions/centrifugal.centrifugo.api.ConnectionsRequest"
             }
           }
         ],
         "tags": [
-          "stats",
-          "pro"
+          "stats"
         ]
       }
     },
@@ -231,14 +247,20 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/apiDeleteUserStatusResponse"
+              "$ref": "#/definitions/centrifugal.centrifugo.api.DeleteUserStatusResponse"
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
+          "400": {
+            "description": "Returned in case of invalid request.",
+            "schema": {}
+          },
+          "401": {
+            "description": "Returned in case of missing auth.",
+            "schema": {}
+          },
+          "500": {
+            "description": "Returned in case of internal server error.",
+            "schema": {}
           }
         },
         "parameters": [
@@ -247,13 +269,12 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/apiDeleteUserStatusRequest"
+              "$ref": "#/definitions/centrifugal.centrifugo.api.DeleteUserStatusRequest"
             }
           }
         ],
         "tags": [
-          "user status",
-          "pro"
+          "user status"
         ]
       }
     },
@@ -265,14 +286,20 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/apiDeviceListResponse"
+              "$ref": "#/definitions/centrifugal.centrifugo.api.DeviceListResponse"
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
+          "400": {
+            "description": "Returned in case of invalid request.",
+            "schema": {}
+          },
+          "401": {
+            "description": "Returned in case of missing auth.",
+            "schema": {}
+          },
+          "500": {
+            "description": "Returned in case of internal server error.",
+            "schema": {}
           }
         },
         "parameters": [
@@ -281,13 +308,12 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/apiDeviceListRequest"
+              "$ref": "#/definitions/centrifugal.centrifugo.api.DeviceListRequest"
             }
           }
         ],
         "tags": [
-          "push notifications",
-          "pro"
+          "push notifications"
         ]
       }
     },
@@ -299,14 +325,20 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/apiDeviceRegisterResponse"
+              "$ref": "#/definitions/centrifugal.centrifugo.api.DeviceRegisterResponse"
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
+          "400": {
+            "description": "Returned in case of invalid request.",
+            "schema": {}
+          },
+          "401": {
+            "description": "Returned in case of missing auth.",
+            "schema": {}
+          },
+          "500": {
+            "description": "Returned in case of internal server error.",
+            "schema": {}
           }
         },
         "parameters": [
@@ -315,13 +347,12 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/apiDeviceRegisterRequest"
+              "$ref": "#/definitions/centrifugal.centrifugo.api.DeviceRegisterRequest"
             }
           }
         ],
         "tags": [
-          "push notifications",
-          "pro"
+          "push notifications"
         ]
       }
     },
@@ -333,14 +364,20 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/apiDeviceRemoveResponse"
+              "$ref": "#/definitions/centrifugal.centrifugo.api.DeviceRemoveResponse"
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
+          "400": {
+            "description": "Returned in case of invalid request.",
+            "schema": {}
+          },
+          "401": {
+            "description": "Returned in case of missing auth.",
+            "schema": {}
+          },
+          "500": {
+            "description": "Returned in case of internal server error.",
+            "schema": {}
           }
         },
         "parameters": [
@@ -349,13 +386,12 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/apiDeviceRemoveRequest"
+              "$ref": "#/definitions/centrifugal.centrifugo.api.DeviceRemoveRequest"
             }
           }
         ],
         "tags": [
-          "push notifications",
-          "pro"
+          "push notifications"
         ]
       }
     },
@@ -367,14 +403,20 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/apiDeviceUpdateResponse"
+              "$ref": "#/definitions/centrifugal.centrifugo.api.DeviceUpdateResponse"
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
+          "400": {
+            "description": "Returned in case of invalid request.",
+            "schema": {}
+          },
+          "401": {
+            "description": "Returned in case of missing auth.",
+            "schema": {}
+          },
+          "500": {
+            "description": "Returned in case of internal server error.",
+            "schema": {}
           }
         },
         "parameters": [
@@ -383,13 +425,12 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/apiDeviceUpdateRequest"
+              "$ref": "#/definitions/centrifugal.centrifugo.api.DeviceUpdateRequest"
             }
           }
         ],
         "tags": [
-          "push notifications",
-          "pro"
+          "push notifications"
         ]
       }
     },
@@ -401,14 +442,20 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/apiDisconnectResponse"
+              "$ref": "#/definitions/centrifugal.centrifugo.api.DisconnectResponse"
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
+          "400": {
+            "description": "Returned in case of invalid request.",
+            "schema": {}
+          },
+          "401": {
+            "description": "Returned in case of missing auth.",
+            "schema": {}
+          },
+          "500": {
+            "description": "Returned in case of internal server error.",
+            "schema": {}
           }
         },
         "parameters": [
@@ -417,13 +464,12 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/apiDisconnectRequest"
+              "$ref": "#/definitions/centrifugal.centrifugo.api.DisconnectRequest"
             }
           }
         ],
         "tags": [
-          "connection management",
-          "oss"
+          "connection management"
         ]
       }
     },
@@ -435,14 +481,20 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/apiGetUserStatusResponse"
+              "$ref": "#/definitions/centrifugal.centrifugo.api.GetUserStatusResponse"
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
+          "400": {
+            "description": "Returned in case of invalid request.",
+            "schema": {}
+          },
+          "401": {
+            "description": "Returned in case of missing auth.",
+            "schema": {}
+          },
+          "500": {
+            "description": "Returned in case of internal server error.",
+            "schema": {}
           }
         },
         "parameters": [
@@ -451,13 +503,12 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/apiGetUserStatusRequest"
+              "$ref": "#/definitions/centrifugal.centrifugo.api.GetUserStatusRequest"
             }
           }
         ],
         "tags": [
-          "user status",
-          "pro"
+          "user status"
         ]
       }
     },
@@ -469,14 +520,20 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/apiHistoryResponse"
+              "$ref": "#/definitions/centrifugal.centrifugo.api.HistoryResponse"
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
+          "400": {
+            "description": "Returned in case of invalid request.",
+            "schema": {}
+          },
+          "401": {
+            "description": "Returned in case of missing auth.",
+            "schema": {}
+          },
+          "500": {
+            "description": "Returned in case of internal server error.",
+            "schema": {}
           }
         },
         "parameters": [
@@ -485,13 +542,12 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/apiHistoryRequest"
+              "$ref": "#/definitions/centrifugal.centrifugo.api.HistoryRequest"
             }
           }
         ],
         "tags": [
-          "history",
-          "oss"
+          "history"
         ]
       }
     },
@@ -503,14 +559,20 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/apiHistoryRemoveResponse"
+              "$ref": "#/definitions/centrifugal.centrifugo.api.HistoryRemoveResponse"
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
+          "400": {
+            "description": "Returned in case of invalid request.",
+            "schema": {}
+          },
+          "401": {
+            "description": "Returned in case of missing auth.",
+            "schema": {}
+          },
+          "500": {
+            "description": "Returned in case of internal server error.",
+            "schema": {}
           }
         },
         "parameters": [
@@ -519,13 +581,12 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/apiHistoryRemoveRequest"
+              "$ref": "#/definitions/centrifugal.centrifugo.api.HistoryRemoveRequest"
             }
           }
         ],
         "tags": [
-          "history",
-          "oss"
+          "history"
         ]
       }
     },
@@ -537,14 +598,20 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/apiInfoResponse"
+              "$ref": "#/definitions/centrifugal.centrifugo.api.InfoResponse"
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
+          "400": {
+            "description": "Returned in case of invalid request.",
+            "schema": {}
+          },
+          "401": {
+            "description": "Returned in case of missing auth.",
+            "schema": {}
+          },
+          "500": {
+            "description": "Returned in case of internal server error.",
+            "schema": {}
           }
         },
         "parameters": [
@@ -553,13 +620,12 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/apiInfoRequest"
+              "$ref": "#/definitions/centrifugal.centrifugo.api.InfoRequest"
             }
           }
         ],
         "tags": [
-          "stats",
-          "oss"
+          "stats"
         ]
       }
     },
@@ -571,14 +637,20 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/apiInvalidateUserTokensResponse"
+              "$ref": "#/definitions/centrifugal.centrifugo.api.InvalidateUserTokensResponse"
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
+          "400": {
+            "description": "Returned in case of invalid request.",
+            "schema": {}
+          },
+          "401": {
+            "description": "Returned in case of missing auth.",
+            "schema": {}
+          },
+          "500": {
+            "description": "Returned in case of internal server error.",
+            "schema": {}
           }
         },
         "parameters": [
@@ -587,13 +659,12 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/apiInvalidateUserTokensRequest"
+              "$ref": "#/definitions/centrifugal.centrifugo.api.InvalidateUserTokensRequest"
             }
           }
         ],
         "tags": [
-          "token",
-          "pro"
+          "token"
         ]
       }
     },
@@ -605,14 +676,20 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/apiPresenceResponse"
+              "$ref": "#/definitions/centrifugal.centrifugo.api.PresenceResponse"
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
+          "400": {
+            "description": "Returned in case of invalid request.",
+            "schema": {}
+          },
+          "401": {
+            "description": "Returned in case of missing auth.",
+            "schema": {}
+          },
+          "500": {
+            "description": "Returned in case of internal server error.",
+            "schema": {}
           }
         },
         "parameters": [
@@ -621,13 +698,12 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/apiPresenceRequest"
+              "$ref": "#/definitions/centrifugal.centrifugo.api.PresenceRequest"
             }
           }
         ],
         "tags": [
-          "presence",
-          "oss"
+          "presence"
         ]
       }
     },
@@ -639,14 +715,20 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/apiPresenceStatsResponse"
+              "$ref": "#/definitions/centrifugal.centrifugo.api.PresenceStatsResponse"
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
+          "400": {
+            "description": "Returned in case of invalid request.",
+            "schema": {}
+          },
+          "401": {
+            "description": "Returned in case of missing auth.",
+            "schema": {}
+          },
+          "500": {
+            "description": "Returned in case of internal server error.",
+            "schema": {}
           }
         },
         "parameters": [
@@ -655,13 +737,12 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/apiPresenceStatsRequest"
+              "$ref": "#/definitions/centrifugal.centrifugo.api.PresenceStatsRequest"
             }
           }
         ],
         "tags": [
-          "presence",
-          "oss"
+          "presence"
         ]
       }
     },
@@ -673,14 +754,20 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/apiPublishResponse"
+              "$ref": "#/definitions/centrifugal.centrifugo.api.PublishResponse"
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
+          "400": {
+            "description": "Returned in case of invalid request.",
+            "schema": {}
+          },
+          "401": {
+            "description": "Returned in case of missing auth.",
+            "schema": {}
+          },
+          "500": {
+            "description": "Returned in case of internal server error.",
+            "schema": {}
           }
         },
         "parameters": [
@@ -689,13 +776,12 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/apiPublishRequest"
+              "$ref": "#/definitions/centrifugal.centrifugo.api.PublishRequest"
             }
           }
         ],
         "tags": [
-          "publication",
-          "oss"
+          "publication"
         ]
       }
     },
@@ -707,14 +793,20 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/apiPushUserChannelListResponse"
+              "$ref": "#/definitions/centrifugal.centrifugo.api.PushUserChannelListResponse"
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
+          "400": {
+            "description": "Returned in case of invalid request.",
+            "schema": {}
+          },
+          "401": {
+            "description": "Returned in case of missing auth.",
+            "schema": {}
+          },
+          "500": {
+            "description": "Returned in case of internal server error.",
+            "schema": {}
           }
         },
         "parameters": [
@@ -723,13 +815,12 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/apiPushUserChannelListRequest"
+              "$ref": "#/definitions/centrifugal.centrifugo.api.PushUserChannelListRequest"
             }
           }
         ],
         "tags": [
-          "push notifications",
-          "pro"
+          "push notifications"
         ]
       }
     },
@@ -741,14 +832,20 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/apiPushUserChannelUpdateResponse"
+              "$ref": "#/definitions/centrifugal.centrifugo.api.PushUserChannelUpdateResponse"
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
+          "400": {
+            "description": "Returned in case of invalid request.",
+            "schema": {}
+          },
+          "401": {
+            "description": "Returned in case of missing auth.",
+            "schema": {}
+          },
+          "500": {
+            "description": "Returned in case of internal server error.",
+            "schema": {}
           }
         },
         "parameters": [
@@ -757,13 +854,12 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/apiPushUserChannelUpdateRequest"
+              "$ref": "#/definitions/centrifugal.centrifugo.api.PushUserChannelUpdateRequest"
             }
           }
         ],
         "tags": [
-          "push notifications",
-          "pro"
+          "push notifications"
         ]
       }
     },
@@ -775,14 +871,20 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/apiRefreshResponse"
+              "$ref": "#/definitions/centrifugal.centrifugo.api.RefreshResponse"
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
+          "400": {
+            "description": "Returned in case of invalid request.",
+            "schema": {}
+          },
+          "401": {
+            "description": "Returned in case of missing auth.",
+            "schema": {}
+          },
+          "500": {
+            "description": "Returned in case of internal server error.",
+            "schema": {}
           }
         },
         "parameters": [
@@ -791,13 +893,12 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/apiRefreshRequest"
+              "$ref": "#/definitions/centrifugal.centrifugo.api.RefreshRequest"
             }
           }
         ],
         "tags": [
-          "connection management",
-          "oss"
+          "connection management"
         ]
       }
     },
@@ -809,14 +910,20 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/apiRevokeTokenResponse"
+              "$ref": "#/definitions/centrifugal.centrifugo.api.RevokeTokenResponse"
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
+          "400": {
+            "description": "Returned in case of invalid request.",
+            "schema": {}
+          },
+          "401": {
+            "description": "Returned in case of missing auth.",
+            "schema": {}
+          },
+          "500": {
+            "description": "Returned in case of internal server error.",
+            "schema": {}
           }
         },
         "parameters": [
@@ -825,13 +932,12 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/apiRevokeTokenRequest"
+              "$ref": "#/definitions/centrifugal.centrifugo.api.RevokeTokenRequest"
             }
           }
         ],
         "tags": [
-          "token",
-          "pro"
+          "token"
         ]
       }
     },
@@ -843,14 +949,20 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/apiSendPushNotificationResponse"
+              "$ref": "#/definitions/centrifugal.centrifugo.api.SendPushNotificationResponse"
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
+          "400": {
+            "description": "Returned in case of invalid request.",
+            "schema": {}
+          },
+          "401": {
+            "description": "Returned in case of missing auth.",
+            "schema": {}
+          },
+          "500": {
+            "description": "Returned in case of internal server error.",
+            "schema": {}
           }
         },
         "parameters": [
@@ -859,13 +971,12 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/apiSendPushNotificationRequest"
+              "$ref": "#/definitions/centrifugal.centrifugo.api.SendPushNotificationRequest"
             }
           }
         ],
         "tags": [
-          "push notifications",
-          "pro"
+          "push notifications"
         ]
       }
     },
@@ -877,14 +988,20 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/apiSubscribeResponse"
+              "$ref": "#/definitions/centrifugal.centrifugo.api.SubscribeResponse"
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
+          "400": {
+            "description": "Returned in case of invalid request.",
+            "schema": {}
+          },
+          "401": {
+            "description": "Returned in case of missing auth.",
+            "schema": {}
+          },
+          "500": {
+            "description": "Returned in case of internal server error.",
+            "schema": {}
           }
         },
         "parameters": [
@@ -893,13 +1010,12 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/apiSubscribeRequest"
+              "$ref": "#/definitions/centrifugal.centrifugo.api.SubscribeRequest"
             }
           }
         ],
         "tags": [
-          "connection management",
-          "oss"
+          "connection management"
         ]
       }
     },
@@ -911,14 +1027,20 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/apiUnblockUserResponse"
+              "$ref": "#/definitions/centrifugal.centrifugo.api.UnblockUserResponse"
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
+          "400": {
+            "description": "Returned in case of invalid request.",
+            "schema": {}
+          },
+          "401": {
+            "description": "Returned in case of missing auth.",
+            "schema": {}
+          },
+          "500": {
+            "description": "Returned in case of internal server error.",
+            "schema": {}
           }
         },
         "parameters": [
@@ -927,13 +1049,12 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/apiUnblockUserRequest"
+              "$ref": "#/definitions/centrifugal.centrifugo.api.UnblockUserRequest"
             }
           }
         ],
         "tags": [
-          "user block",
-          "pro"
+          "user block"
         ]
       }
     },
@@ -945,14 +1066,20 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/apiUnsubscribeResponse"
+              "$ref": "#/definitions/centrifugal.centrifugo.api.UnsubscribeResponse"
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
+          "400": {
+            "description": "Returned in case of invalid request.",
+            "schema": {}
+          },
+          "401": {
+            "description": "Returned in case of missing auth.",
+            "schema": {}
+          },
+          "500": {
+            "description": "Returned in case of internal server error.",
+            "schema": {}
           }
         },
         "parameters": [
@@ -961,13 +1088,12 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/apiUnsubscribeRequest"
+              "$ref": "#/definitions/centrifugal.centrifugo.api.UnsubscribeRequest"
             }
           }
         ],
         "tags": [
-          "connection management",
-          "oss"
+          "connection management"
         ]
       }
     },
@@ -979,14 +1105,20 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/apiUpdateUserStatusResponse"
+              "$ref": "#/definitions/centrifugal.centrifugo.api.UpdateUserStatusResponse"
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
+          "400": {
+            "description": "Returned in case of invalid request.",
+            "schema": {}
+          },
+          "401": {
+            "description": "Returned in case of missing auth.",
+            "schema": {}
+          },
+          "500": {
+            "description": "Returned in case of internal server error.",
+            "schema": {}
           }
         },
         "parameters": [
@@ -995,19 +1127,18 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/apiUpdateUserStatusRequest"
+              "$ref": "#/definitions/centrifugal.centrifugo.api.UpdateUserStatusRequest"
             }
           }
         ],
         "tags": [
-          "user status",
-          "pro"
+          "user status"
         ]
       }
     }
   },
   "definitions": {
-    "apiApnsPushNotification": {
+    "centrifugal.centrifugo.api.ApnsPushNotification": {
       "type": "object",
       "properties": {
         "headers": {
@@ -1021,57 +1152,56 @@
         }
       }
     },
-    "apiBatchRequest": {
+    "centrifugal.centrifugo.api.BatchRequest": {
       "type": "object",
       "properties": {
         "commands": {
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/apiCommand"
+            "$ref": "#/definitions/centrifugal.centrifugo.api.Command"
           }
         }
       }
     },
-    "apiBatchResponse": {
+    "centrifugal.centrifugo.api.BatchResponse": {
       "type": "object",
       "properties": {
         "replies": {
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/apiReply"
+            "$ref": "#/definitions/centrifugal.centrifugo.api.Reply"
           }
         }
       }
     },
-    "apiBlockUserRequest": {
+    "centrifugal.centrifugo.api.BlockUserRequest": {
       "type": "object",
       "properties": {
         "expire_at": {
-          "type": "string",
-          "format": "int64"
+          "type": "integer"
         },
         "user": {
           "type": "string"
         }
       }
     },
-    "apiBlockUserResponse": {
+    "centrifugal.centrifugo.api.BlockUserResponse": {
       "type": "object",
       "properties": {
         "error": {
-          "$ref": "#/definitions/apiError"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.Error"
         },
         "result": {
-          "$ref": "#/definitions/apiBlockUserResult"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.BlockUserResult"
         }
       }
     },
-    "apiBlockUserResult": {
+    "centrifugal.centrifugo.api.BlockUserResult": {
       "type": "object"
     },
-    "apiBoolValue": {
+    "centrifugal.centrifugo.api.BoolValue": {
       "type": "object",
       "properties": {
         "value": {
@@ -1079,7 +1209,7 @@
         }
       }
     },
-    "apiBroadcastRequest": {
+    "centrifugal.centrifugo.api.BroadcastRequest": {
       "type": "object",
       "properties": {
         "channels": {
@@ -1105,30 +1235,30 @@
         }
       }
     },
-    "apiBroadcastResponse": {
+    "centrifugal.centrifugo.api.BroadcastResponse": {
       "type": "object",
       "properties": {
         "error": {
-          "$ref": "#/definitions/apiError"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.Error"
         },
         "result": {
-          "$ref": "#/definitions/apiBroadcastResult"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.BroadcastResult"
         }
       }
     },
-    "apiBroadcastResult": {
+    "centrifugal.centrifugo.api.BroadcastResult": {
       "type": "object",
       "properties": {
         "responses": {
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/apiPublishResponse"
+            "$ref": "#/definitions/centrifugal.centrifugo.api.PublishResponse"
           }
         }
       }
     },
-    "apiChannelContext": {
+    "centrifugal.centrifugo.api.ChannelContext": {
       "type": "object",
       "properties": {
         "source": {
@@ -1137,7 +1267,7 @@
         }
       }
     },
-    "apiChannelInfo": {
+    "centrifugal.centrifugo.api.ChannelInfo": {
       "type": "object",
       "properties": {
         "num_clients": {
@@ -1146,7 +1276,7 @@
         }
       }
     },
-    "apiChannelsRequest": {
+    "centrifugal.centrifugo.api.ChannelsRequest": {
       "type": "object",
       "properties": {
         "pattern": {
@@ -1154,29 +1284,29 @@
         }
       }
     },
-    "apiChannelsResponse": {
+    "centrifugal.centrifugo.api.ChannelsResponse": {
       "type": "object",
       "properties": {
         "error": {
-          "$ref": "#/definitions/apiError"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.Error"
         },
         "result": {
-          "$ref": "#/definitions/apiChannelsResult"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.ChannelsResult"
         }
       }
     },
-    "apiChannelsResult": {
+    "centrifugal.centrifugo.api.ChannelsResult": {
       "type": "object",
       "properties": {
         "channels": {
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/definitions/apiChannelInfo"
+            "$ref": "#/definitions/centrifugal.centrifugo.api.ChannelInfo"
           }
         }
       }
     },
-    "apiClientInfo": {
+    "centrifugal.centrifugo.api.ClientInfo": {
       "type": "object",
       "properties": {
         "user": {
@@ -1193,96 +1323,96 @@
         }
       }
     },
-    "apiCommand": {
+    "centrifugal.centrifugo.api.Command": {
       "type": "object",
       "properties": {
         "publish": {
-          "$ref": "#/definitions/apiPublishRequest"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.PublishRequest"
         },
         "broadcast": {
-          "$ref": "#/definitions/apiBroadcastRequest"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.BroadcastRequest"
         },
         "subscribe": {
-          "$ref": "#/definitions/apiSubscribeRequest"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.SubscribeRequest"
         },
         "unsubscribe": {
-          "$ref": "#/definitions/apiUnsubscribeRequest"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.UnsubscribeRequest"
         },
         "disconnect": {
-          "$ref": "#/definitions/apiDisconnectRequest"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.DisconnectRequest"
         },
         "presence": {
-          "$ref": "#/definitions/apiPresenceRequest"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.PresenceRequest"
         },
         "presence_stats": {
-          "$ref": "#/definitions/apiPresenceStatsRequest"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.PresenceStatsRequest"
         },
         "history": {
-          "$ref": "#/definitions/apiHistoryRequest"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.HistoryRequest"
         },
         "history_remove": {
-          "$ref": "#/definitions/apiHistoryRemoveRequest"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.HistoryRemoveRequest"
         },
         "info": {
-          "$ref": "#/definitions/apiInfoRequest"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.InfoRequest"
         },
         "rpc": {
-          "$ref": "#/definitions/apiRPCRequest"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.RPCRequest"
         },
         "refresh": {
-          "$ref": "#/definitions/apiRefreshRequest"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.RefreshRequest"
         },
         "channels": {
-          "$ref": "#/definitions/apiChannelsRequest"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.ChannelsRequest"
         },
         "connections": {
-          "$ref": "#/definitions/apiConnectionsRequest"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.ConnectionsRequest"
         },
         "update_user_status": {
-          "$ref": "#/definitions/apiUpdateUserStatusRequest"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.UpdateUserStatusRequest"
         },
         "get_user_status": {
-          "$ref": "#/definitions/apiGetUserStatusRequest"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.GetUserStatusRequest"
         },
         "delete_user_status": {
-          "$ref": "#/definitions/apiDeleteUserStatusRequest"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.DeleteUserStatusRequest"
         },
         "block_user": {
-          "$ref": "#/definitions/apiBlockUserRequest"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.BlockUserRequest"
         },
         "unblock_user": {
-          "$ref": "#/definitions/apiUnblockUserRequest"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.UnblockUserRequest"
         },
         "revoke_token": {
-          "$ref": "#/definitions/apiRevokeTokenRequest"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.RevokeTokenRequest"
         },
         "invalidate_user_tokens": {
-          "$ref": "#/definitions/apiInvalidateUserTokensRequest"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.InvalidateUserTokensRequest"
         },
         "device_register": {
-          "$ref": "#/definitions/apiDeviceRegisterRequest"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.DeviceRegisterRequest"
         },
         "device_update": {
-          "$ref": "#/definitions/apiDeviceUpdateRequest"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.DeviceUpdateRequest"
         },
         "device_remove": {
-          "$ref": "#/definitions/apiDeviceRemoveRequest"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.DeviceRemoveRequest"
         },
         "device_list": {
-          "$ref": "#/definitions/apiDeviceListRequest"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.DeviceListRequest"
         },
         "push_user_channel_list": {
-          "$ref": "#/definitions/apiPushUserChannelListRequest"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.PushUserChannelListRequest"
         },
         "push_user_channel_update": {
-          "$ref": "#/definitions/apiPushUserChannelUpdateRequest"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.PushUserChannelUpdateRequest"
         },
         "send_push_notification": {
-          "$ref": "#/definitions/apiSendPushNotificationRequest"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.SendPushNotificationRequest"
         }
       }
     },
-    "apiConnectionInfo": {
+    "centrifugal.centrifugo.api.ConnectionInfo": {
       "type": "object",
       "properties": {
         "app_name": {
@@ -1302,26 +1432,26 @@
           "description": "5-7 dropped for backwards compatibility."
         },
         "state": {
-          "$ref": "#/definitions/apiConnectionState"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.ConnectionState"
         }
       }
     },
-    "apiConnectionState": {
+    "centrifugal.centrifugo.api.ConnectionState": {
       "type": "object",
       "properties": {
         "channels": {
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/definitions/apiChannelContext"
+            "$ref": "#/definitions/centrifugal.centrifugo.api.ChannelContext"
           }
         },
         "connection_token": {
-          "$ref": "#/definitions/apiConnectionTokenInfo"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.ConnectionTokenInfo"
         },
         "subscription_tokens": {
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/definitions/apiSubscriptionTokenInfo"
+            "$ref": "#/definitions/centrifugal.centrifugo.api.SubscriptionTokenInfo"
           }
         },
         "meta": {
@@ -1329,19 +1459,18 @@
         }
       }
     },
-    "apiConnectionTokenInfo": {
+    "centrifugal.centrifugo.api.ConnectionTokenInfo": {
       "type": "object",
       "properties": {
         "uid": {
           "type": "string"
         },
         "issued_at": {
-          "type": "string",
-          "format": "int64"
+          "type": "integer"
         }
       }
     },
-    "apiConnectionsRequest": {
+    "centrifugal.centrifugo.api.ConnectionsRequest": {
       "type": "object",
       "properties": {
         "user": {
@@ -1352,29 +1481,29 @@
         }
       }
     },
-    "apiConnectionsResponse": {
+    "centrifugal.centrifugo.api.ConnectionsResponse": {
       "type": "object",
       "properties": {
         "error": {
-          "$ref": "#/definitions/apiError"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.Error"
         },
         "result": {
-          "$ref": "#/definitions/apiConnectionsResult"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.ConnectionsResult"
         }
       }
     },
-    "apiConnectionsResult": {
+    "centrifugal.centrifugo.api.ConnectionsResult": {
       "type": "object",
       "properties": {
         "connections": {
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/definitions/apiConnectionInfo"
+            "$ref": "#/definitions/centrifugal.centrifugo.api.ConnectionInfo"
           }
         }
       }
     },
-    "apiDeleteUserStatusRequest": {
+    "centrifugal.centrifugo.api.DeleteUserStatusRequest": {
       "type": "object",
       "properties": {
         "users": {
@@ -1385,21 +1514,21 @@
         }
       }
     },
-    "apiDeleteUserStatusResponse": {
+    "centrifugal.centrifugo.api.DeleteUserStatusResponse": {
       "type": "object",
       "properties": {
         "error": {
-          "$ref": "#/definitions/apiError"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.Error"
         },
         "result": {
-          "$ref": "#/definitions/apiDeleteUserStatusResult"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.DeleteUserStatusResult"
         }
       }
     },
-    "apiDeleteUserStatusResult": {
+    "centrifugal.centrifugo.api.DeleteUserStatusResult": {
       "type": "object"
     },
-    "apiDevice": {
+    "centrifugal.centrifugo.api.Device": {
       "type": "object",
       "properties": {
         "id": {
@@ -1437,7 +1566,7 @@
         }
       }
     },
-    "apiDeviceChannelsUpdate": {
+    "centrifugal.centrifugo.api.DeviceChannelsUpdate": {
       "type": "object",
       "properties": {
         "op": {
@@ -1452,7 +1581,7 @@
         }
       }
     },
-    "apiDeviceListRequest": {
+    "centrifugal.centrifugo.api.DeviceListRequest": {
       "type": "object",
       "properties": {
         "ids": {
@@ -1471,7 +1600,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/apiDeviceProviderTokens"
+            "$ref": "#/definitions/centrifugal.centrifugo.api.DeviceProviderTokens"
           }
         },
         "platforms": {
@@ -1510,25 +1639,25 @@
         }
       }
     },
-    "apiDeviceListResponse": {
+    "centrifugal.centrifugo.api.DeviceListResponse": {
       "type": "object",
       "properties": {
         "error": {
-          "$ref": "#/definitions/apiError"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.Error"
         },
         "result": {
-          "$ref": "#/definitions/apiDeviceListResult"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.DeviceListResult"
         }
       }
     },
-    "apiDeviceListResult": {
+    "centrifugal.centrifugo.api.DeviceListResult": {
       "type": "object",
       "properties": {
         "items": {
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/apiDevice"
+            "$ref": "#/definitions/centrifugal.centrifugo.api.Device"
           }
         },
         "has_more": {
@@ -1536,7 +1665,7 @@
         }
       }
     },
-    "apiDeviceMetaUpdate": {
+    "centrifugal.centrifugo.api.DeviceMetaUpdate": {
       "type": "object",
       "properties": {
         "meta": {
@@ -1547,7 +1676,7 @@
         }
       }
     },
-    "apiDeviceProviderTokens": {
+    "centrifugal.centrifugo.api.DeviceProviderTokens": {
       "type": "object",
       "properties": {
         "provider": {
@@ -1561,7 +1690,7 @@
         }
       }
     },
-    "apiDeviceRegisterRequest": {
+    "centrifugal.centrifugo.api.DeviceRegisterRequest": {
       "type": "object",
       "properties": {
         "id": {
@@ -1599,26 +1728,26 @@
         }
       }
     },
-    "apiDeviceRegisterResponse": {
+    "centrifugal.centrifugo.api.DeviceRegisterResponse": {
       "type": "object",
       "properties": {
         "error": {
-          "$ref": "#/definitions/apiError"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.Error"
         },
         "result": {
-          "$ref": "#/definitions/apiDeviceRegisterResult"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.DeviceRegisterResult"
         }
       }
     },
-    "apiDeviceRegisterResult": {
+    "centrifugal.centrifugo.api.DeviceRegisterResult": {
       "type": "object",
       "properties": {
         "device": {
-          "$ref": "#/definitions/apiDevice"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.Device"
         }
       }
     },
-    "apiDeviceRemoveRequest": {
+    "centrifugal.centrifugo.api.DeviceRemoveRequest": {
       "type": "object",
       "properties": {
         "ids": {
@@ -1637,26 +1766,26 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/apiDeviceProviderTokens"
+            "$ref": "#/definitions/centrifugal.centrifugo.api.DeviceProviderTokens"
           }
         }
       }
     },
-    "apiDeviceRemoveResponse": {
+    "centrifugal.centrifugo.api.DeviceRemoveResponse": {
       "type": "object",
       "properties": {
         "error": {
-          "$ref": "#/definitions/apiError"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.Error"
         },
         "result": {
-          "$ref": "#/definitions/apiDeviceRemoveResult"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.DeviceRemoveResult"
         }
       }
     },
-    "apiDeviceRemoveResult": {
+    "centrifugal.centrifugo.api.DeviceRemoveResult": {
       "type": "object"
     },
-    "apiDeviceTagsUpdate": {
+    "centrifugal.centrifugo.api.DeviceTagsUpdate": {
       "type": "object",
       "properties": {
         "op": {
@@ -1671,7 +1800,7 @@
         }
       }
     },
-    "apiDeviceUpdateRequest": {
+    "centrifugal.centrifugo.api.DeviceUpdateRequest": {
       "type": "object",
       "properties": {
         "ids": {
@@ -1690,38 +1819,38 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/apiDeviceProviderTokens"
+            "$ref": "#/definitions/centrifugal.centrifugo.api.DeviceProviderTokens"
           }
         },
         "user_update": {
-          "$ref": "#/definitions/apiDeviceUserUpdate"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.DeviceUserUpdate"
         },
         "meta_update": {
-          "$ref": "#/definitions/apiDeviceMetaUpdate"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.DeviceMetaUpdate"
         },
         "tags_update": {
-          "$ref": "#/definitions/apiDeviceTagsUpdate"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.DeviceTagsUpdate"
         },
         "channels_update": {
-          "$ref": "#/definitions/apiDeviceChannelsUpdate"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.DeviceChannelsUpdate"
         }
       }
     },
-    "apiDeviceUpdateResponse": {
+    "centrifugal.centrifugo.api.DeviceUpdateResponse": {
       "type": "object",
       "properties": {
         "error": {
-          "$ref": "#/definitions/apiError"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.Error"
         },
         "result": {
-          "$ref": "#/definitions/apiDeviceUpdateResult"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.DeviceUpdateResult"
         }
       }
     },
-    "apiDeviceUpdateResult": {
+    "centrifugal.centrifugo.api.DeviceUpdateResult": {
       "type": "object"
     },
-    "apiDeviceUserUpdate": {
+    "centrifugal.centrifugo.api.DeviceUserUpdate": {
       "type": "object",
       "properties": {
         "user": {
@@ -1729,7 +1858,7 @@
         }
       }
     },
-    "apiDisconnect": {
+    "centrifugal.centrifugo.api.Disconnect": {
       "type": "object",
       "properties": {
         "code": {
@@ -1744,14 +1873,14 @@
         }
       }
     },
-    "apiDisconnectRequest": {
+    "centrifugal.centrifugo.api.DisconnectRequest": {
       "type": "object",
       "properties": {
         "user": {
           "type": "string"
         },
         "disconnect": {
-          "$ref": "#/definitions/apiDisconnect"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.Disconnect"
         },
         "client": {
           "type": "string"
@@ -1767,21 +1896,21 @@
         }
       }
     },
-    "apiDisconnectResponse": {
+    "centrifugal.centrifugo.api.DisconnectResponse": {
       "type": "object",
       "properties": {
         "error": {
-          "$ref": "#/definitions/apiError"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.Error"
         },
         "result": {
-          "$ref": "#/definitions/apiDisconnectResult"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.DisconnectResult"
         }
       }
     },
-    "apiDisconnectResult": {
+    "centrifugal.centrifugo.api.DisconnectResult": {
       "type": "object"
     },
-    "apiError": {
+    "centrifugal.centrifugo.api.Error": {
       "type": "object",
       "properties": {
         "code": {
@@ -1793,7 +1922,7 @@
         }
       }
     },
-    "apiFcmPushNotification": {
+    "centrifugal.centrifugo.api.FcmPushNotification": {
       "type": "object",
       "properties": {
         "message": {
@@ -1801,7 +1930,7 @@
         }
       }
     },
-    "apiGetUserStatusRequest": {
+    "centrifugal.centrifugo.api.GetUserStatusRequest": {
       "type": "object",
       "properties": {
         "users": {
@@ -1812,30 +1941,30 @@
         }
       }
     },
-    "apiGetUserStatusResponse": {
+    "centrifugal.centrifugo.api.GetUserStatusResponse": {
       "type": "object",
       "properties": {
         "error": {
-          "$ref": "#/definitions/apiError"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.Error"
         },
         "result": {
-          "$ref": "#/definitions/apiGetUserStatusResult"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.GetUserStatusResult"
         }
       }
     },
-    "apiGetUserStatusResult": {
+    "centrifugal.centrifugo.api.GetUserStatusResult": {
       "type": "object",
       "properties": {
         "statuses": {
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/apiUserStatus"
+            "$ref": "#/definitions/centrifugal.centrifugo.api.UserStatus"
           }
         }
       }
     },
-    "apiHistoryRemoveRequest": {
+    "centrifugal.centrifugo.api.HistoryRemoveRequest": {
       "type": "object",
       "properties": {
         "channel": {
@@ -1843,21 +1972,21 @@
         }
       }
     },
-    "apiHistoryRemoveResponse": {
+    "centrifugal.centrifugo.api.HistoryRemoveResponse": {
       "type": "object",
       "properties": {
         "error": {
-          "$ref": "#/definitions/apiError"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.Error"
         },
         "result": {
-          "$ref": "#/definitions/apiHistoryRemoveResult"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.HistoryRemoveResult"
         }
       }
     },
-    "apiHistoryRemoveResult": {
+    "centrifugal.centrifugo.api.HistoryRemoveResult": {
       "type": "object"
     },
-    "apiHistoryRequest": {
+    "centrifugal.centrifugo.api.HistoryRequest": {
       "type": "object",
       "properties": {
         "channel": {
@@ -1868,32 +1997,32 @@
           "format": "int32"
         },
         "since": {
-          "$ref": "#/definitions/apiStreamPosition"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.StreamPosition"
         },
         "reverse": {
           "type": "boolean"
         }
       }
     },
-    "apiHistoryResponse": {
+    "centrifugal.centrifugo.api.HistoryResponse": {
       "type": "object",
       "properties": {
         "error": {
-          "$ref": "#/definitions/apiError"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.Error"
         },
         "result": {
-          "$ref": "#/definitions/apiHistoryResult"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.HistoryResult"
         }
       }
     },
-    "apiHistoryResult": {
+    "centrifugal.centrifugo.api.HistoryResult": {
       "type": "object",
       "properties": {
         "publications": {
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/apiPublication"
+            "$ref": "#/definitions/centrifugal.centrifugo.api.Publication"
           }
         },
         "epoch": {
@@ -1904,7 +2033,7 @@
         }
       }
     },
-    "apiHmsPushNotification": {
+    "centrifugal.centrifugo.api.HmsPushNotification": {
       "type": "object",
       "properties": {
         "message": {
@@ -1912,66 +2041,64 @@
         }
       }
     },
-    "apiInfoRequest": {
+    "centrifugal.centrifugo.api.InfoRequest": {
       "type": "object"
     },
-    "apiInfoResponse": {
+    "centrifugal.centrifugo.api.InfoResponse": {
       "type": "object",
       "properties": {
         "error": {
-          "$ref": "#/definitions/apiError"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.Error"
         },
         "result": {
-          "$ref": "#/definitions/apiInfoResult"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.InfoResult"
         }
       }
     },
-    "apiInfoResult": {
+    "centrifugal.centrifugo.api.InfoResult": {
       "type": "object",
       "properties": {
         "nodes": {
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/apiNodeResult"
+            "$ref": "#/definitions/centrifugal.centrifugo.api.NodeResult"
           }
         }
       }
     },
-    "apiInvalidateUserTokensRequest": {
+    "centrifugal.centrifugo.api.InvalidateUserTokensRequest": {
       "type": "object",
       "properties": {
         "expire_at": {
-          "type": "string",
-          "format": "int64"
+          "type": "integer"
         },
         "user": {
           "type": "string"
         },
         "issued_before": {
-          "type": "string",
-          "format": "int64"
+          "type": "integer"
         },
         "channel": {
           "type": "string"
         }
       }
     },
-    "apiInvalidateUserTokensResponse": {
+    "centrifugal.centrifugo.api.InvalidateUserTokensResponse": {
       "type": "object",
       "properties": {
         "error": {
-          "$ref": "#/definitions/apiError"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.Error"
         },
         "result": {
-          "$ref": "#/definitions/apiInvalidateUserTokensResult"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.InvalidateUserTokensResult"
         }
       }
     },
-    "apiInvalidateUserTokensResult": {
+    "centrifugal.centrifugo.api.InvalidateUserTokensResult": {
       "type": "object"
     },
-    "apiMetrics": {
+    "centrifugal.centrifugo.api.Metrics": {
       "type": "object",
       "properties": {
         "interval": {
@@ -1987,7 +2114,7 @@
         }
       }
     },
-    "apiNodeResult": {
+    "centrifugal.centrifugo.api.NodeResult": {
       "type": "object",
       "properties": {
         "uid": {
@@ -2016,10 +2143,10 @@
           "format": "int64"
         },
         "metrics": {
-          "$ref": "#/definitions/apiMetrics"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.Metrics"
         },
         "process": {
-          "$ref": "#/definitions/apiProcess"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.Process"
         },
         "num_subs": {
           "type": "integer",
@@ -2027,7 +2154,7 @@
         }
       }
     },
-    "apiPresenceRequest": {
+    "centrifugal.centrifugo.api.PresenceRequest": {
       "type": "object",
       "properties": {
         "channel": {
@@ -2035,29 +2162,29 @@
         }
       }
     },
-    "apiPresenceResponse": {
+    "centrifugal.centrifugo.api.PresenceResponse": {
       "type": "object",
       "properties": {
         "error": {
-          "$ref": "#/definitions/apiError"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.Error"
         },
         "result": {
-          "$ref": "#/definitions/apiPresenceResult"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.PresenceResult"
         }
       }
     },
-    "apiPresenceResult": {
+    "centrifugal.centrifugo.api.PresenceResult": {
       "type": "object",
       "properties": {
         "presence": {
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/definitions/apiClientInfo"
+            "$ref": "#/definitions/centrifugal.centrifugo.api.ClientInfo"
           }
         }
       }
     },
-    "apiPresenceStatsRequest": {
+    "centrifugal.centrifugo.api.PresenceStatsRequest": {
       "type": "object",
       "properties": {
         "channel": {
@@ -2065,18 +2192,18 @@
         }
       }
     },
-    "apiPresenceStatsResponse": {
+    "centrifugal.centrifugo.api.PresenceStatsResponse": {
       "type": "object",
       "properties": {
         "error": {
-          "$ref": "#/definitions/apiError"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.Error"
         },
         "result": {
-          "$ref": "#/definitions/apiPresenceStatsResult"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.PresenceStatsResult"
         }
       }
     },
-    "apiPresenceStatsResult": {
+    "centrifugal.centrifugo.api.PresenceStatsResult": {
       "type": "object",
       "properties": {
         "num_clients": {
@@ -2089,7 +2216,7 @@
         }
       }
     },
-    "apiProcess": {
+    "centrifugal.centrifugo.api.Process": {
       "type": "object",
       "properties": {
         "cpu": {
@@ -2097,12 +2224,11 @@
           "format": "double"
         },
         "rss": {
-          "type": "string",
-          "format": "int64"
+          "type": "integer"
         }
       }
     },
-    "apiPublication": {
+    "centrifugal.centrifugo.api.Publication": {
       "type": "object",
       "properties": {
         "data": {
@@ -2110,7 +2236,7 @@
           "title": "Removed: string uid = 1;"
         },
         "info": {
-          "$ref": "#/definitions/apiClientInfo"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.ClientInfo"
         },
         "offset": {
           "type": "integer"
@@ -2123,7 +2249,7 @@
         }
       }
     },
-    "apiPublishRequest": {
+    "centrifugal.centrifugo.api.PublishRequest": {
       "type": "object",
       "properties": {
         "channel": {
@@ -2146,18 +2272,18 @@
         }
       }
     },
-    "apiPublishResponse": {
+    "centrifugal.centrifugo.api.PublishResponse": {
       "type": "object",
       "properties": {
         "error": {
-          "$ref": "#/definitions/apiError"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.Error"
         },
         "result": {
-          "$ref": "#/definitions/apiPublishResult"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.PublishResult"
         }
       }
     },
-    "apiPublishResult": {
+    "centrifugal.centrifugo.api.PublishResult": {
       "type": "object",
       "properties": {
         "offset": {
@@ -2168,28 +2294,27 @@
         }
       }
     },
-    "apiPushNotification": {
+    "centrifugal.centrifugo.api.PushNotification": {
       "type": "object",
       "properties": {
         "fcm": {
-          "$ref": "#/definitions/apiFcmPushNotification"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.FcmPushNotification"
         },
         "hms": {
-          "$ref": "#/definitions/apiHmsPushNotification"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.HmsPushNotification"
         },
         "apns": {
-          "$ref": "#/definitions/apiApnsPushNotification"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.ApnsPushNotification"
         },
         "uid": {
           "type": "string"
         },
         "expire_at": {
-          "type": "string",
-          "format": "int64"
+          "type": "integer"
         }
       }
     },
-    "apiPushRecipient": {
+    "centrifugal.centrifugo.api.PushRecipient": {
       "type": "object",
       "properties": {
         "device_ids": {
@@ -2236,7 +2361,7 @@
         }
       }
     },
-    "apiPushUserChannel": {
+    "centrifugal.centrifugo.api.PushUserChannel": {
       "type": "object",
       "properties": {
         "id": {
@@ -2250,7 +2375,7 @@
         }
       }
     },
-    "apiPushUserChannelListRequest": {
+    "centrifugal.centrifugo.api.PushUserChannelListRequest": {
       "type": "object",
       "properties": {
         "users": {
@@ -2274,25 +2399,25 @@
         }
       }
     },
-    "apiPushUserChannelListResponse": {
+    "centrifugal.centrifugo.api.PushUserChannelListResponse": {
       "type": "object",
       "properties": {
         "error": {
-          "$ref": "#/definitions/apiError"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.Error"
         },
         "result": {
-          "$ref": "#/definitions/apiPushUserChannelListResult"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.PushUserChannelListResult"
         }
       }
     },
-    "apiPushUserChannelListResult": {
+    "centrifugal.centrifugo.api.PushUserChannelListResult": {
       "type": "object",
       "properties": {
         "items": {
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/apiPushUserChannel"
+            "$ref": "#/definitions/centrifugal.centrifugo.api.PushUserChannel"
           }
         },
         "has_more": {
@@ -2300,7 +2425,7 @@
         }
       }
     },
-    "apiPushUserChannelUpdateRequest": {
+    "centrifugal.centrifugo.api.PushUserChannelUpdateRequest": {
       "type": "object",
       "properties": {
         "user": {
@@ -2318,21 +2443,21 @@
         }
       }
     },
-    "apiPushUserChannelUpdateResponse": {
+    "centrifugal.centrifugo.api.PushUserChannelUpdateResponse": {
       "type": "object",
       "properties": {
         "error": {
-          "$ref": "#/definitions/apiError"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.Error"
         },
         "result": {
-          "$ref": "#/definitions/apiPushUserChannelUpdateResult"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.PushUserChannelUpdateResult"
         }
       }
     },
-    "apiPushUserChannelUpdateResult": {
+    "centrifugal.centrifugo.api.PushUserChannelUpdateResult": {
       "type": "object"
     },
-    "apiRPCRequest": {
+    "centrifugal.centrifugo.api.RPCRequest": {
       "type": "object",
       "properties": {
         "method": {
@@ -2343,7 +2468,7 @@
         }
       }
     },
-    "apiRPCResult": {
+    "centrifugal.centrifugo.api.RPCResult": {
       "type": "object",
       "properties": {
         "data": {
@@ -2351,7 +2476,7 @@
         }
       }
     },
-    "apiRefreshRequest": {
+    "centrifugal.centrifugo.api.RefreshRequest": {
       "type": "object",
       "properties": {
         "user": {
@@ -2364,8 +2489,7 @@
           "type": "boolean"
         },
         "expire_at": {
-          "type": "string",
-          "format": "int64"
+          "type": "integer"
         },
         "info": {
           "type": "object"
@@ -2375,158 +2499,157 @@
         }
       }
     },
-    "apiRefreshResponse": {
+    "centrifugal.centrifugo.api.RefreshResponse": {
       "type": "object",
       "properties": {
         "error": {
-          "$ref": "#/definitions/apiError"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.Error"
         },
         "result": {
-          "$ref": "#/definitions/apiRefreshResult"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.RefreshResult"
         }
       }
     },
-    "apiRefreshResult": {
+    "centrifugal.centrifugo.api.RefreshResult": {
       "type": "object"
     },
-    "apiReply": {
+    "centrifugal.centrifugo.api.Reply": {
       "type": "object",
       "properties": {
         "publish": {
-          "$ref": "#/definitions/apiPublishResult"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.PublishResult"
         },
         "broadcast": {
-          "$ref": "#/definitions/apiBroadcastResult"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.BroadcastResult"
         },
         "subscribe": {
-          "$ref": "#/definitions/apiSubscribeResult"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.SubscribeResult"
         },
         "unsubscribe": {
-          "$ref": "#/definitions/apiUnsubscribeResult"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.UnsubscribeResult"
         },
         "disconnect": {
-          "$ref": "#/definitions/apiDisconnectResult"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.DisconnectResult"
         },
         "presence": {
-          "$ref": "#/definitions/apiPresenceResult"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.PresenceResult"
         },
         "presence_stats": {
-          "$ref": "#/definitions/apiPresenceStatsResult"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.PresenceStatsResult"
         },
         "history": {
-          "$ref": "#/definitions/apiHistoryResult"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.HistoryResult"
         },
         "history_remove": {
-          "$ref": "#/definitions/apiHistoryRemoveResult"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.HistoryRemoveResult"
         },
         "info": {
-          "$ref": "#/definitions/apiInfoResult"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.InfoResult"
         },
         "rpc": {
-          "$ref": "#/definitions/apiRPCResult"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.RPCResult"
         },
         "refresh": {
-          "$ref": "#/definitions/apiRefreshResult"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.RefreshResult"
         },
         "channels": {
-          "$ref": "#/definitions/apiChannelsResult"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.ChannelsResult"
         },
         "connections": {
-          "$ref": "#/definitions/apiConnectionsResult"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.ConnectionsResult"
         },
         "update_user_status": {
-          "$ref": "#/definitions/apiUpdateUserStatusResult"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.UpdateUserStatusResult"
         },
         "get_user_status": {
-          "$ref": "#/definitions/apiGetUserStatusResult"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.GetUserStatusResult"
         },
         "delete_user_status": {
-          "$ref": "#/definitions/apiDeleteUserStatusResult"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.DeleteUserStatusResult"
         },
         "block_user": {
-          "$ref": "#/definitions/apiBlockUserResult"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.BlockUserResult"
         },
         "unblock_user": {
-          "$ref": "#/definitions/apiUnblockUserResult"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.UnblockUserResult"
         },
         "revoke_token": {
-          "$ref": "#/definitions/apiRevokeTokenResult"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.RevokeTokenResult"
         },
         "invalidate_user_tokens": {
-          "$ref": "#/definitions/apiInvalidateUserTokensResult"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.InvalidateUserTokensResult"
         },
         "device_register": {
-          "$ref": "#/definitions/apiDeviceRegisterResult"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.DeviceRegisterResult"
         },
         "device_update": {
-          "$ref": "#/definitions/apiDeviceUpdateResult"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.DeviceUpdateResult"
         },
         "device_remove": {
-          "$ref": "#/definitions/apiDeviceRemoveResult"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.DeviceRemoveResult"
         },
         "device_list": {
-          "$ref": "#/definitions/apiDeviceListResult"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.DeviceListResult"
         },
         "push_user_channel_list": {
-          "$ref": "#/definitions/apiPushUserChannelListResult"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.PushUserChannelListResult"
         },
         "push_user_channel_update": {
-          "$ref": "#/definitions/apiPushUserChannelUpdateResult"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.PushUserChannelUpdateResult"
         },
         "send_push_notification": {
-          "$ref": "#/definitions/apiSendPushNotificationResult"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.SendPushNotificationResult"
         }
       }
     },
-    "apiRevokeTokenRequest": {
+    "centrifugal.centrifugo.api.RevokeTokenRequest": {
       "type": "object",
       "properties": {
         "expire_at": {
-          "type": "string",
-          "format": "int64"
+          "type": "integer"
         },
         "uid": {
           "type": "string"
         }
       }
     },
-    "apiRevokeTokenResponse": {
+    "centrifugal.centrifugo.api.RevokeTokenResponse": {
       "type": "object",
       "properties": {
         "error": {
-          "$ref": "#/definitions/apiError"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.Error"
         },
         "result": {
-          "$ref": "#/definitions/apiRevokeTokenResult"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.RevokeTokenResult"
         }
       }
     },
-    "apiRevokeTokenResult": {
+    "centrifugal.centrifugo.api.RevokeTokenResult": {
       "type": "object"
     },
-    "apiSendPushNotificationRequest": {
+    "centrifugal.centrifugo.api.SendPushNotificationRequest": {
       "type": "object",
       "properties": {
         "recipient": {
-          "$ref": "#/definitions/apiPushRecipient"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.PushRecipient"
         },
         "notification": {
-          "$ref": "#/definitions/apiPushNotification"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.PushNotification"
         }
       }
     },
-    "apiSendPushNotificationResponse": {
+    "centrifugal.centrifugo.api.SendPushNotificationResponse": {
       "type": "object",
       "properties": {
         "error": {
-          "$ref": "#/definitions/apiError"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.Error"
         },
         "result": {
-          "$ref": "#/definitions/apiSendPushNotificationResult"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.SendPushNotificationResult"
         }
       }
     },
-    "apiSendPushNotificationResult": {
+    "centrifugal.centrifugo.api.SendPushNotificationResult": {
       "type": "object",
       "properties": {
         "uid": {
@@ -2535,7 +2658,7 @@
         }
       }
     },
-    "apiStreamPosition": {
+    "centrifugal.centrifugo.api.StreamPosition": {
       "type": "object",
       "properties": {
         "offset": {
@@ -2546,27 +2669,27 @@
         }
       }
     },
-    "apiSubscribeOptionOverride": {
+    "centrifugal.centrifugo.api.SubscribeOptionOverride": {
       "type": "object",
       "properties": {
         "presence": {
-          "$ref": "#/definitions/apiBoolValue"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.BoolValue"
         },
         "join_leave": {
-          "$ref": "#/definitions/apiBoolValue"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.BoolValue"
         },
         "force_recovery": {
-          "$ref": "#/definitions/apiBoolValue"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.BoolValue"
         },
         "force_positioning": {
-          "$ref": "#/definitions/apiBoolValue"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.BoolValue"
         },
         "force_push_join_leave": {
-          "$ref": "#/definitions/apiBoolValue"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.BoolValue"
         }
       }
     },
-    "apiSubscribeRequest": {
+    "centrifugal.centrifugo.api.SubscribeRequest": {
       "type": "object",
       "properties": {
         "channel": {
@@ -2576,8 +2699,7 @@
           "type": "string"
         },
         "expire_at": {
-          "type": "string",
-          "format": "int64"
+          "type": "integer"
         },
         "info": {
           "type": "object"
@@ -2595,43 +2717,42 @@
           "type": "string"
         },
         "recover_since": {
-          "$ref": "#/definitions/apiStreamPosition"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.StreamPosition"
         },
         "override": {
-          "$ref": "#/definitions/apiSubscribeOptionOverride"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.SubscribeOptionOverride"
         },
         "session": {
           "type": "string"
         }
       }
     },
-    "apiSubscribeResponse": {
+    "centrifugal.centrifugo.api.SubscribeResponse": {
       "type": "object",
       "properties": {
         "error": {
-          "$ref": "#/definitions/apiError"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.Error"
         },
         "result": {
-          "$ref": "#/definitions/apiSubscribeResult"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.SubscribeResult"
         }
       }
     },
-    "apiSubscribeResult": {
+    "centrifugal.centrifugo.api.SubscribeResult": {
       "type": "object"
     },
-    "apiSubscriptionTokenInfo": {
+    "centrifugal.centrifugo.api.SubscriptionTokenInfo": {
       "type": "object",
       "properties": {
         "uid": {
           "type": "string"
         },
         "issued_at": {
-          "type": "string",
-          "format": "int64"
+          "type": "integer"
         }
       }
     },
-    "apiUnblockUserRequest": {
+    "centrifugal.centrifugo.api.UnblockUserRequest": {
       "type": "object",
       "properties": {
         "user": {
@@ -2639,21 +2760,21 @@
         }
       }
     },
-    "apiUnblockUserResponse": {
+    "centrifugal.centrifugo.api.UnblockUserResponse": {
       "type": "object",
       "properties": {
         "error": {
-          "$ref": "#/definitions/apiError"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.Error"
         },
         "result": {
-          "$ref": "#/definitions/apiUnblockUserResult"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.UnblockUserResult"
         }
       }
     },
-    "apiUnblockUserResult": {
+    "centrifugal.centrifugo.api.UnblockUserResult": {
       "type": "object"
     },
-    "apiUnsubscribeRequest": {
+    "centrifugal.centrifugo.api.UnsubscribeRequest": {
       "type": "object",
       "properties": {
         "channel": {
@@ -2670,21 +2791,21 @@
         }
       }
     },
-    "apiUnsubscribeResponse": {
+    "centrifugal.centrifugo.api.UnsubscribeResponse": {
       "type": "object",
       "properties": {
         "error": {
-          "$ref": "#/definitions/apiError"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.Error"
         },
         "result": {
-          "$ref": "#/definitions/apiUnsubscribeResult"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.UnsubscribeResult"
         }
       }
     },
-    "apiUnsubscribeResult": {
+    "centrifugal.centrifugo.api.UnsubscribeResult": {
       "type": "object"
     },
-    "apiUpdateUserStatusRequest": {
+    "centrifugal.centrifugo.api.UpdateUserStatusRequest": {
       "type": "object",
       "properties": {
         "users": {
@@ -2695,61 +2816,31 @@
         }
       }
     },
-    "apiUpdateUserStatusResponse": {
+    "centrifugal.centrifugo.api.UpdateUserStatusResponse": {
       "type": "object",
       "properties": {
         "error": {
-          "$ref": "#/definitions/apiError"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.Error"
         },
         "result": {
-          "$ref": "#/definitions/apiUpdateUserStatusResult"
+          "$ref": "#/definitions/centrifugal.centrifugo.api.UpdateUserStatusResult"
         }
       }
     },
-    "apiUpdateUserStatusResult": {
+    "centrifugal.centrifugo.api.UpdateUserStatusResult": {
       "type": "object"
     },
-    "apiUserStatus": {
+    "centrifugal.centrifugo.api.UserStatus": {
       "type": "object",
       "properties": {
         "user": {
           "type": "string"
         },
         "active": {
-          "type": "string",
-          "format": "int64"
+          "type": "integer"
         },
         "online": {
-          "type": "string",
-          "format": "int64"
-        }
-      }
-    },
-    "protobufAny": {
-      "type": "object",
-      "properties": {
-        "@type": {
-          "type": "string"
-        }
-      },
-      "additionalProperties": {}
-    },
-    "rpcStatus": {
-      "type": "object",
-      "properties": {
-        "code": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "message": {
-          "type": "string"
-        },
-        "details": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "$ref": "#/definitions/protobufAny"
-          }
+          "type": "integer"
         }
       }
     }

--- a/internal/apiproto/api.swagger.json
+++ b/internal/apiproto/api.swagger.json
@@ -1,8 +1,8 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "api.proto",
-    "version": "version not set"
+    "title": "Centrifugo server HTTP API",
+    "version": "5.0"
   },
   "consumes": [
     "application/json"
@@ -11,6 +11,582 @@
     "application/json"
   ],
   "paths": {
+    "/batch": {
+      "post": {
+        "operationId": "CentrifugoApi_Batch",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/apiBatchResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/gatewayruntimeError"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/apiBatchRequest"
+            }
+          }
+        ],
+        "tags": [
+          "CentrifugoApi"
+        ]
+      }
+    },
+    "/block_user": {
+      "post": {
+        "operationId": "CentrifugoApi_BlockUser",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/apiBlockUserResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/gatewayruntimeError"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/apiBlockUserRequest"
+            }
+          }
+        ],
+        "tags": [
+          "CentrifugoApi"
+        ]
+      }
+    },
+    "/broadcast": {
+      "post": {
+        "operationId": "CentrifugoApi_Broadcast",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/apiBroadcastResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/gatewayruntimeError"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/apiBroadcastRequest"
+            }
+          }
+        ],
+        "tags": [
+          "CentrifugoApi"
+        ]
+      }
+    },
+    "/channels": {
+      "post": {
+        "operationId": "CentrifugoApi_Channels",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/apiChannelsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/gatewayruntimeError"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/apiChannelsRequest"
+            }
+          }
+        ],
+        "tags": [
+          "CentrifugoApi"
+        ]
+      }
+    },
+    "/connections": {
+      "post": {
+        "operationId": "CentrifugoApi_Connections",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/apiConnectionsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/gatewayruntimeError"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/apiConnectionsRequest"
+            }
+          }
+        ],
+        "tags": [
+          "CentrifugoApi"
+        ]
+      }
+    },
+    "/delete_user_status": {
+      "post": {
+        "operationId": "CentrifugoApi_DeleteUserStatus",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/apiDeleteUserStatusResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/gatewayruntimeError"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/apiDeleteUserStatusRequest"
+            }
+          }
+        ],
+        "tags": [
+          "CentrifugoApi"
+        ]
+      }
+    },
+    "/device_list": {
+      "post": {
+        "operationId": "CentrifugoApi_DeviceList",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/apiDeviceListResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/gatewayruntimeError"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/apiDeviceListRequest"
+            }
+          }
+        ],
+        "tags": [
+          "CentrifugoApi"
+        ]
+      }
+    },
+    "/device_register": {
+      "post": {
+        "operationId": "CentrifugoApi_DeviceRegister",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/apiDeviceRegisterResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/gatewayruntimeError"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/apiDeviceRegisterRequest"
+            }
+          }
+        ],
+        "tags": [
+          "CentrifugoApi"
+        ]
+      }
+    },
+    "/device_remove": {
+      "post": {
+        "operationId": "CentrifugoApi_DeviceRemove",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/apiDeviceRemoveResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/gatewayruntimeError"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/apiDeviceRemoveRequest"
+            }
+          }
+        ],
+        "tags": [
+          "CentrifugoApi"
+        ]
+      }
+    },
+    "/device_update": {
+      "post": {
+        "operationId": "CentrifugoApi_DeviceUpdate",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/apiDeviceUpdateResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/gatewayruntimeError"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/apiDeviceUpdateRequest"
+            }
+          }
+        ],
+        "tags": [
+          "CentrifugoApi"
+        ]
+      }
+    },
+    "/disconnect": {
+      "post": {
+        "operationId": "CentrifugoApi_Disconnect",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/apiDisconnectResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/gatewayruntimeError"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/apiDisconnectRequest"
+            }
+          }
+        ],
+        "tags": [
+          "CentrifugoApi"
+        ]
+      }
+    },
+    "/get_user_status": {
+      "post": {
+        "operationId": "CentrifugoApi_GetUserStatus",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/apiGetUserStatusResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/gatewayruntimeError"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/apiGetUserStatusRequest"
+            }
+          }
+        ],
+        "tags": [
+          "CentrifugoApi"
+        ]
+      }
+    },
+    "/history": {
+      "post": {
+        "operationId": "CentrifugoApi_History",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/apiHistoryResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/gatewayruntimeError"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/apiHistoryRequest"
+            }
+          }
+        ],
+        "tags": [
+          "CentrifugoApi"
+        ]
+      }
+    },
+    "/history_remove": {
+      "post": {
+        "operationId": "CentrifugoApi_HistoryRemove",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/apiHistoryRemoveResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/gatewayruntimeError"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/apiHistoryRemoveRequest"
+            }
+          }
+        ],
+        "tags": [
+          "CentrifugoApi"
+        ]
+      }
+    },
+    "/info": {
+      "post": {
+        "operationId": "CentrifugoApi_Info",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/apiInfoResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/gatewayruntimeError"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/apiInfoRequest"
+            }
+          }
+        ],
+        "tags": [
+          "CentrifugoApi"
+        ]
+      }
+    },
+    "/invalidate_user_tokens": {
+      "post": {
+        "operationId": "CentrifugoApi_InvalidateUserTokens",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/apiInvalidateUserTokensResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/gatewayruntimeError"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/apiInvalidateUserTokensRequest"
+            }
+          }
+        ],
+        "tags": [
+          "CentrifugoApi"
+        ]
+      }
+    },
+    "/presence": {
+      "post": {
+        "operationId": "CentrifugoApi_Presence",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/apiPresenceResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/gatewayruntimeError"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/apiPresenceRequest"
+            }
+          }
+        ],
+        "tags": [
+          "CentrifugoApi"
+        ]
+      }
+    },
+    "/presence_stats": {
+      "post": {
+        "operationId": "CentrifugoApi_PresenceStats",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/apiPresenceStatsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/gatewayruntimeError"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/apiPresenceStatsRequest"
+            }
+          }
+        ],
+        "tags": [
+          "CentrifugoApi"
+        ]
+      }
+    },
     "/publish": {
       "post": {
         "operationId": "CentrifugoApi_Publish",
@@ -42,43 +618,329 @@
           "CentrifugoApi"
         ]
       }
+    },
+    "/push_user_channel_list": {
+      "post": {
+        "operationId": "CentrifugoApi_PushUserChannelList",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/apiPushUserChannelListResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/gatewayruntimeError"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/apiPushUserChannelListRequest"
+            }
+          }
+        ],
+        "tags": [
+          "CentrifugoApi"
+        ]
+      }
+    },
+    "/push_user_channel_update": {
+      "post": {
+        "operationId": "CentrifugoApi_PushUserChannelUpdate",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/apiPushUserChannelUpdateResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/gatewayruntimeError"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/apiPushUserChannelUpdateRequest"
+            }
+          }
+        ],
+        "tags": [
+          "CentrifugoApi"
+        ]
+      }
+    },
+    "/refresh": {
+      "post": {
+        "operationId": "CentrifugoApi_Refresh",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/apiRefreshResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/gatewayruntimeError"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/apiRefreshRequest"
+            }
+          }
+        ],
+        "tags": [
+          "CentrifugoApi"
+        ]
+      }
+    },
+    "/revoke_token": {
+      "post": {
+        "operationId": "CentrifugoApi_RevokeToken",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/apiRevokeTokenResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/gatewayruntimeError"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/apiRevokeTokenRequest"
+            }
+          }
+        ],
+        "tags": [
+          "CentrifugoApi"
+        ]
+      }
+    },
+    "/rpc": {
+      "post": {
+        "operationId": "CentrifugoApi_RPC",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/apiRPCResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/gatewayruntimeError"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/apiRPCRequest"
+            }
+          }
+        ],
+        "tags": [
+          "CentrifugoApi"
+        ]
+      }
+    },
+    "/send_push_notification": {
+      "post": {
+        "operationId": "CentrifugoApi_SendPushNotification",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/apiSendPushNotificationResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/gatewayruntimeError"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/apiSendPushNotificationRequest"
+            }
+          }
+        ],
+        "tags": [
+          "CentrifugoApi"
+        ]
+      }
+    },
+    "/subscribe": {
+      "post": {
+        "operationId": "CentrifugoApi_Subscribe",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/apiSubscribeResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/gatewayruntimeError"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/apiSubscribeRequest"
+            }
+          }
+        ],
+        "tags": [
+          "CentrifugoApi"
+        ]
+      }
+    },
+    "/unblock_user": {
+      "post": {
+        "operationId": "CentrifugoApi_UnblockUser",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/apiUnblockUserResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/gatewayruntimeError"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/apiUnblockUserRequest"
+            }
+          }
+        ],
+        "tags": [
+          "CentrifugoApi"
+        ]
+      }
+    },
+    "/unsubscribe": {
+      "post": {
+        "operationId": "CentrifugoApi_Unsubscribe",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/apiUnsubscribeResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/gatewayruntimeError"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/apiUnsubscribeRequest"
+            }
+          }
+        ],
+        "tags": [
+          "CentrifugoApi"
+        ]
+      }
+    },
+    "/update_user_status": {
+      "post": {
+        "operationId": "CentrifugoApi_UpdateUserStatus",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/apiUpdateUserStatusResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/gatewayruntimeError"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/apiUpdateUserStatusRequest"
+            }
+          }
+        ],
+        "tags": [
+          "CentrifugoApi"
+        ]
+      }
     }
   },
   "definitions": {
-    "CommandMethodType": {
-      "type": "string",
-      "enum": [
-        "PUBLISH",
-        "BROADCAST",
-        "UNSUBSCRIBE",
-        "DISCONNECT",
-        "PRESENCE",
-        "PRESENCE_STATS",
-        "HISTORY",
-        "HISTORY_REMOVE",
-        "CHANNELS",
-        "INFO",
-        "RPC",
-        "SUBSCRIBE",
-        "REFRESH",
-        "CONNECTIONS",
-        "UPDATE_USER_STATUS",
-        "GET_USER_STATUS",
-        "DELETE_USER_STATUS",
-        "BLOCK_USER",
-        "UNBLOCK_USER",
-        "REVOKE_TOKEN",
-        "INVALIDATE_USER_TOKENS",
-        "DEVICE_REGISTER",
-        "DEVICE_UPDATE",
-        "DEVICE_REMOVE",
-        "DEVICE_LIST",
-        "PUSH_USER_CHANNEL_LIST",
-        "PUSH_USER_CHANNEL_UPDATE",
-        "SEND_PUSH_NOTIFICATION"
-      ],
-      "default": "PUBLISH"
-    },
     "apiApnsPushNotification": {
       "type": "object",
       "properties": {
@@ -91,6 +953,17 @@
         "payload": {
           "type": "string",
           "format": "byte"
+        }
+      }
+    },
+    "apiBatchRequest": {
+      "type": "object",
+      "properties": {
+        "commands": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/apiCommand"
+          }
         }
       }
     },
@@ -257,17 +1130,6 @@
     "apiCommand": {
       "type": "object",
       "properties": {
-        "id": {
-          "type": "integer",
-          "format": "int64"
-        },
-        "method": {
-          "$ref": "#/definitions/CommandMethodType"
-        },
-        "params": {
-          "type": "string",
-          "format": "byte"
-        },
         "publish": {
           "$ref": "#/definitions/apiPublishRequest"
         },
@@ -1460,17 +2322,6 @@
     "apiReply": {
       "type": "object",
       "properties": {
-        "id": {
-          "type": "integer",
-          "format": "int64"
-        },
-        "error": {
-          "$ref": "#/definitions/centrifugoapiError"
-        },
-        "result": {
-          "type": "string",
-          "format": "byte"
-        },
         "publish": {
           "$ref": "#/definitions/apiPublishResult"
         },
@@ -1849,6 +2700,13 @@
           "format": "byte"
         }
       }
+    }
+  },
+  "securityDefinitions": {
+    "ApiKeyAuth": {
+      "type": "apiKey",
+      "name": "Authorization",
+      "in": "header"
     }
   }
 }

--- a/internal/apiproto/api.swagger.json
+++ b/internal/apiproto/api.swagger.json
@@ -30,7 +30,7 @@
       "name": "token"
     },
     {
-      "name": "push notifications"
+      "name": "push notification"
     },
     {
       "name": "batch"
@@ -313,7 +313,7 @@
           }
         ],
         "tags": [
-          "push notifications"
+          "push notification"
         ]
       }
     },
@@ -352,7 +352,7 @@
           }
         ],
         "tags": [
-          "push notifications"
+          "push notification"
         ]
       }
     },
@@ -391,7 +391,7 @@
           }
         ],
         "tags": [
-          "push notifications"
+          "push notification"
         ]
       }
     },
@@ -430,7 +430,7 @@
           }
         ],
         "tags": [
-          "push notifications"
+          "push notification"
         ]
       }
     },
@@ -820,7 +820,7 @@
           }
         ],
         "tags": [
-          "push notifications"
+          "push notification"
         ]
       }
     },
@@ -859,7 +859,7 @@
           }
         ],
         "tags": [
-          "push notifications"
+          "push notification"
         ]
       }
     },
@@ -976,7 +976,7 @@
           }
         ],
         "tags": [
-          "push notifications"
+          "push notification"
         ]
       }
     },

--- a/internal/apiproto/api.swagger.json
+++ b/internal/apiproto/api.swagger.json
@@ -52,7 +52,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/centrifugal.centrifugo.api.BatchResponse"
+              "$ref": "#/definitions/BatchResponse"
             }
           },
           "400": {
@@ -74,7 +74,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/centrifugal.centrifugo.api.BatchRequest"
+              "$ref": "#/definitions/BatchRequest"
             }
           }
         ],
@@ -91,7 +91,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/centrifugal.centrifugo.api.BlockUserResponse"
+              "$ref": "#/definitions/BlockUserResponse"
             }
           },
           "400": {
@@ -113,7 +113,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/centrifugal.centrifugo.api.BlockUserRequest"
+              "$ref": "#/definitions/BlockUserRequest"
             }
           }
         ],
@@ -130,7 +130,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/centrifugal.centrifugo.api.BroadcastResponse"
+              "$ref": "#/definitions/BroadcastResponse"
             }
           },
           "400": {
@@ -152,7 +152,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/centrifugal.centrifugo.api.BroadcastRequest"
+              "$ref": "#/definitions/BroadcastRequest"
             }
           }
         ],
@@ -169,7 +169,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/centrifugal.centrifugo.api.ChannelsResponse"
+              "$ref": "#/definitions/ChannelsResponse"
             }
           },
           "400": {
@@ -191,7 +191,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/centrifugal.centrifugo.api.ChannelsRequest"
+              "$ref": "#/definitions/ChannelsRequest"
             }
           }
         ],
@@ -208,7 +208,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/centrifugal.centrifugo.api.ConnectionsResponse"
+              "$ref": "#/definitions/ConnectionsResponse"
             }
           },
           "400": {
@@ -230,7 +230,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/centrifugal.centrifugo.api.ConnectionsRequest"
+              "$ref": "#/definitions/ConnectionsRequest"
             }
           }
         ],
@@ -247,7 +247,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/centrifugal.centrifugo.api.DeleteUserStatusResponse"
+              "$ref": "#/definitions/DeleteUserStatusResponse"
             }
           },
           "400": {
@@ -269,7 +269,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/centrifugal.centrifugo.api.DeleteUserStatusRequest"
+              "$ref": "#/definitions/DeleteUserStatusRequest"
             }
           }
         ],
@@ -286,7 +286,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/centrifugal.centrifugo.api.DeviceListResponse"
+              "$ref": "#/definitions/DeviceListResponse"
             }
           },
           "400": {
@@ -308,7 +308,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/centrifugal.centrifugo.api.DeviceListRequest"
+              "$ref": "#/definitions/DeviceListRequest"
             }
           }
         ],
@@ -325,7 +325,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/centrifugal.centrifugo.api.DeviceRegisterResponse"
+              "$ref": "#/definitions/DeviceRegisterResponse"
             }
           },
           "400": {
@@ -347,7 +347,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/centrifugal.centrifugo.api.DeviceRegisterRequest"
+              "$ref": "#/definitions/DeviceRegisterRequest"
             }
           }
         ],
@@ -364,7 +364,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/centrifugal.centrifugo.api.DeviceRemoveResponse"
+              "$ref": "#/definitions/DeviceRemoveResponse"
             }
           },
           "400": {
@@ -386,7 +386,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/centrifugal.centrifugo.api.DeviceRemoveRequest"
+              "$ref": "#/definitions/DeviceRemoveRequest"
             }
           }
         ],
@@ -403,7 +403,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/centrifugal.centrifugo.api.DeviceUpdateResponse"
+              "$ref": "#/definitions/DeviceUpdateResponse"
             }
           },
           "400": {
@@ -425,7 +425,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/centrifugal.centrifugo.api.DeviceUpdateRequest"
+              "$ref": "#/definitions/DeviceUpdateRequest"
             }
           }
         ],
@@ -442,7 +442,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/centrifugal.centrifugo.api.DisconnectResponse"
+              "$ref": "#/definitions/DisconnectResponse"
             }
           },
           "400": {
@@ -464,7 +464,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/centrifugal.centrifugo.api.DisconnectRequest"
+              "$ref": "#/definitions/DisconnectRequest"
             }
           }
         ],
@@ -481,7 +481,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/centrifugal.centrifugo.api.GetUserStatusResponse"
+              "$ref": "#/definitions/GetUserStatusResponse"
             }
           },
           "400": {
@@ -503,7 +503,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/centrifugal.centrifugo.api.GetUserStatusRequest"
+              "$ref": "#/definitions/GetUserStatusRequest"
             }
           }
         ],
@@ -520,7 +520,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/centrifugal.centrifugo.api.HistoryResponse"
+              "$ref": "#/definitions/HistoryResponse"
             }
           },
           "400": {
@@ -542,7 +542,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/centrifugal.centrifugo.api.HistoryRequest"
+              "$ref": "#/definitions/HistoryRequest"
             }
           }
         ],
@@ -559,7 +559,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/centrifugal.centrifugo.api.HistoryRemoveResponse"
+              "$ref": "#/definitions/HistoryRemoveResponse"
             }
           },
           "400": {
@@ -581,7 +581,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/centrifugal.centrifugo.api.HistoryRemoveRequest"
+              "$ref": "#/definitions/HistoryRemoveRequest"
             }
           }
         ],
@@ -598,7 +598,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/centrifugal.centrifugo.api.InfoResponse"
+              "$ref": "#/definitions/InfoResponse"
             }
           },
           "400": {
@@ -620,7 +620,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/centrifugal.centrifugo.api.InfoRequest"
+              "$ref": "#/definitions/InfoRequest"
             }
           }
         ],
@@ -637,7 +637,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/centrifugal.centrifugo.api.InvalidateUserTokensResponse"
+              "$ref": "#/definitions/InvalidateUserTokensResponse"
             }
           },
           "400": {
@@ -659,7 +659,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/centrifugal.centrifugo.api.InvalidateUserTokensRequest"
+              "$ref": "#/definitions/InvalidateUserTokensRequest"
             }
           }
         ],
@@ -676,7 +676,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/centrifugal.centrifugo.api.PresenceResponse"
+              "$ref": "#/definitions/PresenceResponse"
             }
           },
           "400": {
@@ -698,7 +698,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/centrifugal.centrifugo.api.PresenceRequest"
+              "$ref": "#/definitions/PresenceRequest"
             }
           }
         ],
@@ -715,7 +715,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/centrifugal.centrifugo.api.PresenceStatsResponse"
+              "$ref": "#/definitions/PresenceStatsResponse"
             }
           },
           "400": {
@@ -737,7 +737,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/centrifugal.centrifugo.api.PresenceStatsRequest"
+              "$ref": "#/definitions/PresenceStatsRequest"
             }
           }
         ],
@@ -754,7 +754,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/centrifugal.centrifugo.api.PublishResponse"
+              "$ref": "#/definitions/PublishResponse"
             }
           },
           "400": {
@@ -776,7 +776,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/centrifugal.centrifugo.api.PublishRequest"
+              "$ref": "#/definitions/PublishRequest"
             }
           }
         ],
@@ -793,7 +793,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/centrifugal.centrifugo.api.PushUserChannelListResponse"
+              "$ref": "#/definitions/PushUserChannelListResponse"
             }
           },
           "400": {
@@ -815,7 +815,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/centrifugal.centrifugo.api.PushUserChannelListRequest"
+              "$ref": "#/definitions/PushUserChannelListRequest"
             }
           }
         ],
@@ -832,7 +832,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/centrifugal.centrifugo.api.PushUserChannelUpdateResponse"
+              "$ref": "#/definitions/PushUserChannelUpdateResponse"
             }
           },
           "400": {
@@ -854,7 +854,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/centrifugal.centrifugo.api.PushUserChannelUpdateRequest"
+              "$ref": "#/definitions/PushUserChannelUpdateRequest"
             }
           }
         ],
@@ -871,7 +871,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/centrifugal.centrifugo.api.RefreshResponse"
+              "$ref": "#/definitions/RefreshResponse"
             }
           },
           "400": {
@@ -893,7 +893,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/centrifugal.centrifugo.api.RefreshRequest"
+              "$ref": "#/definitions/RefreshRequest"
             }
           }
         ],
@@ -910,7 +910,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/centrifugal.centrifugo.api.RevokeTokenResponse"
+              "$ref": "#/definitions/RevokeTokenResponse"
             }
           },
           "400": {
@@ -932,7 +932,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/centrifugal.centrifugo.api.RevokeTokenRequest"
+              "$ref": "#/definitions/RevokeTokenRequest"
             }
           }
         ],
@@ -949,7 +949,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/centrifugal.centrifugo.api.SendPushNotificationResponse"
+              "$ref": "#/definitions/SendPushNotificationResponse"
             }
           },
           "400": {
@@ -971,7 +971,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/centrifugal.centrifugo.api.SendPushNotificationRequest"
+              "$ref": "#/definitions/SendPushNotificationRequest"
             }
           }
         ],
@@ -988,7 +988,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/centrifugal.centrifugo.api.SubscribeResponse"
+              "$ref": "#/definitions/SubscribeResponse"
             }
           },
           "400": {
@@ -1010,7 +1010,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/centrifugal.centrifugo.api.SubscribeRequest"
+              "$ref": "#/definitions/SubscribeRequest"
             }
           }
         ],
@@ -1027,7 +1027,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/centrifugal.centrifugo.api.UnblockUserResponse"
+              "$ref": "#/definitions/UnblockUserResponse"
             }
           },
           "400": {
@@ -1049,7 +1049,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/centrifugal.centrifugo.api.UnblockUserRequest"
+              "$ref": "#/definitions/UnblockUserRequest"
             }
           }
         ],
@@ -1066,7 +1066,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/centrifugal.centrifugo.api.UnsubscribeResponse"
+              "$ref": "#/definitions/UnsubscribeResponse"
             }
           },
           "400": {
@@ -1088,7 +1088,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/centrifugal.centrifugo.api.UnsubscribeRequest"
+              "$ref": "#/definitions/UnsubscribeRequest"
             }
           }
         ],
@@ -1105,7 +1105,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/centrifugal.centrifugo.api.UpdateUserStatusResponse"
+              "$ref": "#/definitions/UpdateUserStatusResponse"
             }
           },
           "400": {
@@ -1127,7 +1127,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/centrifugal.centrifugo.api.UpdateUserStatusRequest"
+              "$ref": "#/definitions/UpdateUserStatusRequest"
             }
           }
         ],
@@ -1138,7 +1138,7 @@
     }
   },
   "definitions": {
-    "centrifugal.centrifugo.api.ApnsPushNotification": {
+    "ApnsPushNotification": {
       "type": "object",
       "properties": {
         "headers": {
@@ -1152,31 +1152,31 @@
         }
       }
     },
-    "centrifugal.centrifugo.api.BatchRequest": {
+    "BatchRequest": {
       "type": "object",
       "properties": {
         "commands": {
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/centrifugal.centrifugo.api.Command"
+            "$ref": "#/definitions/Command"
           }
         }
       }
     },
-    "centrifugal.centrifugo.api.BatchResponse": {
+    "BatchResponse": {
       "type": "object",
       "properties": {
         "replies": {
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/centrifugal.centrifugo.api.Reply"
+            "$ref": "#/definitions/Reply"
           }
         }
       }
     },
-    "centrifugal.centrifugo.api.BlockUserRequest": {
+    "BlockUserRequest": {
       "type": "object",
       "properties": {
         "expire_at": {
@@ -1187,21 +1187,21 @@
         }
       }
     },
-    "centrifugal.centrifugo.api.BlockUserResponse": {
+    "BlockUserResponse": {
       "type": "object",
       "properties": {
         "error": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.Error"
+          "$ref": "#/definitions/Error"
         },
         "result": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.BlockUserResult"
+          "$ref": "#/definitions/BlockUserResult"
         }
       }
     },
-    "centrifugal.centrifugo.api.BlockUserResult": {
+    "BlockUserResult": {
       "type": "object"
     },
-    "centrifugal.centrifugo.api.BoolValue": {
+    "BoolValue": {
       "type": "object",
       "properties": {
         "value": {
@@ -1209,7 +1209,7 @@
         }
       }
     },
-    "centrifugal.centrifugo.api.BroadcastRequest": {
+    "BroadcastRequest": {
       "type": "object",
       "properties": {
         "channels": {
@@ -1235,30 +1235,30 @@
         }
       }
     },
-    "centrifugal.centrifugo.api.BroadcastResponse": {
+    "BroadcastResponse": {
       "type": "object",
       "properties": {
         "error": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.Error"
+          "$ref": "#/definitions/Error"
         },
         "result": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.BroadcastResult"
+          "$ref": "#/definitions/BroadcastResult"
         }
       }
     },
-    "centrifugal.centrifugo.api.BroadcastResult": {
+    "BroadcastResult": {
       "type": "object",
       "properties": {
         "responses": {
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/centrifugal.centrifugo.api.PublishResponse"
+            "$ref": "#/definitions/PublishResponse"
           }
         }
       }
     },
-    "centrifugal.centrifugo.api.ChannelContext": {
+    "ChannelContext": {
       "type": "object",
       "properties": {
         "source": {
@@ -1267,7 +1267,7 @@
         }
       }
     },
-    "centrifugal.centrifugo.api.ChannelInfo": {
+    "ChannelInfo": {
       "type": "object",
       "properties": {
         "num_clients": {
@@ -1276,7 +1276,7 @@
         }
       }
     },
-    "centrifugal.centrifugo.api.ChannelsRequest": {
+    "ChannelsRequest": {
       "type": "object",
       "properties": {
         "pattern": {
@@ -1284,29 +1284,29 @@
         }
       }
     },
-    "centrifugal.centrifugo.api.ChannelsResponse": {
+    "ChannelsResponse": {
       "type": "object",
       "properties": {
         "error": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.Error"
+          "$ref": "#/definitions/Error"
         },
         "result": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.ChannelsResult"
+          "$ref": "#/definitions/ChannelsResult"
         }
       }
     },
-    "centrifugal.centrifugo.api.ChannelsResult": {
+    "ChannelsResult": {
       "type": "object",
       "properties": {
         "channels": {
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/definitions/centrifugal.centrifugo.api.ChannelInfo"
+            "$ref": "#/definitions/ChannelInfo"
           }
         }
       }
     },
-    "centrifugal.centrifugo.api.ClientInfo": {
+    "ClientInfo": {
       "type": "object",
       "properties": {
         "user": {
@@ -1323,96 +1323,96 @@
         }
       }
     },
-    "centrifugal.centrifugo.api.Command": {
+    "Command": {
       "type": "object",
       "properties": {
         "publish": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.PublishRequest"
+          "$ref": "#/definitions/PublishRequest"
         },
         "broadcast": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.BroadcastRequest"
+          "$ref": "#/definitions/BroadcastRequest"
         },
         "subscribe": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.SubscribeRequest"
+          "$ref": "#/definitions/SubscribeRequest"
         },
         "unsubscribe": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.UnsubscribeRequest"
+          "$ref": "#/definitions/UnsubscribeRequest"
         },
         "disconnect": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.DisconnectRequest"
+          "$ref": "#/definitions/DisconnectRequest"
         },
         "presence": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.PresenceRequest"
+          "$ref": "#/definitions/PresenceRequest"
         },
         "presence_stats": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.PresenceStatsRequest"
+          "$ref": "#/definitions/PresenceStatsRequest"
         },
         "history": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.HistoryRequest"
+          "$ref": "#/definitions/HistoryRequest"
         },
         "history_remove": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.HistoryRemoveRequest"
+          "$ref": "#/definitions/HistoryRemoveRequest"
         },
         "info": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.InfoRequest"
+          "$ref": "#/definitions/InfoRequest"
         },
         "rpc": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.RPCRequest"
+          "$ref": "#/definitions/RPCRequest"
         },
         "refresh": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.RefreshRequest"
+          "$ref": "#/definitions/RefreshRequest"
         },
         "channels": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.ChannelsRequest"
+          "$ref": "#/definitions/ChannelsRequest"
         },
         "connections": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.ConnectionsRequest"
+          "$ref": "#/definitions/ConnectionsRequest"
         },
         "update_user_status": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.UpdateUserStatusRequest"
+          "$ref": "#/definitions/UpdateUserStatusRequest"
         },
         "get_user_status": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.GetUserStatusRequest"
+          "$ref": "#/definitions/GetUserStatusRequest"
         },
         "delete_user_status": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.DeleteUserStatusRequest"
+          "$ref": "#/definitions/DeleteUserStatusRequest"
         },
         "block_user": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.BlockUserRequest"
+          "$ref": "#/definitions/BlockUserRequest"
         },
         "unblock_user": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.UnblockUserRequest"
+          "$ref": "#/definitions/UnblockUserRequest"
         },
         "revoke_token": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.RevokeTokenRequest"
+          "$ref": "#/definitions/RevokeTokenRequest"
         },
         "invalidate_user_tokens": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.InvalidateUserTokensRequest"
+          "$ref": "#/definitions/InvalidateUserTokensRequest"
         },
         "device_register": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.DeviceRegisterRequest"
+          "$ref": "#/definitions/DeviceRegisterRequest"
         },
         "device_update": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.DeviceUpdateRequest"
+          "$ref": "#/definitions/DeviceUpdateRequest"
         },
         "device_remove": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.DeviceRemoveRequest"
+          "$ref": "#/definitions/DeviceRemoveRequest"
         },
         "device_list": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.DeviceListRequest"
+          "$ref": "#/definitions/DeviceListRequest"
         },
         "push_user_channel_list": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.PushUserChannelListRequest"
+          "$ref": "#/definitions/PushUserChannelListRequest"
         },
         "push_user_channel_update": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.PushUserChannelUpdateRequest"
+          "$ref": "#/definitions/PushUserChannelUpdateRequest"
         },
         "send_push_notification": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.SendPushNotificationRequest"
+          "$ref": "#/definitions/SendPushNotificationRequest"
         }
       }
     },
-    "centrifugal.centrifugo.api.ConnectionInfo": {
+    "ConnectionInfo": {
       "type": "object",
       "properties": {
         "app_name": {
@@ -1432,26 +1432,26 @@
           "description": "5-7 dropped for backwards compatibility."
         },
         "state": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.ConnectionState"
+          "$ref": "#/definitions/ConnectionState"
         }
       }
     },
-    "centrifugal.centrifugo.api.ConnectionState": {
+    "ConnectionState": {
       "type": "object",
       "properties": {
         "channels": {
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/definitions/centrifugal.centrifugo.api.ChannelContext"
+            "$ref": "#/definitions/ChannelContext"
           }
         },
         "connection_token": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.ConnectionTokenInfo"
+          "$ref": "#/definitions/ConnectionTokenInfo"
         },
         "subscription_tokens": {
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/definitions/centrifugal.centrifugo.api.SubscriptionTokenInfo"
+            "$ref": "#/definitions/SubscriptionTokenInfo"
           }
         },
         "meta": {
@@ -1459,7 +1459,7 @@
         }
       }
     },
-    "centrifugal.centrifugo.api.ConnectionTokenInfo": {
+    "ConnectionTokenInfo": {
       "type": "object",
       "properties": {
         "uid": {
@@ -1470,7 +1470,7 @@
         }
       }
     },
-    "centrifugal.centrifugo.api.ConnectionsRequest": {
+    "ConnectionsRequest": {
       "type": "object",
       "properties": {
         "user": {
@@ -1481,29 +1481,29 @@
         }
       }
     },
-    "centrifugal.centrifugo.api.ConnectionsResponse": {
+    "ConnectionsResponse": {
       "type": "object",
       "properties": {
         "error": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.Error"
+          "$ref": "#/definitions/Error"
         },
         "result": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.ConnectionsResult"
+          "$ref": "#/definitions/ConnectionsResult"
         }
       }
     },
-    "centrifugal.centrifugo.api.ConnectionsResult": {
+    "ConnectionsResult": {
       "type": "object",
       "properties": {
         "connections": {
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/definitions/centrifugal.centrifugo.api.ConnectionInfo"
+            "$ref": "#/definitions/ConnectionInfo"
           }
         }
       }
     },
-    "centrifugal.centrifugo.api.DeleteUserStatusRequest": {
+    "DeleteUserStatusRequest": {
       "type": "object",
       "properties": {
         "users": {
@@ -1514,21 +1514,21 @@
         }
       }
     },
-    "centrifugal.centrifugo.api.DeleteUserStatusResponse": {
+    "DeleteUserStatusResponse": {
       "type": "object",
       "properties": {
         "error": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.Error"
+          "$ref": "#/definitions/Error"
         },
         "result": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.DeleteUserStatusResult"
+          "$ref": "#/definitions/DeleteUserStatusResult"
         }
       }
     },
-    "centrifugal.centrifugo.api.DeleteUserStatusResult": {
+    "DeleteUserStatusResult": {
       "type": "object"
     },
-    "centrifugal.centrifugo.api.Device": {
+    "Device": {
       "type": "object",
       "properties": {
         "id": {
@@ -1566,7 +1566,7 @@
         }
       }
     },
-    "centrifugal.centrifugo.api.DeviceChannelsUpdate": {
+    "DeviceChannelsUpdate": {
       "type": "object",
       "properties": {
         "op": {
@@ -1581,7 +1581,7 @@
         }
       }
     },
-    "centrifugal.centrifugo.api.DeviceListRequest": {
+    "DeviceListRequest": {
       "type": "object",
       "properties": {
         "ids": {
@@ -1600,7 +1600,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/centrifugal.centrifugo.api.DeviceProviderTokens"
+            "$ref": "#/definitions/DeviceProviderTokens"
           }
         },
         "platforms": {
@@ -1639,25 +1639,25 @@
         }
       }
     },
-    "centrifugal.centrifugo.api.DeviceListResponse": {
+    "DeviceListResponse": {
       "type": "object",
       "properties": {
         "error": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.Error"
+          "$ref": "#/definitions/Error"
         },
         "result": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.DeviceListResult"
+          "$ref": "#/definitions/DeviceListResult"
         }
       }
     },
-    "centrifugal.centrifugo.api.DeviceListResult": {
+    "DeviceListResult": {
       "type": "object",
       "properties": {
         "items": {
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/centrifugal.centrifugo.api.Device"
+            "$ref": "#/definitions/Device"
           }
         },
         "has_more": {
@@ -1665,7 +1665,7 @@
         }
       }
     },
-    "centrifugal.centrifugo.api.DeviceMetaUpdate": {
+    "DeviceMetaUpdate": {
       "type": "object",
       "properties": {
         "meta": {
@@ -1676,7 +1676,7 @@
         }
       }
     },
-    "centrifugal.centrifugo.api.DeviceProviderTokens": {
+    "DeviceProviderTokens": {
       "type": "object",
       "properties": {
         "provider": {
@@ -1690,7 +1690,7 @@
         }
       }
     },
-    "centrifugal.centrifugo.api.DeviceRegisterRequest": {
+    "DeviceRegisterRequest": {
       "type": "object",
       "properties": {
         "id": {
@@ -1728,26 +1728,26 @@
         }
       }
     },
-    "centrifugal.centrifugo.api.DeviceRegisterResponse": {
+    "DeviceRegisterResponse": {
       "type": "object",
       "properties": {
         "error": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.Error"
+          "$ref": "#/definitions/Error"
         },
         "result": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.DeviceRegisterResult"
+          "$ref": "#/definitions/DeviceRegisterResult"
         }
       }
     },
-    "centrifugal.centrifugo.api.DeviceRegisterResult": {
+    "DeviceRegisterResult": {
       "type": "object",
       "properties": {
         "device": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.Device"
+          "$ref": "#/definitions/Device"
         }
       }
     },
-    "centrifugal.centrifugo.api.DeviceRemoveRequest": {
+    "DeviceRemoveRequest": {
       "type": "object",
       "properties": {
         "ids": {
@@ -1766,26 +1766,26 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/centrifugal.centrifugo.api.DeviceProviderTokens"
+            "$ref": "#/definitions/DeviceProviderTokens"
           }
         }
       }
     },
-    "centrifugal.centrifugo.api.DeviceRemoveResponse": {
+    "DeviceRemoveResponse": {
       "type": "object",
       "properties": {
         "error": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.Error"
+          "$ref": "#/definitions/Error"
         },
         "result": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.DeviceRemoveResult"
+          "$ref": "#/definitions/DeviceRemoveResult"
         }
       }
     },
-    "centrifugal.centrifugo.api.DeviceRemoveResult": {
+    "DeviceRemoveResult": {
       "type": "object"
     },
-    "centrifugal.centrifugo.api.DeviceTagsUpdate": {
+    "DeviceTagsUpdate": {
       "type": "object",
       "properties": {
         "op": {
@@ -1800,7 +1800,7 @@
         }
       }
     },
-    "centrifugal.centrifugo.api.DeviceUpdateRequest": {
+    "DeviceUpdateRequest": {
       "type": "object",
       "properties": {
         "ids": {
@@ -1819,38 +1819,38 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/centrifugal.centrifugo.api.DeviceProviderTokens"
+            "$ref": "#/definitions/DeviceProviderTokens"
           }
         },
         "user_update": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.DeviceUserUpdate"
+          "$ref": "#/definitions/DeviceUserUpdate"
         },
         "meta_update": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.DeviceMetaUpdate"
+          "$ref": "#/definitions/DeviceMetaUpdate"
         },
         "tags_update": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.DeviceTagsUpdate"
+          "$ref": "#/definitions/DeviceTagsUpdate"
         },
         "channels_update": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.DeviceChannelsUpdate"
+          "$ref": "#/definitions/DeviceChannelsUpdate"
         }
       }
     },
-    "centrifugal.centrifugo.api.DeviceUpdateResponse": {
+    "DeviceUpdateResponse": {
       "type": "object",
       "properties": {
         "error": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.Error"
+          "$ref": "#/definitions/Error"
         },
         "result": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.DeviceUpdateResult"
+          "$ref": "#/definitions/DeviceUpdateResult"
         }
       }
     },
-    "centrifugal.centrifugo.api.DeviceUpdateResult": {
+    "DeviceUpdateResult": {
       "type": "object"
     },
-    "centrifugal.centrifugo.api.DeviceUserUpdate": {
+    "DeviceUserUpdate": {
       "type": "object",
       "properties": {
         "user": {
@@ -1858,7 +1858,7 @@
         }
       }
     },
-    "centrifugal.centrifugo.api.Disconnect": {
+    "Disconnect": {
       "type": "object",
       "properties": {
         "code": {
@@ -1873,14 +1873,14 @@
         }
       }
     },
-    "centrifugal.centrifugo.api.DisconnectRequest": {
+    "DisconnectRequest": {
       "type": "object",
       "properties": {
         "user": {
           "type": "string"
         },
         "disconnect": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.Disconnect"
+          "$ref": "#/definitions/Disconnect"
         },
         "client": {
           "type": "string"
@@ -1896,21 +1896,21 @@
         }
       }
     },
-    "centrifugal.centrifugo.api.DisconnectResponse": {
+    "DisconnectResponse": {
       "type": "object",
       "properties": {
         "error": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.Error"
+          "$ref": "#/definitions/Error"
         },
         "result": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.DisconnectResult"
+          "$ref": "#/definitions/DisconnectResult"
         }
       }
     },
-    "centrifugal.centrifugo.api.DisconnectResult": {
+    "DisconnectResult": {
       "type": "object"
     },
-    "centrifugal.centrifugo.api.Error": {
+    "Error": {
       "type": "object",
       "properties": {
         "code": {
@@ -1922,7 +1922,7 @@
         }
       }
     },
-    "centrifugal.centrifugo.api.FcmPushNotification": {
+    "FcmPushNotification": {
       "type": "object",
       "properties": {
         "message": {
@@ -1930,7 +1930,7 @@
         }
       }
     },
-    "centrifugal.centrifugo.api.GetUserStatusRequest": {
+    "GetUserStatusRequest": {
       "type": "object",
       "properties": {
         "users": {
@@ -1941,30 +1941,30 @@
         }
       }
     },
-    "centrifugal.centrifugo.api.GetUserStatusResponse": {
+    "GetUserStatusResponse": {
       "type": "object",
       "properties": {
         "error": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.Error"
+          "$ref": "#/definitions/Error"
         },
         "result": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.GetUserStatusResult"
+          "$ref": "#/definitions/GetUserStatusResult"
         }
       }
     },
-    "centrifugal.centrifugo.api.GetUserStatusResult": {
+    "GetUserStatusResult": {
       "type": "object",
       "properties": {
         "statuses": {
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/centrifugal.centrifugo.api.UserStatus"
+            "$ref": "#/definitions/UserStatus"
           }
         }
       }
     },
-    "centrifugal.centrifugo.api.HistoryRemoveRequest": {
+    "HistoryRemoveRequest": {
       "type": "object",
       "properties": {
         "channel": {
@@ -1972,21 +1972,21 @@
         }
       }
     },
-    "centrifugal.centrifugo.api.HistoryRemoveResponse": {
+    "HistoryRemoveResponse": {
       "type": "object",
       "properties": {
         "error": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.Error"
+          "$ref": "#/definitions/Error"
         },
         "result": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.HistoryRemoveResult"
+          "$ref": "#/definitions/HistoryRemoveResult"
         }
       }
     },
-    "centrifugal.centrifugo.api.HistoryRemoveResult": {
+    "HistoryRemoveResult": {
       "type": "object"
     },
-    "centrifugal.centrifugo.api.HistoryRequest": {
+    "HistoryRequest": {
       "type": "object",
       "properties": {
         "channel": {
@@ -1997,32 +1997,32 @@
           "format": "int32"
         },
         "since": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.StreamPosition"
+          "$ref": "#/definitions/StreamPosition"
         },
         "reverse": {
           "type": "boolean"
         }
       }
     },
-    "centrifugal.centrifugo.api.HistoryResponse": {
+    "HistoryResponse": {
       "type": "object",
       "properties": {
         "error": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.Error"
+          "$ref": "#/definitions/Error"
         },
         "result": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.HistoryResult"
+          "$ref": "#/definitions/HistoryResult"
         }
       }
     },
-    "centrifugal.centrifugo.api.HistoryResult": {
+    "HistoryResult": {
       "type": "object",
       "properties": {
         "publications": {
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/centrifugal.centrifugo.api.Publication"
+            "$ref": "#/definitions/Publication"
           }
         },
         "epoch": {
@@ -2033,7 +2033,7 @@
         }
       }
     },
-    "centrifugal.centrifugo.api.HmsPushNotification": {
+    "HmsPushNotification": {
       "type": "object",
       "properties": {
         "message": {
@@ -2041,33 +2041,33 @@
         }
       }
     },
-    "centrifugal.centrifugo.api.InfoRequest": {
+    "InfoRequest": {
       "type": "object"
     },
-    "centrifugal.centrifugo.api.InfoResponse": {
+    "InfoResponse": {
       "type": "object",
       "properties": {
         "error": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.Error"
+          "$ref": "#/definitions/Error"
         },
         "result": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.InfoResult"
+          "$ref": "#/definitions/InfoResult"
         }
       }
     },
-    "centrifugal.centrifugo.api.InfoResult": {
+    "InfoResult": {
       "type": "object",
       "properties": {
         "nodes": {
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/centrifugal.centrifugo.api.NodeResult"
+            "$ref": "#/definitions/NodeResult"
           }
         }
       }
     },
-    "centrifugal.centrifugo.api.InvalidateUserTokensRequest": {
+    "InvalidateUserTokensRequest": {
       "type": "object",
       "properties": {
         "expire_at": {
@@ -2084,21 +2084,21 @@
         }
       }
     },
-    "centrifugal.centrifugo.api.InvalidateUserTokensResponse": {
+    "InvalidateUserTokensResponse": {
       "type": "object",
       "properties": {
         "error": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.Error"
+          "$ref": "#/definitions/Error"
         },
         "result": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.InvalidateUserTokensResult"
+          "$ref": "#/definitions/InvalidateUserTokensResult"
         }
       }
     },
-    "centrifugal.centrifugo.api.InvalidateUserTokensResult": {
+    "InvalidateUserTokensResult": {
       "type": "object"
     },
-    "centrifugal.centrifugo.api.Metrics": {
+    "Metrics": {
       "type": "object",
       "properties": {
         "interval": {
@@ -2114,7 +2114,7 @@
         }
       }
     },
-    "centrifugal.centrifugo.api.NodeResult": {
+    "NodeResult": {
       "type": "object",
       "properties": {
         "uid": {
@@ -2143,10 +2143,10 @@
           "format": "int64"
         },
         "metrics": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.Metrics"
+          "$ref": "#/definitions/Metrics"
         },
         "process": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.Process"
+          "$ref": "#/definitions/Process"
         },
         "num_subs": {
           "type": "integer",
@@ -2154,7 +2154,7 @@
         }
       }
     },
-    "centrifugal.centrifugo.api.PresenceRequest": {
+    "PresenceRequest": {
       "type": "object",
       "properties": {
         "channel": {
@@ -2162,29 +2162,29 @@
         }
       }
     },
-    "centrifugal.centrifugo.api.PresenceResponse": {
+    "PresenceResponse": {
       "type": "object",
       "properties": {
         "error": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.Error"
+          "$ref": "#/definitions/Error"
         },
         "result": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.PresenceResult"
+          "$ref": "#/definitions/PresenceResult"
         }
       }
     },
-    "centrifugal.centrifugo.api.PresenceResult": {
+    "PresenceResult": {
       "type": "object",
       "properties": {
         "presence": {
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/definitions/centrifugal.centrifugo.api.ClientInfo"
+            "$ref": "#/definitions/ClientInfo"
           }
         }
       }
     },
-    "centrifugal.centrifugo.api.PresenceStatsRequest": {
+    "PresenceStatsRequest": {
       "type": "object",
       "properties": {
         "channel": {
@@ -2192,18 +2192,18 @@
         }
       }
     },
-    "centrifugal.centrifugo.api.PresenceStatsResponse": {
+    "PresenceStatsResponse": {
       "type": "object",
       "properties": {
         "error": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.Error"
+          "$ref": "#/definitions/Error"
         },
         "result": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.PresenceStatsResult"
+          "$ref": "#/definitions/PresenceStatsResult"
         }
       }
     },
-    "centrifugal.centrifugo.api.PresenceStatsResult": {
+    "PresenceStatsResult": {
       "type": "object",
       "properties": {
         "num_clients": {
@@ -2216,7 +2216,7 @@
         }
       }
     },
-    "centrifugal.centrifugo.api.Process": {
+    "Process": {
       "type": "object",
       "properties": {
         "cpu": {
@@ -2228,7 +2228,7 @@
         }
       }
     },
-    "centrifugal.centrifugo.api.Publication": {
+    "Publication": {
       "type": "object",
       "properties": {
         "data": {
@@ -2236,7 +2236,7 @@
           "title": "Removed: string uid = 1;"
         },
         "info": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.ClientInfo"
+          "$ref": "#/definitions/ClientInfo"
         },
         "offset": {
           "type": "integer"
@@ -2249,7 +2249,7 @@
         }
       }
     },
-    "centrifugal.centrifugo.api.PublishRequest": {
+    "PublishRequest": {
       "type": "object",
       "properties": {
         "channel": {
@@ -2272,18 +2272,18 @@
         }
       }
     },
-    "centrifugal.centrifugo.api.PublishResponse": {
+    "PublishResponse": {
       "type": "object",
       "properties": {
         "error": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.Error"
+          "$ref": "#/definitions/Error"
         },
         "result": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.PublishResult"
+          "$ref": "#/definitions/PublishResult"
         }
       }
     },
-    "centrifugal.centrifugo.api.PublishResult": {
+    "PublishResult": {
       "type": "object",
       "properties": {
         "offset": {
@@ -2294,17 +2294,17 @@
         }
       }
     },
-    "centrifugal.centrifugo.api.PushNotification": {
+    "PushNotification": {
       "type": "object",
       "properties": {
         "fcm": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.FcmPushNotification"
+          "$ref": "#/definitions/FcmPushNotification"
         },
         "hms": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.HmsPushNotification"
+          "$ref": "#/definitions/HmsPushNotification"
         },
         "apns": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.ApnsPushNotification"
+          "$ref": "#/definitions/ApnsPushNotification"
         },
         "uid": {
           "type": "string"
@@ -2314,7 +2314,7 @@
         }
       }
     },
-    "centrifugal.centrifugo.api.PushRecipient": {
+    "PushRecipient": {
       "type": "object",
       "properties": {
         "device_ids": {
@@ -2361,7 +2361,7 @@
         }
       }
     },
-    "centrifugal.centrifugo.api.PushUserChannel": {
+    "PushUserChannel": {
       "type": "object",
       "properties": {
         "id": {
@@ -2375,7 +2375,7 @@
         }
       }
     },
-    "centrifugal.centrifugo.api.PushUserChannelListRequest": {
+    "PushUserChannelListRequest": {
       "type": "object",
       "properties": {
         "users": {
@@ -2399,25 +2399,25 @@
         }
       }
     },
-    "centrifugal.centrifugo.api.PushUserChannelListResponse": {
+    "PushUserChannelListResponse": {
       "type": "object",
       "properties": {
         "error": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.Error"
+          "$ref": "#/definitions/Error"
         },
         "result": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.PushUserChannelListResult"
+          "$ref": "#/definitions/PushUserChannelListResult"
         }
       }
     },
-    "centrifugal.centrifugo.api.PushUserChannelListResult": {
+    "PushUserChannelListResult": {
       "type": "object",
       "properties": {
         "items": {
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/centrifugal.centrifugo.api.PushUserChannel"
+            "$ref": "#/definitions/PushUserChannel"
           }
         },
         "has_more": {
@@ -2425,7 +2425,7 @@
         }
       }
     },
-    "centrifugal.centrifugo.api.PushUserChannelUpdateRequest": {
+    "PushUserChannelUpdateRequest": {
       "type": "object",
       "properties": {
         "user": {
@@ -2443,21 +2443,21 @@
         }
       }
     },
-    "centrifugal.centrifugo.api.PushUserChannelUpdateResponse": {
+    "PushUserChannelUpdateResponse": {
       "type": "object",
       "properties": {
         "error": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.Error"
+          "$ref": "#/definitions/Error"
         },
         "result": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.PushUserChannelUpdateResult"
+          "$ref": "#/definitions/PushUserChannelUpdateResult"
         }
       }
     },
-    "centrifugal.centrifugo.api.PushUserChannelUpdateResult": {
+    "PushUserChannelUpdateResult": {
       "type": "object"
     },
-    "centrifugal.centrifugo.api.RPCRequest": {
+    "RPCRequest": {
       "type": "object",
       "properties": {
         "method": {
@@ -2468,7 +2468,7 @@
         }
       }
     },
-    "centrifugal.centrifugo.api.RPCResult": {
+    "RPCResult": {
       "type": "object",
       "properties": {
         "data": {
@@ -2476,7 +2476,7 @@
         }
       }
     },
-    "centrifugal.centrifugo.api.RefreshRequest": {
+    "RefreshRequest": {
       "type": "object",
       "properties": {
         "user": {
@@ -2499,110 +2499,110 @@
         }
       }
     },
-    "centrifugal.centrifugo.api.RefreshResponse": {
+    "RefreshResponse": {
       "type": "object",
       "properties": {
         "error": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.Error"
+          "$ref": "#/definitions/Error"
         },
         "result": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.RefreshResult"
+          "$ref": "#/definitions/RefreshResult"
         }
       }
     },
-    "centrifugal.centrifugo.api.RefreshResult": {
+    "RefreshResult": {
       "type": "object"
     },
-    "centrifugal.centrifugo.api.Reply": {
+    "Reply": {
       "type": "object",
       "properties": {
         "publish": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.PublishResult"
+          "$ref": "#/definitions/PublishResult"
         },
         "broadcast": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.BroadcastResult"
+          "$ref": "#/definitions/BroadcastResult"
         },
         "subscribe": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.SubscribeResult"
+          "$ref": "#/definitions/SubscribeResult"
         },
         "unsubscribe": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.UnsubscribeResult"
+          "$ref": "#/definitions/UnsubscribeResult"
         },
         "disconnect": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.DisconnectResult"
+          "$ref": "#/definitions/DisconnectResult"
         },
         "presence": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.PresenceResult"
+          "$ref": "#/definitions/PresenceResult"
         },
         "presence_stats": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.PresenceStatsResult"
+          "$ref": "#/definitions/PresenceStatsResult"
         },
         "history": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.HistoryResult"
+          "$ref": "#/definitions/HistoryResult"
         },
         "history_remove": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.HistoryRemoveResult"
+          "$ref": "#/definitions/HistoryRemoveResult"
         },
         "info": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.InfoResult"
+          "$ref": "#/definitions/InfoResult"
         },
         "rpc": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.RPCResult"
+          "$ref": "#/definitions/RPCResult"
         },
         "refresh": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.RefreshResult"
+          "$ref": "#/definitions/RefreshResult"
         },
         "channels": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.ChannelsResult"
+          "$ref": "#/definitions/ChannelsResult"
         },
         "connections": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.ConnectionsResult"
+          "$ref": "#/definitions/ConnectionsResult"
         },
         "update_user_status": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.UpdateUserStatusResult"
+          "$ref": "#/definitions/UpdateUserStatusResult"
         },
         "get_user_status": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.GetUserStatusResult"
+          "$ref": "#/definitions/GetUserStatusResult"
         },
         "delete_user_status": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.DeleteUserStatusResult"
+          "$ref": "#/definitions/DeleteUserStatusResult"
         },
         "block_user": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.BlockUserResult"
+          "$ref": "#/definitions/BlockUserResult"
         },
         "unblock_user": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.UnblockUserResult"
+          "$ref": "#/definitions/UnblockUserResult"
         },
         "revoke_token": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.RevokeTokenResult"
+          "$ref": "#/definitions/RevokeTokenResult"
         },
         "invalidate_user_tokens": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.InvalidateUserTokensResult"
+          "$ref": "#/definitions/InvalidateUserTokensResult"
         },
         "device_register": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.DeviceRegisterResult"
+          "$ref": "#/definitions/DeviceRegisterResult"
         },
         "device_update": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.DeviceUpdateResult"
+          "$ref": "#/definitions/DeviceUpdateResult"
         },
         "device_remove": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.DeviceRemoveResult"
+          "$ref": "#/definitions/DeviceRemoveResult"
         },
         "device_list": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.DeviceListResult"
+          "$ref": "#/definitions/DeviceListResult"
         },
         "push_user_channel_list": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.PushUserChannelListResult"
+          "$ref": "#/definitions/PushUserChannelListResult"
         },
         "push_user_channel_update": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.PushUserChannelUpdateResult"
+          "$ref": "#/definitions/PushUserChannelUpdateResult"
         },
         "send_push_notification": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.SendPushNotificationResult"
+          "$ref": "#/definitions/SendPushNotificationResult"
         }
       }
     },
-    "centrifugal.centrifugo.api.RevokeTokenRequest": {
+    "RevokeTokenRequest": {
       "type": "object",
       "properties": {
         "expire_at": {
@@ -2613,43 +2613,43 @@
         }
       }
     },
-    "centrifugal.centrifugo.api.RevokeTokenResponse": {
+    "RevokeTokenResponse": {
       "type": "object",
       "properties": {
         "error": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.Error"
+          "$ref": "#/definitions/Error"
         },
         "result": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.RevokeTokenResult"
+          "$ref": "#/definitions/RevokeTokenResult"
         }
       }
     },
-    "centrifugal.centrifugo.api.RevokeTokenResult": {
+    "RevokeTokenResult": {
       "type": "object"
     },
-    "centrifugal.centrifugo.api.SendPushNotificationRequest": {
+    "SendPushNotificationRequest": {
       "type": "object",
       "properties": {
         "recipient": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.PushRecipient"
+          "$ref": "#/definitions/PushRecipient"
         },
         "notification": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.PushNotification"
+          "$ref": "#/definitions/PushNotification"
         }
       }
     },
-    "centrifugal.centrifugo.api.SendPushNotificationResponse": {
+    "SendPushNotificationResponse": {
       "type": "object",
       "properties": {
         "error": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.Error"
+          "$ref": "#/definitions/Error"
         },
         "result": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.SendPushNotificationResult"
+          "$ref": "#/definitions/SendPushNotificationResult"
         }
       }
     },
-    "centrifugal.centrifugo.api.SendPushNotificationResult": {
+    "SendPushNotificationResult": {
       "type": "object",
       "properties": {
         "uid": {
@@ -2658,7 +2658,7 @@
         }
       }
     },
-    "centrifugal.centrifugo.api.StreamPosition": {
+    "StreamPosition": {
       "type": "object",
       "properties": {
         "offset": {
@@ -2669,27 +2669,27 @@
         }
       }
     },
-    "centrifugal.centrifugo.api.SubscribeOptionOverride": {
+    "SubscribeOptionOverride": {
       "type": "object",
       "properties": {
         "presence": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.BoolValue"
+          "$ref": "#/definitions/BoolValue"
         },
         "join_leave": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.BoolValue"
+          "$ref": "#/definitions/BoolValue"
         },
         "force_recovery": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.BoolValue"
+          "$ref": "#/definitions/BoolValue"
         },
         "force_positioning": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.BoolValue"
+          "$ref": "#/definitions/BoolValue"
         },
         "force_push_join_leave": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.BoolValue"
+          "$ref": "#/definitions/BoolValue"
         }
       }
     },
-    "centrifugal.centrifugo.api.SubscribeRequest": {
+    "SubscribeRequest": {
       "type": "object",
       "properties": {
         "channel": {
@@ -2717,31 +2717,31 @@
           "type": "string"
         },
         "recover_since": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.StreamPosition"
+          "$ref": "#/definitions/StreamPosition"
         },
         "override": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.SubscribeOptionOverride"
+          "$ref": "#/definitions/SubscribeOptionOverride"
         },
         "session": {
           "type": "string"
         }
       }
     },
-    "centrifugal.centrifugo.api.SubscribeResponse": {
+    "SubscribeResponse": {
       "type": "object",
       "properties": {
         "error": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.Error"
+          "$ref": "#/definitions/Error"
         },
         "result": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.SubscribeResult"
+          "$ref": "#/definitions/SubscribeResult"
         }
       }
     },
-    "centrifugal.centrifugo.api.SubscribeResult": {
+    "SubscribeResult": {
       "type": "object"
     },
-    "centrifugal.centrifugo.api.SubscriptionTokenInfo": {
+    "SubscriptionTokenInfo": {
       "type": "object",
       "properties": {
         "uid": {
@@ -2752,7 +2752,7 @@
         }
       }
     },
-    "centrifugal.centrifugo.api.UnblockUserRequest": {
+    "UnblockUserRequest": {
       "type": "object",
       "properties": {
         "user": {
@@ -2760,21 +2760,21 @@
         }
       }
     },
-    "centrifugal.centrifugo.api.UnblockUserResponse": {
+    "UnblockUserResponse": {
       "type": "object",
       "properties": {
         "error": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.Error"
+          "$ref": "#/definitions/Error"
         },
         "result": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.UnblockUserResult"
+          "$ref": "#/definitions/UnblockUserResult"
         }
       }
     },
-    "centrifugal.centrifugo.api.UnblockUserResult": {
+    "UnblockUserResult": {
       "type": "object"
     },
-    "centrifugal.centrifugo.api.UnsubscribeRequest": {
+    "UnsubscribeRequest": {
       "type": "object",
       "properties": {
         "channel": {
@@ -2791,21 +2791,21 @@
         }
       }
     },
-    "centrifugal.centrifugo.api.UnsubscribeResponse": {
+    "UnsubscribeResponse": {
       "type": "object",
       "properties": {
         "error": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.Error"
+          "$ref": "#/definitions/Error"
         },
         "result": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.UnsubscribeResult"
+          "$ref": "#/definitions/UnsubscribeResult"
         }
       }
     },
-    "centrifugal.centrifugo.api.UnsubscribeResult": {
+    "UnsubscribeResult": {
       "type": "object"
     },
-    "centrifugal.centrifugo.api.UpdateUserStatusRequest": {
+    "UpdateUserStatusRequest": {
       "type": "object",
       "properties": {
         "users": {
@@ -2816,21 +2816,21 @@
         }
       }
     },
-    "centrifugal.centrifugo.api.UpdateUserStatusResponse": {
+    "UpdateUserStatusResponse": {
       "type": "object",
       "properties": {
         "error": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.Error"
+          "$ref": "#/definitions/Error"
         },
         "result": {
-          "$ref": "#/definitions/centrifugal.centrifugo.api.UpdateUserStatusResult"
+          "$ref": "#/definitions/UpdateUserStatusResult"
         }
       }
     },
-    "centrifugal.centrifugo.api.UpdateUserStatusResult": {
+    "UpdateUserStatusResult": {
       "type": "object"
     },
-    "centrifugal.centrifugo.api.UserStatus": {
+    "UserStatus": {
       "type": "object",
       "properties": {
         "user": {

--- a/internal/apiproto/api.swagger.json
+++ b/internal/apiproto/api.swagger.json
@@ -46,7 +46,7 @@
   "paths": {
     "/batch": {
       "post": {
-        "summary": "Batch request",
+        "summary": "Batch request (send many commands in one request)",
         "operationId": "CentrifugoApi_Batch",
         "responses": {
           "200": {
@@ -124,7 +124,7 @@
     },
     "/broadcast": {
       "post": {
-        "summary": "Broadcast request",
+        "summary": "Broadcast allows publishing same data into many channels",
         "operationId": "CentrifugoApi_Broadcast",
         "responses": {
           "200": {
@@ -436,7 +436,7 @@
     },
     "/disconnect": {
       "post": {
-        "summary": "Disconnect request",
+        "summary": "Disconnect client(s) from server",
         "operationId": "CentrifugoApi_Disconnect",
         "responses": {
           "200": {
@@ -514,7 +514,7 @@
     },
     "/history": {
       "post": {
-        "summary": "History request",
+        "summary": "History for a channel",
         "operationId": "CentrifugoApi_History",
         "responses": {
           "200": {
@@ -553,7 +553,7 @@
     },
     "/history_remove": {
       "post": {
-        "summary": "History remove request",
+        "summary": "Remove history for a channel",
         "operationId": "CentrifugoApi_HistoryRemove",
         "responses": {
           "200": {
@@ -592,7 +592,7 @@
     },
     "/info": {
       "post": {
-        "summary": "Info request",
+        "summary": "Info shows details about server nodes",
         "operationId": "CentrifugoApi_Info",
         "responses": {
           "200": {
@@ -670,7 +670,7 @@
     },
     "/presence": {
       "post": {
-        "summary": "Presence request",
+        "summary": "Presence information for a channel",
         "operationId": "CentrifugoApi_Presence",
         "responses": {
           "200": {
@@ -709,7 +709,7 @@
     },
     "/presence_stats": {
       "post": {
-        "summary": "Presence stats request",
+        "summary": "Presence stats information for a channel",
         "operationId": "CentrifugoApi_PresenceStats",
         "responses": {
           "200": {
@@ -748,7 +748,7 @@
     },
     "/publish": {
       "post": {
-        "summary": "Publish request",
+        "summary": "Publish data into channel",
         "operationId": "CentrifugoApi_Publish",
         "responses": {
           "200": {
@@ -865,7 +865,7 @@
     },
     "/refresh": {
       "post": {
-        "summary": "Refresh request",
+        "summary": "Refresh connection(s) by server-side call",
         "operationId": "CentrifugoApi_Refresh",
         "responses": {
           "200": {
@@ -982,7 +982,7 @@
     },
     "/subscribe": {
       "post": {
-        "summary": "Subscribe request",
+        "summary": "Subscribe connection(s) to a channel",
         "operationId": "CentrifugoApi_Subscribe",
         "responses": {
           "200": {
@@ -1060,7 +1060,7 @@
     },
     "/unsubscribe": {
       "post": {
-        "summary": "Unsubscribe request",
+        "summary": "Unsubscribe connection(s) from channel",
         "operationId": "CentrifugoApi_Unsubscribe",
         "responses": {
           "200": {
@@ -2856,5 +2856,9 @@
     {
       "ApiKeyAuth": []
     }
-  ]
+  ],
+  "externalDocs": {
+    "description": "More about Centrifugo HTTP API",
+    "url": "https://centrifugal.dev/docs/server/server_api"
+  }
 }

--- a/internal/apiproto/api.swagger.json
+++ b/internal/apiproto/api.swagger.json
@@ -45,6 +45,7 @@
       "name": "pro"
     }
   ],
+  "basePath": "/api",
   "consumes": [
     "application/json"
   ],

--- a/internal/apiproto/api.swagger.json
+++ b/internal/apiproto/api.swagger.json
@@ -1017,8 +1017,7 @@
           }
         },
         "payload": {
-          "type": "string",
-          "format": "byte"
+          "type": "object"
         }
       }
     },
@@ -1049,7 +1048,7 @@
     "apiBlockUserRequest": {
       "type": "object",
       "properties": {
-        "expireAt": {
+        "expire_at": {
           "type": "string",
           "format": "int64"
         },
@@ -1095,7 +1094,7 @@
         "b64data": {
           "type": "string"
         },
-        "skipHistory": {
+        "skip_history": {
           "type": "boolean"
         },
         "tags": {
@@ -1141,7 +1140,7 @@
     "apiChannelInfo": {
       "type": "object",
       "properties": {
-        "numClients": {
+        "num_clients": {
           "type": "integer",
           "format": "int64"
         }
@@ -1186,13 +1185,11 @@
         "client": {
           "type": "string"
         },
-        "connInfo": {
-          "type": "string",
-          "format": "byte"
+        "conn_info": {
+          "type": "object"
         },
-        "chanInfo": {
-          "type": "string",
-          "format": "byte"
+        "chan_info": {
+          "type": "object"
         }
       }
     },
@@ -1217,13 +1214,13 @@
         "presence": {
           "$ref": "#/definitions/apiPresenceRequest"
         },
-        "presenceStats": {
+        "presence_stats": {
           "$ref": "#/definitions/apiPresenceStatsRequest"
         },
         "history": {
           "$ref": "#/definitions/apiHistoryRequest"
         },
-        "historyRemove": {
+        "history_remove": {
           "$ref": "#/definitions/apiHistoryRemoveRequest"
         },
         "info": {
@@ -1241,46 +1238,46 @@
         "connections": {
           "$ref": "#/definitions/apiConnectionsRequest"
         },
-        "updateUserStatus": {
+        "update_user_status": {
           "$ref": "#/definitions/apiUpdateUserStatusRequest"
         },
-        "getUserStatus": {
+        "get_user_status": {
           "$ref": "#/definitions/apiGetUserStatusRequest"
         },
-        "deleteUserStatus": {
+        "delete_user_status": {
           "$ref": "#/definitions/apiDeleteUserStatusRequest"
         },
-        "blockUser": {
+        "block_user": {
           "$ref": "#/definitions/apiBlockUserRequest"
         },
-        "unblockUser": {
+        "unblock_user": {
           "$ref": "#/definitions/apiUnblockUserRequest"
         },
-        "revokeToken": {
+        "revoke_token": {
           "$ref": "#/definitions/apiRevokeTokenRequest"
         },
-        "invalidateUserTokens": {
+        "invalidate_user_tokens": {
           "$ref": "#/definitions/apiInvalidateUserTokensRequest"
         },
-        "deviceRegister": {
+        "device_register": {
           "$ref": "#/definitions/apiDeviceRegisterRequest"
         },
-        "deviceUpdate": {
+        "device_update": {
           "$ref": "#/definitions/apiDeviceUpdateRequest"
         },
-        "deviceRemove": {
+        "device_remove": {
           "$ref": "#/definitions/apiDeviceRemoveRequest"
         },
-        "deviceList": {
+        "device_list": {
           "$ref": "#/definitions/apiDeviceListRequest"
         },
-        "pushUserChannelList": {
+        "push_user_channel_list": {
           "$ref": "#/definitions/apiPushUserChannelListRequest"
         },
-        "pushUserChannelUpdate": {
+        "push_user_channel_update": {
           "$ref": "#/definitions/apiPushUserChannelUpdateRequest"
         },
-        "sendPushNotification": {
+        "send_push_notification": {
           "$ref": "#/definitions/apiSendPushNotificationRequest"
         }
       }
@@ -1288,10 +1285,10 @@
     "apiConnectionInfo": {
       "type": "object",
       "properties": {
-        "appName": {
+        "app_name": {
           "type": "string"
         },
-        "appVersion": {
+        "app_version": {
           "type": "string"
         },
         "transport": {
@@ -1318,18 +1315,17 @@
             "$ref": "#/definitions/apiChannelContext"
           }
         },
-        "connectionToken": {
+        "connection_token": {
           "$ref": "#/definitions/apiConnectionTokenInfo"
         },
-        "subscriptionTokens": {
+        "subscription_tokens": {
           "type": "object",
           "additionalProperties": {
             "$ref": "#/definitions/apiSubscriptionTokenInfo"
           }
         },
         "meta": {
-          "type": "string",
-          "format": "byte"
+          "type": "object"
         }
       }
     },
@@ -1339,7 +1335,7 @@
         "uid": {
           "type": "string"
         },
-        "issuedAt": {
+        "issued_at": {
           "type": "string",
           "format": "int64"
         }
@@ -1471,7 +1467,7 @@
             "type": "string"
           }
         },
-        "providerTokens": {
+        "provider_tokens": {
           "type": "array",
           "items": {
             "type": "object",
@@ -1503,13 +1499,13 @@
           "type": "integer",
           "format": "int32"
         },
-        "includeChannels": {
+        "include_channels": {
           "type": "boolean"
         },
-        "includeMeta": {
+        "include_meta": {
           "type": "boolean"
         },
-        "includeTags": {
+        "include_tags": {
           "type": "boolean"
         }
       }
@@ -1535,7 +1531,7 @@
             "$ref": "#/definitions/apiDevice"
           }
         },
-        "hasMore": {
+        "has_more": {
           "type": "boolean"
         }
       }
@@ -1637,7 +1633,7 @@
             "type": "string"
           }
         },
-        "providerTokens": {
+        "provider_tokens": {
           "type": "array",
           "items": {
             "type": "object",
@@ -1690,23 +1686,23 @@
             "type": "string"
           }
         },
-        "providerTokens": {
+        "provider_tokens": {
           "type": "array",
           "items": {
             "type": "object",
             "$ref": "#/definitions/apiDeviceProviderTokens"
           }
         },
-        "userUpdate": {
+        "user_update": {
           "$ref": "#/definitions/apiDeviceUserUpdate"
         },
-        "metaUpdate": {
+        "meta_update": {
           "$ref": "#/definitions/apiDeviceMetaUpdate"
         },
-        "tagsUpdate": {
+        "tags_update": {
           "$ref": "#/definitions/apiDeviceTagsUpdate"
         },
-        "channelsUpdate": {
+        "channels_update": {
           "$ref": "#/definitions/apiDeviceChannelsUpdate"
         }
       }
@@ -1801,8 +1797,7 @@
       "type": "object",
       "properties": {
         "message": {
-          "type": "string",
-          "format": "byte"
+          "type": "object"
         }
       }
     },
@@ -1905,8 +1900,7 @@
           "type": "string"
         },
         "offset": {
-          "type": "string",
-          "format": "uint64"
+          "type": "integer"
         }
       }
     },
@@ -1914,8 +1908,7 @@
       "type": "object",
       "properties": {
         "message": {
-          "type": "string",
-          "format": "byte"
+          "type": "object"
         }
       }
     },
@@ -1948,14 +1941,14 @@
     "apiInvalidateUserTokensRequest": {
       "type": "object",
       "properties": {
-        "expireAt": {
+        "expire_at": {
           "type": "string",
           "format": "int64"
         },
         "user": {
           "type": "string"
         },
-        "issuedBefore": {
+        "issued_before": {
           "type": "string",
           "format": "int64"
         },
@@ -2006,15 +1999,15 @@
         "version": {
           "type": "string"
         },
-        "numClients": {
+        "num_clients": {
           "type": "integer",
           "format": "int64"
         },
-        "numUsers": {
+        "num_users": {
           "type": "integer",
           "format": "int64"
         },
-        "numChannels": {
+        "num_channels": {
           "type": "integer",
           "format": "int64"
         },
@@ -2028,7 +2021,7 @@
         "process": {
           "$ref": "#/definitions/apiProcess"
         },
-        "numSubs": {
+        "num_subs": {
           "type": "integer",
           "format": "int64"
         }
@@ -2086,11 +2079,11 @@
     "apiPresenceStatsResult": {
       "type": "object",
       "properties": {
-        "numClients": {
+        "num_clients": {
           "type": "integer",
           "format": "int64"
         },
-        "numUsers": {
+        "num_users": {
           "type": "integer",
           "format": "int64"
         }
@@ -2120,8 +2113,7 @@
           "$ref": "#/definitions/apiClientInfo"
         },
         "offset": {
-          "type": "string",
-          "format": "uint64"
+          "type": "integer"
         },
         "tags": {
           "type": "object",
@@ -2143,7 +2135,7 @@
         "b64data": {
           "type": "string"
         },
-        "skipHistory": {
+        "skip_history": {
           "type": "boolean"
         },
         "tags": {
@@ -2169,8 +2161,7 @@
       "type": "object",
       "properties": {
         "offset": {
-          "type": "string",
-          "format": "uint64"
+          "type": "integer"
         },
         "epoch": {
           "type": "string"
@@ -2192,7 +2183,7 @@
         "uid": {
           "type": "string"
         },
-        "expireAt": {
+        "expire_at": {
           "type": "string",
           "format": "int64"
         }
@@ -2201,7 +2192,7 @@
     "apiPushRecipient": {
       "type": "object",
       "properties": {
-        "deviceIds": {
+        "device_ids": {
           "type": "array",
           "items": {
             "type": "string"
@@ -2213,31 +2204,31 @@
             "type": "string"
           }
         },
-        "fcmTokens": {
+        "fcm_tokens": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "fcmTopic": {
+        "fcm_topic": {
           "type": "string"
         },
-        "fcmCondition": {
+        "fcm_condition": {
           "type": "string"
         },
-        "hmsTokens": {
+        "hms_tokens": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "hmsTopic": {
+        "hms_topic": {
           "type": "string"
         },
-        "hmsCondition": {
+        "hms_condition": {
           "type": "string"
         },
-        "apnsTokens": {
+        "apns_tokens": {
           "type": "array",
           "items": {
             "type": "string"
@@ -2304,7 +2295,7 @@
             "$ref": "#/definitions/apiPushUserChannel"
           }
         },
-        "hasMore": {
+        "has_more": {
           "type": "boolean"
         }
       }
@@ -2348,8 +2339,7 @@
           "type": "string"
         },
         "params": {
-          "type": "string",
-          "format": "byte"
+          "type": "object"
         }
       }
     },
@@ -2373,13 +2363,12 @@
         "expired": {
           "type": "boolean"
         },
-        "expireAt": {
+        "expire_at": {
           "type": "string",
           "format": "int64"
         },
         "info": {
-          "type": "string",
-          "format": "byte"
+          "type": "object"
         },
         "session": {
           "type": "string"
@@ -2421,13 +2410,13 @@
         "presence": {
           "$ref": "#/definitions/apiPresenceResult"
         },
-        "presenceStats": {
+        "presence_stats": {
           "$ref": "#/definitions/apiPresenceStatsResult"
         },
         "history": {
           "$ref": "#/definitions/apiHistoryResult"
         },
-        "historyRemove": {
+        "history_remove": {
           "$ref": "#/definitions/apiHistoryRemoveResult"
         },
         "info": {
@@ -2445,46 +2434,46 @@
         "connections": {
           "$ref": "#/definitions/apiConnectionsResult"
         },
-        "updateUserStatus": {
+        "update_user_status": {
           "$ref": "#/definitions/apiUpdateUserStatusResult"
         },
-        "getUserStatus": {
+        "get_user_status": {
           "$ref": "#/definitions/apiGetUserStatusResult"
         },
-        "deleteUserStatus": {
+        "delete_user_status": {
           "$ref": "#/definitions/apiDeleteUserStatusResult"
         },
-        "blockUser": {
+        "block_user": {
           "$ref": "#/definitions/apiBlockUserResult"
         },
-        "unblockUser": {
+        "unblock_user": {
           "$ref": "#/definitions/apiUnblockUserResult"
         },
-        "revokeToken": {
+        "revoke_token": {
           "$ref": "#/definitions/apiRevokeTokenResult"
         },
-        "invalidateUserTokens": {
+        "invalidate_user_tokens": {
           "$ref": "#/definitions/apiInvalidateUserTokensResult"
         },
-        "deviceRegister": {
+        "device_register": {
           "$ref": "#/definitions/apiDeviceRegisterResult"
         },
-        "deviceUpdate": {
+        "device_update": {
           "$ref": "#/definitions/apiDeviceUpdateResult"
         },
-        "deviceRemove": {
+        "device_remove": {
           "$ref": "#/definitions/apiDeviceRemoveResult"
         },
-        "deviceList": {
+        "device_list": {
           "$ref": "#/definitions/apiDeviceListResult"
         },
-        "pushUserChannelList": {
+        "push_user_channel_list": {
           "$ref": "#/definitions/apiPushUserChannelListResult"
         },
-        "pushUserChannelUpdate": {
+        "push_user_channel_update": {
           "$ref": "#/definitions/apiPushUserChannelUpdateResult"
         },
-        "sendPushNotification": {
+        "send_push_notification": {
           "$ref": "#/definitions/apiSendPushNotificationResult"
         }
       }
@@ -2492,7 +2481,7 @@
     "apiRevokeTokenRequest": {
       "type": "object",
       "properties": {
-        "expireAt": {
+        "expire_at": {
           "type": "string",
           "format": "int64"
         },
@@ -2550,8 +2539,7 @@
       "type": "object",
       "properties": {
         "offset": {
-          "type": "string",
-          "format": "uint64"
+          "type": "integer"
         },
         "epoch": {
           "type": "string"
@@ -2564,16 +2552,16 @@
         "presence": {
           "$ref": "#/definitions/apiBoolValue"
         },
-        "joinLeave": {
+        "join_leave": {
           "$ref": "#/definitions/apiBoolValue"
         },
-        "forceRecovery": {
+        "force_recovery": {
           "$ref": "#/definitions/apiBoolValue"
         },
-        "forcePositioning": {
+        "force_positioning": {
           "$ref": "#/definitions/apiBoolValue"
         },
-        "forcePushJoinLeave": {
+        "force_push_join_leave": {
           "$ref": "#/definitions/apiBoolValue"
         }
       }
@@ -2587,13 +2575,12 @@
         "user": {
           "type": "string"
         },
-        "expireAt": {
+        "expire_at": {
           "type": "string",
           "format": "int64"
         },
         "info": {
-          "type": "string",
-          "format": "byte"
+          "type": "object"
         },
         "b64info": {
           "type": "string"
@@ -2607,7 +2594,7 @@
         "b64data": {
           "type": "string"
         },
-        "recoverSince": {
+        "recover_since": {
           "$ref": "#/definitions/apiStreamPosition"
         },
         "override": {
@@ -2638,7 +2625,7 @@
         "uid": {
           "type": "string"
         },
-        "issuedAt": {
+        "issued_at": {
           "type": "string",
           "format": "int64"
         }

--- a/internal/apiproto/api.swagger.json
+++ b/internal/apiproto/api.swagger.json
@@ -2848,7 +2848,7 @@
   "securityDefinitions": {
     "ApiKeyAuth": {
       "type": "apiKey",
-      "name": "Authorization",
+      "name": "X-API-Key",
       "in": "header"
     }
   },

--- a/internal/apiproto/api.swagger.json
+++ b/internal/apiproto/api.swagger.json
@@ -1,0 +1,1854 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "api.proto",
+    "version": "version not set"
+  },
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/publish": {
+      "post": {
+        "operationId": "CentrifugoApi_Publish",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/apiPublishResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/gatewayruntimeError"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/apiPublishRequest"
+            }
+          }
+        ],
+        "tags": [
+          "CentrifugoApi"
+        ]
+      }
+    }
+  },
+  "definitions": {
+    "CommandMethodType": {
+      "type": "string",
+      "enum": [
+        "PUBLISH",
+        "BROADCAST",
+        "UNSUBSCRIBE",
+        "DISCONNECT",
+        "PRESENCE",
+        "PRESENCE_STATS",
+        "HISTORY",
+        "HISTORY_REMOVE",
+        "CHANNELS",
+        "INFO",
+        "RPC",
+        "SUBSCRIBE",
+        "REFRESH",
+        "CONNECTIONS",
+        "UPDATE_USER_STATUS",
+        "GET_USER_STATUS",
+        "DELETE_USER_STATUS",
+        "BLOCK_USER",
+        "UNBLOCK_USER",
+        "REVOKE_TOKEN",
+        "INVALIDATE_USER_TOKENS",
+        "DEVICE_REGISTER",
+        "DEVICE_UPDATE",
+        "DEVICE_REMOVE",
+        "DEVICE_LIST",
+        "PUSH_USER_CHANNEL_LIST",
+        "PUSH_USER_CHANNEL_UPDATE",
+        "SEND_PUSH_NOTIFICATION"
+      ],
+      "default": "PUBLISH"
+    },
+    "apiApnsPushNotification": {
+      "type": "object",
+      "properties": {
+        "headers": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "payload": {
+          "type": "string",
+          "format": "byte"
+        }
+      }
+    },
+    "apiBatchResponse": {
+      "type": "object",
+      "properties": {
+        "replies": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/apiReply"
+          }
+        }
+      }
+    },
+    "apiBlockUserRequest": {
+      "type": "object",
+      "properties": {
+        "expire_at": {
+          "type": "string",
+          "format": "int64"
+        },
+        "user": {
+          "type": "string"
+        }
+      }
+    },
+    "apiBlockUserResponse": {
+      "type": "object",
+      "properties": {
+        "error": {
+          "$ref": "#/definitions/centrifugoapiError"
+        },
+        "result": {
+          "$ref": "#/definitions/apiBlockUserResult"
+        }
+      }
+    },
+    "apiBlockUserResult": {
+      "type": "object"
+    },
+    "apiBoolValue": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "boolean"
+        }
+      }
+    },
+    "apiBroadcastRequest": {
+      "type": "object",
+      "properties": {
+        "channels": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "data": {
+          "type": "object"
+        },
+        "b64data": {
+          "type": "string"
+        },
+        "skip_history": {
+          "type": "boolean"
+        },
+        "tags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "apiBroadcastResponse": {
+      "type": "object",
+      "properties": {
+        "error": {
+          "$ref": "#/definitions/centrifugoapiError"
+        },
+        "result": {
+          "$ref": "#/definitions/apiBroadcastResult"
+        }
+      }
+    },
+    "apiBroadcastResult": {
+      "type": "object",
+      "properties": {
+        "responses": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/apiPublishResponse"
+          }
+        }
+      }
+    },
+    "apiChannelContext": {
+      "type": "object",
+      "properties": {
+        "source": {
+          "type": "integer",
+          "format": "int64"
+        }
+      }
+    },
+    "apiChannelInfo": {
+      "type": "object",
+      "properties": {
+        "num_clients": {
+          "type": "integer",
+          "format": "int64"
+        }
+      }
+    },
+    "apiChannelsRequest": {
+      "type": "object",
+      "properties": {
+        "pattern": {
+          "type": "string"
+        }
+      }
+    },
+    "apiChannelsResponse": {
+      "type": "object",
+      "properties": {
+        "error": {
+          "$ref": "#/definitions/centrifugoapiError"
+        },
+        "result": {
+          "$ref": "#/definitions/apiChannelsResult"
+        }
+      }
+    },
+    "apiChannelsResult": {
+      "type": "object",
+      "properties": {
+        "channels": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/apiChannelInfo"
+          }
+        }
+      }
+    },
+    "apiClientInfo": {
+      "type": "object",
+      "properties": {
+        "user": {
+          "type": "string"
+        },
+        "client": {
+          "type": "string"
+        },
+        "conn_info": {
+          "type": "string",
+          "format": "byte"
+        },
+        "chan_info": {
+          "type": "string",
+          "format": "byte"
+        }
+      }
+    },
+    "apiCommand": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "method": {
+          "$ref": "#/definitions/CommandMethodType"
+        },
+        "params": {
+          "type": "string",
+          "format": "byte"
+        },
+        "publish": {
+          "$ref": "#/definitions/apiPublishRequest"
+        },
+        "broadcast": {
+          "$ref": "#/definitions/apiBroadcastRequest"
+        },
+        "subscribe": {
+          "$ref": "#/definitions/apiSubscribeRequest"
+        },
+        "unsubscribe": {
+          "$ref": "#/definitions/apiUnsubscribeRequest"
+        },
+        "disconnect": {
+          "$ref": "#/definitions/apiDisconnectRequest"
+        },
+        "presence": {
+          "$ref": "#/definitions/apiPresenceRequest"
+        },
+        "presence_stats": {
+          "$ref": "#/definitions/apiPresenceStatsRequest"
+        },
+        "history": {
+          "$ref": "#/definitions/apiHistoryRequest"
+        },
+        "history_remove": {
+          "$ref": "#/definitions/apiHistoryRemoveRequest"
+        },
+        "info": {
+          "$ref": "#/definitions/apiInfoRequest"
+        },
+        "rpc": {
+          "$ref": "#/definitions/apiRPCRequest"
+        },
+        "refresh": {
+          "$ref": "#/definitions/apiRefreshRequest"
+        },
+        "channels": {
+          "$ref": "#/definitions/apiChannelsRequest"
+        },
+        "connections": {
+          "$ref": "#/definitions/apiConnectionsRequest"
+        },
+        "update_user_status": {
+          "$ref": "#/definitions/apiUpdateUserStatusRequest"
+        },
+        "get_user_status": {
+          "$ref": "#/definitions/apiGetUserStatusRequest"
+        },
+        "delete_user_status": {
+          "$ref": "#/definitions/apiDeleteUserStatusRequest"
+        },
+        "block_user": {
+          "$ref": "#/definitions/apiBlockUserRequest"
+        },
+        "unblock_user": {
+          "$ref": "#/definitions/apiUnblockUserRequest"
+        },
+        "revoke_token": {
+          "$ref": "#/definitions/apiRevokeTokenRequest"
+        },
+        "invalidate_user_tokens": {
+          "$ref": "#/definitions/apiInvalidateUserTokensRequest"
+        },
+        "device_register": {
+          "$ref": "#/definitions/apiDeviceRegisterRequest"
+        },
+        "device_update": {
+          "$ref": "#/definitions/apiDeviceUpdateRequest"
+        },
+        "device_remove": {
+          "$ref": "#/definitions/apiDeviceRemoveRequest"
+        },
+        "device_list": {
+          "$ref": "#/definitions/apiDeviceListRequest"
+        },
+        "push_user_channel_list": {
+          "$ref": "#/definitions/apiPushUserChannelListRequest"
+        },
+        "push_user_channel_update": {
+          "$ref": "#/definitions/apiPushUserChannelUpdateRequest"
+        },
+        "send_push_notification": {
+          "$ref": "#/definitions/apiSendPushNotificationRequest"
+        }
+      }
+    },
+    "apiConnectionInfo": {
+      "type": "object",
+      "properties": {
+        "app_name": {
+          "type": "string"
+        },
+        "app_version": {
+          "type": "string"
+        },
+        "transport": {
+          "type": "string"
+        },
+        "protocol": {
+          "type": "string"
+        },
+        "user": {
+          "type": "string",
+          "description": "5-7 dropped for backwards compatibility."
+        },
+        "state": {
+          "$ref": "#/definitions/apiConnectionState"
+        }
+      }
+    },
+    "apiConnectionState": {
+      "type": "object",
+      "properties": {
+        "channels": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/apiChannelContext"
+          }
+        },
+        "connection_token": {
+          "$ref": "#/definitions/apiConnectionTokenInfo"
+        },
+        "subscription_tokens": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/apiSubscriptionTokenInfo"
+          }
+        },
+        "meta": {
+          "type": "string",
+          "format": "byte"
+        }
+      }
+    },
+    "apiConnectionTokenInfo": {
+      "type": "object",
+      "properties": {
+        "uid": {
+          "type": "string"
+        },
+        "issued_at": {
+          "type": "string",
+          "format": "int64"
+        }
+      }
+    },
+    "apiConnectionsRequest": {
+      "type": "object",
+      "properties": {
+        "user": {
+          "type": "string"
+        },
+        "expression": {
+          "type": "string"
+        }
+      }
+    },
+    "apiConnectionsResponse": {
+      "type": "object",
+      "properties": {
+        "error": {
+          "$ref": "#/definitions/centrifugoapiError"
+        },
+        "result": {
+          "$ref": "#/definitions/apiConnectionsResult"
+        }
+      }
+    },
+    "apiConnectionsResult": {
+      "type": "object",
+      "properties": {
+        "connections": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/apiConnectionInfo"
+          }
+        }
+      }
+    },
+    "apiDeleteUserStatusRequest": {
+      "type": "object",
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "apiDeleteUserStatusResponse": {
+      "type": "object",
+      "properties": {
+        "error": {
+          "$ref": "#/definitions/centrifugoapiError"
+        },
+        "result": {
+          "$ref": "#/definitions/apiDeleteUserStatusResult"
+        }
+      }
+    },
+    "apiDeleteUserStatusResult": {
+      "type": "object"
+    },
+    "apiDevice": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "platform": {
+          "type": "string"
+        },
+        "provider": {
+          "type": "string"
+        },
+        "token": {
+          "type": "string"
+        },
+        "user": {
+          "type": "string"
+        },
+        "meta": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "channels": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "apiDeviceChannelsUpdate": {
+      "type": "object",
+      "properties": {
+        "op": {
+          "type": "string"
+        },
+        "channels": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "apiDeviceListRequest": {
+      "type": "object",
+      "properties": {
+        "ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "providers": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "provider_tokens": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/apiDeviceProviderTokens"
+          }
+        },
+        "platforms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "channels": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "since": {
+          "type": "string"
+        },
+        "limit": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "include_channels": {
+          "type": "boolean"
+        },
+        "include_meta": {
+          "type": "boolean"
+        },
+        "include_tags": {
+          "type": "boolean"
+        }
+      }
+    },
+    "apiDeviceListResponse": {
+      "type": "object",
+      "properties": {
+        "error": {
+          "$ref": "#/definitions/centrifugoapiError"
+        },
+        "result": {
+          "$ref": "#/definitions/apiDeviceListResult"
+        }
+      }
+    },
+    "apiDeviceListResult": {
+      "type": "object",
+      "properties": {
+        "items": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/apiDevice"
+          }
+        },
+        "has_more": {
+          "type": "boolean"
+        }
+      }
+    },
+    "apiDeviceMetaUpdate": {
+      "type": "object",
+      "properties": {
+        "meta": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "apiDeviceProviderTokens": {
+      "type": "object",
+      "properties": {
+        "provider": {
+          "type": "string"
+        },
+        "tokens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "apiDeviceRegisterRequest": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "provider": {
+          "type": "string"
+        },
+        "token": {
+          "type": "string"
+        },
+        "platform": {
+          "type": "string"
+        },
+        "user": {
+          "type": "string"
+        },
+        "meta": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "tags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "channels": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "apiDeviceRegisterResponse": {
+      "type": "object",
+      "properties": {
+        "error": {
+          "$ref": "#/definitions/centrifugoapiError"
+        },
+        "result": {
+          "$ref": "#/definitions/apiDeviceRegisterResult"
+        }
+      }
+    },
+    "apiDeviceRegisterResult": {
+      "type": "object",
+      "properties": {
+        "device": {
+          "$ref": "#/definitions/apiDevice"
+        }
+      }
+    },
+    "apiDeviceRemoveRequest": {
+      "type": "object",
+      "properties": {
+        "ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "provider_tokens": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/apiDeviceProviderTokens"
+          }
+        }
+      }
+    },
+    "apiDeviceRemoveResponse": {
+      "type": "object",
+      "properties": {
+        "error": {
+          "$ref": "#/definitions/centrifugoapiError"
+        },
+        "result": {
+          "$ref": "#/definitions/apiDeviceRemoveResult"
+        }
+      }
+    },
+    "apiDeviceRemoveResult": {
+      "type": "object"
+    },
+    "apiDeviceTagsUpdate": {
+      "type": "object",
+      "properties": {
+        "op": {
+          "type": "string"
+        },
+        "tags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "apiDeviceUpdateRequest": {
+      "type": "object",
+      "properties": {
+        "ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "provider_tokens": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/apiDeviceProviderTokens"
+          }
+        },
+        "user_update": {
+          "$ref": "#/definitions/apiDeviceUserUpdate"
+        },
+        "meta_update": {
+          "$ref": "#/definitions/apiDeviceMetaUpdate"
+        },
+        "tags_update": {
+          "$ref": "#/definitions/apiDeviceTagsUpdate"
+        },
+        "channels_update": {
+          "$ref": "#/definitions/apiDeviceChannelsUpdate"
+        }
+      }
+    },
+    "apiDeviceUpdateResponse": {
+      "type": "object",
+      "properties": {
+        "error": {
+          "$ref": "#/definitions/centrifugoapiError"
+        },
+        "result": {
+          "$ref": "#/definitions/apiDeviceUpdateResult"
+        }
+      }
+    },
+    "apiDeviceUpdateResult": {
+      "type": "object"
+    },
+    "apiDeviceUserUpdate": {
+      "type": "object",
+      "properties": {
+        "user": {
+          "type": "string"
+        }
+      }
+    },
+    "apiDisconnect": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "reason": {
+          "type": "string"
+        },
+        "reconnect": {
+          "type": "boolean"
+        }
+      }
+    },
+    "apiDisconnectRequest": {
+      "type": "object",
+      "properties": {
+        "user": {
+          "type": "string"
+        },
+        "disconnect": {
+          "$ref": "#/definitions/apiDisconnect"
+        },
+        "client": {
+          "type": "string"
+        },
+        "whitelist": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "session": {
+          "type": "string"
+        }
+      }
+    },
+    "apiDisconnectResponse": {
+      "type": "object",
+      "properties": {
+        "error": {
+          "$ref": "#/definitions/centrifugoapiError"
+        },
+        "result": {
+          "$ref": "#/definitions/apiDisconnectResult"
+        }
+      }
+    },
+    "apiDisconnectResult": {
+      "type": "object"
+    },
+    "apiFcmPushNotification": {
+      "type": "object",
+      "properties": {
+        "message": {
+          "type": "string",
+          "format": "byte"
+        }
+      }
+    },
+    "apiGetUserStatusRequest": {
+      "type": "object",
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "apiGetUserStatusResponse": {
+      "type": "object",
+      "properties": {
+        "error": {
+          "$ref": "#/definitions/centrifugoapiError"
+        },
+        "result": {
+          "$ref": "#/definitions/apiGetUserStatusResult"
+        }
+      }
+    },
+    "apiGetUserStatusResult": {
+      "type": "object",
+      "properties": {
+        "statuses": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/apiUserStatus"
+          }
+        }
+      }
+    },
+    "apiHistoryRemoveRequest": {
+      "type": "object",
+      "properties": {
+        "channel": {
+          "type": "string"
+        }
+      }
+    },
+    "apiHistoryRemoveResponse": {
+      "type": "object",
+      "properties": {
+        "error": {
+          "$ref": "#/definitions/centrifugoapiError"
+        },
+        "result": {
+          "$ref": "#/definitions/apiHistoryRemoveResult"
+        }
+      }
+    },
+    "apiHistoryRemoveResult": {
+      "type": "object"
+    },
+    "apiHistoryRequest": {
+      "type": "object",
+      "properties": {
+        "channel": {
+          "type": "string"
+        },
+        "limit": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "since": {
+          "$ref": "#/definitions/apiStreamPosition"
+        },
+        "reverse": {
+          "type": "boolean"
+        }
+      }
+    },
+    "apiHistoryResponse": {
+      "type": "object",
+      "properties": {
+        "error": {
+          "$ref": "#/definitions/centrifugoapiError"
+        },
+        "result": {
+          "$ref": "#/definitions/apiHistoryResult"
+        }
+      }
+    },
+    "apiHistoryResult": {
+      "type": "object",
+      "properties": {
+        "publications": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/apiPublication"
+          }
+        },
+        "epoch": {
+          "type": "string"
+        },
+        "offset": {
+          "type": "string",
+          "format": "uint64"
+        }
+      }
+    },
+    "apiHmsPushNotification": {
+      "type": "object",
+      "properties": {
+        "message": {
+          "type": "string",
+          "format": "byte"
+        }
+      }
+    },
+    "apiInfoRequest": {
+      "type": "object"
+    },
+    "apiInfoResponse": {
+      "type": "object",
+      "properties": {
+        "error": {
+          "$ref": "#/definitions/centrifugoapiError"
+        },
+        "result": {
+          "$ref": "#/definitions/apiInfoResult"
+        }
+      }
+    },
+    "apiInfoResult": {
+      "type": "object",
+      "properties": {
+        "nodes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/apiNodeResult"
+          }
+        }
+      }
+    },
+    "apiInvalidateUserTokensRequest": {
+      "type": "object",
+      "properties": {
+        "expire_at": {
+          "type": "string",
+          "format": "int64"
+        },
+        "user": {
+          "type": "string"
+        },
+        "issued_before": {
+          "type": "string",
+          "format": "int64"
+        },
+        "channel": {
+          "type": "string"
+        }
+      }
+    },
+    "apiInvalidateUserTokensResponse": {
+      "type": "object",
+      "properties": {
+        "error": {
+          "$ref": "#/definitions/centrifugoapiError"
+        },
+        "result": {
+          "$ref": "#/definitions/apiInvalidateUserTokensResult"
+        }
+      }
+    },
+    "apiInvalidateUserTokensResult": {
+      "type": "object"
+    },
+    "apiMetrics": {
+      "type": "object",
+      "properties": {
+        "interval": {
+          "type": "number",
+          "format": "double"
+        },
+        "items": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "number",
+            "format": "double"
+          }
+        }
+      }
+    },
+    "apiNodeResult": {
+      "type": "object",
+      "properties": {
+        "uid": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        },
+        "num_clients": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "num_users": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "num_channels": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "uptime": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "metrics": {
+          "$ref": "#/definitions/apiMetrics"
+        },
+        "process": {
+          "$ref": "#/definitions/apiProcess"
+        },
+        "num_subs": {
+          "type": "integer",
+          "format": "int64"
+        }
+      }
+    },
+    "apiPresenceRequest": {
+      "type": "object",
+      "properties": {
+        "channel": {
+          "type": "string"
+        }
+      }
+    },
+    "apiPresenceResponse": {
+      "type": "object",
+      "properties": {
+        "error": {
+          "$ref": "#/definitions/centrifugoapiError"
+        },
+        "result": {
+          "$ref": "#/definitions/apiPresenceResult"
+        }
+      }
+    },
+    "apiPresenceResult": {
+      "type": "object",
+      "properties": {
+        "presence": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/apiClientInfo"
+          }
+        }
+      }
+    },
+    "apiPresenceStatsRequest": {
+      "type": "object",
+      "properties": {
+        "channel": {
+          "type": "string"
+        }
+      }
+    },
+    "apiPresenceStatsResponse": {
+      "type": "object",
+      "properties": {
+        "error": {
+          "$ref": "#/definitions/centrifugoapiError"
+        },
+        "result": {
+          "$ref": "#/definitions/apiPresenceStatsResult"
+        }
+      }
+    },
+    "apiPresenceStatsResult": {
+      "type": "object",
+      "properties": {
+        "num_clients": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "num_users": {
+          "type": "integer",
+          "format": "int64"
+        }
+      }
+    },
+    "apiProcess": {
+      "type": "object",
+      "properties": {
+        "cpu": {
+          "type": "number",
+          "format": "double"
+        },
+        "rss": {
+          "type": "string",
+          "format": "int64"
+        }
+      }
+    },
+    "apiPublication": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "object",
+          "title": "Removed: string uid = 1;"
+        },
+        "info": {
+          "$ref": "#/definitions/apiClientInfo"
+        },
+        "offset": {
+          "type": "string",
+          "format": "uint64"
+        },
+        "tags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "apiPublishRequest": {
+      "type": "object",
+      "properties": {
+        "channel": {
+          "type": "string"
+        },
+        "data": {
+          "type": "object"
+        },
+        "b64data": {
+          "type": "string"
+        },
+        "skip_history": {
+          "type": "boolean"
+        },
+        "tags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "apiPublishResponse": {
+      "type": "object",
+      "properties": {
+        "error": {
+          "$ref": "#/definitions/centrifugoapiError"
+        },
+        "result": {
+          "$ref": "#/definitions/apiPublishResult"
+        }
+      }
+    },
+    "apiPublishResult": {
+      "type": "object",
+      "properties": {
+        "offset": {
+          "type": "string",
+          "format": "uint64"
+        },
+        "epoch": {
+          "type": "string"
+        }
+      }
+    },
+    "apiPushNotification": {
+      "type": "object",
+      "properties": {
+        "fcm": {
+          "$ref": "#/definitions/apiFcmPushNotification"
+        },
+        "hms": {
+          "$ref": "#/definitions/apiHmsPushNotification"
+        },
+        "apns": {
+          "$ref": "#/definitions/apiApnsPushNotification"
+        },
+        "uid": {
+          "type": "string"
+        },
+        "expire_at": {
+          "type": "string",
+          "format": "int64"
+        }
+      }
+    },
+    "apiPushRecipient": {
+      "type": "object",
+      "properties": {
+        "device_ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "channels": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "fcm_tokens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "fcm_topic": {
+          "type": "string"
+        },
+        "fcm_condition": {
+          "type": "string"
+        },
+        "hms_tokens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "hms_topic": {
+          "type": "string"
+        },
+        "hms_condition": {
+          "type": "string"
+        },
+        "apns_tokens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "apiPushUserChannel": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "user": {
+          "type": "string"
+        },
+        "channel": {
+          "type": "string"
+        }
+      }
+    },
+    "apiPushUserChannelListRequest": {
+      "type": "object",
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "channels": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "since": {
+          "type": "string"
+        },
+        "limit": {
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
+    "apiPushUserChannelListResponse": {
+      "type": "object",
+      "properties": {
+        "error": {
+          "$ref": "#/definitions/centrifugoapiError"
+        },
+        "result": {
+          "$ref": "#/definitions/apiPushUserChannelListResult"
+        }
+      }
+    },
+    "apiPushUserChannelListResult": {
+      "type": "object",
+      "properties": {
+        "items": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/apiPushUserChannel"
+          }
+        },
+        "has_more": {
+          "type": "boolean"
+        }
+      }
+    },
+    "apiPushUserChannelUpdateRequest": {
+      "type": "object",
+      "properties": {
+        "user": {
+          "type": "string"
+        },
+        "op": {
+          "type": "string"
+        },
+        "channels": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "apiPushUserChannelUpdateResponse": {
+      "type": "object",
+      "properties": {
+        "error": {
+          "$ref": "#/definitions/centrifugoapiError"
+        },
+        "result": {
+          "$ref": "#/definitions/apiPushUserChannelUpdateResult"
+        }
+      }
+    },
+    "apiPushUserChannelUpdateResult": {
+      "type": "object"
+    },
+    "apiRPCRequest": {
+      "type": "object",
+      "properties": {
+        "method": {
+          "type": "string"
+        },
+        "params": {
+          "type": "string",
+          "format": "byte"
+        }
+      }
+    },
+    "apiRPCResponse": {
+      "type": "object",
+      "properties": {
+        "error": {
+          "$ref": "#/definitions/centrifugoapiError"
+        },
+        "result": {
+          "$ref": "#/definitions/apiRPCResult"
+        }
+      }
+    },
+    "apiRPCResult": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "object"
+        }
+      }
+    },
+    "apiRefreshRequest": {
+      "type": "object",
+      "properties": {
+        "user": {
+          "type": "string"
+        },
+        "client": {
+          "type": "string"
+        },
+        "expired": {
+          "type": "boolean"
+        },
+        "expire_at": {
+          "type": "string",
+          "format": "int64"
+        },
+        "info": {
+          "type": "string",
+          "format": "byte"
+        },
+        "session": {
+          "type": "string"
+        }
+      }
+    },
+    "apiRefreshResponse": {
+      "type": "object",
+      "properties": {
+        "error": {
+          "$ref": "#/definitions/centrifugoapiError"
+        },
+        "result": {
+          "$ref": "#/definitions/apiRefreshResult"
+        }
+      }
+    },
+    "apiRefreshResult": {
+      "type": "object"
+    },
+    "apiReply": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "error": {
+          "$ref": "#/definitions/centrifugoapiError"
+        },
+        "result": {
+          "type": "string",
+          "format": "byte"
+        },
+        "publish": {
+          "$ref": "#/definitions/apiPublishResult"
+        },
+        "broadcast": {
+          "$ref": "#/definitions/apiBroadcastResult"
+        },
+        "subscribe": {
+          "$ref": "#/definitions/apiSubscribeResult"
+        },
+        "unsubscribe": {
+          "$ref": "#/definitions/apiUnsubscribeResult"
+        },
+        "disconnect": {
+          "$ref": "#/definitions/apiDisconnectResult"
+        },
+        "presence": {
+          "$ref": "#/definitions/apiPresenceResult"
+        },
+        "presence_stats": {
+          "$ref": "#/definitions/apiPresenceStatsResult"
+        },
+        "history": {
+          "$ref": "#/definitions/apiHistoryResult"
+        },
+        "history_remove": {
+          "$ref": "#/definitions/apiHistoryRemoveResult"
+        },
+        "info": {
+          "$ref": "#/definitions/apiInfoResult"
+        },
+        "rpc": {
+          "$ref": "#/definitions/apiRPCResult"
+        },
+        "refresh": {
+          "$ref": "#/definitions/apiRefreshResult"
+        },
+        "channels": {
+          "$ref": "#/definitions/apiChannelsResult"
+        },
+        "connections": {
+          "$ref": "#/definitions/apiConnectionsResult"
+        },
+        "update_user_status": {
+          "$ref": "#/definitions/apiUpdateUserStatusResult"
+        },
+        "get_user_status": {
+          "$ref": "#/definitions/apiGetUserStatusResult"
+        },
+        "delete_user_status": {
+          "$ref": "#/definitions/apiDeleteUserStatusResult"
+        },
+        "block_user": {
+          "$ref": "#/definitions/apiBlockUserResult"
+        },
+        "unblock_user": {
+          "$ref": "#/definitions/apiUnblockUserResult"
+        },
+        "revoke_token": {
+          "$ref": "#/definitions/apiRevokeTokenResult"
+        },
+        "invalidate_user_tokens": {
+          "$ref": "#/definitions/apiInvalidateUserTokensResult"
+        },
+        "device_register": {
+          "$ref": "#/definitions/apiDeviceRegisterResult"
+        },
+        "device_update": {
+          "$ref": "#/definitions/apiDeviceUpdateResult"
+        },
+        "device_remove": {
+          "$ref": "#/definitions/apiDeviceRemoveResult"
+        },
+        "device_list": {
+          "$ref": "#/definitions/apiDeviceListResult"
+        },
+        "push_user_channel_list": {
+          "$ref": "#/definitions/apiPushUserChannelListResult"
+        },
+        "push_user_channel_update": {
+          "$ref": "#/definitions/apiPushUserChannelUpdateResult"
+        },
+        "send_push_notification": {
+          "$ref": "#/definitions/apiSendPushNotificationResult"
+        }
+      }
+    },
+    "apiRevokeTokenRequest": {
+      "type": "object",
+      "properties": {
+        "expire_at": {
+          "type": "string",
+          "format": "int64"
+        },
+        "uid": {
+          "type": "string"
+        }
+      }
+    },
+    "apiRevokeTokenResponse": {
+      "type": "object",
+      "properties": {
+        "error": {
+          "$ref": "#/definitions/centrifugoapiError"
+        },
+        "result": {
+          "$ref": "#/definitions/apiRevokeTokenResult"
+        }
+      }
+    },
+    "apiRevokeTokenResult": {
+      "type": "object"
+    },
+    "apiSendPushNotificationRequest": {
+      "type": "object",
+      "properties": {
+        "recipient": {
+          "$ref": "#/definitions/apiPushRecipient"
+        },
+        "notification": {
+          "$ref": "#/definitions/apiPushNotification"
+        }
+      }
+    },
+    "apiSendPushNotificationResponse": {
+      "type": "object",
+      "properties": {
+        "error": {
+          "$ref": "#/definitions/centrifugoapiError"
+        },
+        "result": {
+          "$ref": "#/definitions/apiSendPushNotificationResult"
+        }
+      }
+    },
+    "apiSendPushNotificationResult": {
+      "type": "object",
+      "properties": {
+        "uid": {
+          "type": "string"
+        }
+      }
+    },
+    "apiStreamPosition": {
+      "type": "object",
+      "properties": {
+        "offset": {
+          "type": "string",
+          "format": "uint64"
+        },
+        "epoch": {
+          "type": "string"
+        }
+      }
+    },
+    "apiSubscribeOptionOverride": {
+      "type": "object",
+      "properties": {
+        "presence": {
+          "$ref": "#/definitions/apiBoolValue"
+        },
+        "join_leave": {
+          "$ref": "#/definitions/apiBoolValue"
+        },
+        "force_recovery": {
+          "$ref": "#/definitions/apiBoolValue"
+        },
+        "force_positioning": {
+          "$ref": "#/definitions/apiBoolValue"
+        },
+        "force_push_join_leave": {
+          "$ref": "#/definitions/apiBoolValue"
+        }
+      }
+    },
+    "apiSubscribeRequest": {
+      "type": "object",
+      "properties": {
+        "channel": {
+          "type": "string"
+        },
+        "user": {
+          "type": "string"
+        },
+        "expire_at": {
+          "type": "string",
+          "format": "int64"
+        },
+        "info": {
+          "type": "string",
+          "format": "byte"
+        },
+        "b64info": {
+          "type": "string"
+        },
+        "client": {
+          "type": "string"
+        },
+        "data": {
+          "type": "object"
+        },
+        "b64data": {
+          "type": "string"
+        },
+        "recover_since": {
+          "$ref": "#/definitions/apiStreamPosition"
+        },
+        "override": {
+          "$ref": "#/definitions/apiSubscribeOptionOverride"
+        },
+        "session": {
+          "type": "string"
+        }
+      }
+    },
+    "apiSubscribeResponse": {
+      "type": "object",
+      "properties": {
+        "error": {
+          "$ref": "#/definitions/centrifugoapiError"
+        },
+        "result": {
+          "$ref": "#/definitions/apiSubscribeResult"
+        }
+      }
+    },
+    "apiSubscribeResult": {
+      "type": "object"
+    },
+    "apiSubscriptionTokenInfo": {
+      "type": "object",
+      "properties": {
+        "uid": {
+          "type": "string"
+        },
+        "issued_at": {
+          "type": "string",
+          "format": "int64"
+        }
+      }
+    },
+    "apiUnblockUserRequest": {
+      "type": "object",
+      "properties": {
+        "user": {
+          "type": "string"
+        }
+      }
+    },
+    "apiUnblockUserResponse": {
+      "type": "object",
+      "properties": {
+        "error": {
+          "$ref": "#/definitions/centrifugoapiError"
+        },
+        "result": {
+          "$ref": "#/definitions/apiUnblockUserResult"
+        }
+      }
+    },
+    "apiUnblockUserResult": {
+      "type": "object"
+    },
+    "apiUnsubscribeRequest": {
+      "type": "object",
+      "properties": {
+        "channel": {
+          "type": "string"
+        },
+        "user": {
+          "type": "string"
+        },
+        "client": {
+          "type": "string"
+        },
+        "session": {
+          "type": "string"
+        }
+      }
+    },
+    "apiUnsubscribeResponse": {
+      "type": "object",
+      "properties": {
+        "error": {
+          "$ref": "#/definitions/centrifugoapiError"
+        },
+        "result": {
+          "$ref": "#/definitions/apiUnsubscribeResult"
+        }
+      }
+    },
+    "apiUnsubscribeResult": {
+      "type": "object"
+    },
+    "apiUpdateUserStatusRequest": {
+      "type": "object",
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "apiUpdateUserStatusResponse": {
+      "type": "object",
+      "properties": {
+        "error": {
+          "$ref": "#/definitions/centrifugoapiError"
+        },
+        "result": {
+          "$ref": "#/definitions/apiUpdateUserStatusResult"
+        }
+      }
+    },
+    "apiUpdateUserStatusResult": {
+      "type": "object"
+    },
+    "apiUserStatus": {
+      "type": "object",
+      "properties": {
+        "user": {
+          "type": "string"
+        },
+        "active": {
+          "type": "string",
+          "format": "int64"
+        },
+        "online": {
+          "type": "string",
+          "format": "int64"
+        }
+      }
+    },
+    "centrifugoapiError": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "message": {
+          "type": "string"
+        }
+      }
+    },
+    "gatewayruntimeError": {
+      "type": "object",
+      "properties": {
+        "error": {
+          "type": "string"
+        },
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        },
+        "details": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/protobufAny"
+          }
+        }
+      }
+    },
+    "protobufAny": {
+      "type": "object",
+      "properties": {
+        "type_url": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string",
+          "format": "byte"
+        }
+      }
+    }
+  }
+}

--- a/internal/apiproto/api.swagger.json
+++ b/internal/apiproto/api.swagger.json
@@ -4,6 +4,47 @@
     "title": "Centrifugo server HTTP API",
     "version": "5.0"
   },
+  "tags": [
+    {
+      "name": "CentrifugoApi"
+    },
+    {
+      "name": "publication"
+    },
+    {
+      "name": "connection management"
+    },
+    {
+      "name": "history"
+    },
+    {
+      "name": "presence"
+    },
+    {
+      "name": "stats"
+    },
+    {
+      "name": "user status"
+    },
+    {
+      "name": "user block"
+    },
+    {
+      "name": "token"
+    },
+    {
+      "name": "push notifications"
+    },
+    {
+      "name": "batch"
+    },
+    {
+      "name": "oss"
+    },
+    {
+      "name": "pro"
+    }
+  ],
   "consumes": [
     "application/json"
   ],
@@ -13,6 +54,7 @@
   "paths": {
     "/batch": {
       "post": {
+        "summary": "Batch request",
         "operationId": "CentrifugoApi_Batch",
         "responses": {
           "200": {
@@ -24,7 +66,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/gatewayruntimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -39,12 +81,14 @@
           }
         ],
         "tags": [
-          "CentrifugoApi"
+          "batch",
+          "oss"
         ]
       }
     },
     "/block_user": {
       "post": {
+        "summary": "Block user request",
         "operationId": "CentrifugoApi_BlockUser",
         "responses": {
           "200": {
@@ -56,7 +100,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/gatewayruntimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -71,12 +115,14 @@
           }
         ],
         "tags": [
-          "CentrifugoApi"
+          "user block",
+          "pro"
         ]
       }
     },
     "/broadcast": {
       "post": {
+        "summary": "Broadcast request",
         "operationId": "CentrifugoApi_Broadcast",
         "responses": {
           "200": {
@@ -88,7 +134,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/gatewayruntimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -103,12 +149,14 @@
           }
         ],
         "tags": [
-          "CentrifugoApi"
+          "publication",
+          "oss"
         ]
       }
     },
     "/channels": {
       "post": {
+        "summary": "Channels request",
         "operationId": "CentrifugoApi_Channels",
         "responses": {
           "200": {
@@ -120,7 +168,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/gatewayruntimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -135,12 +183,14 @@
           }
         ],
         "tags": [
-          "CentrifugoApi"
+          "stats",
+          "oss"
         ]
       }
     },
     "/connections": {
       "post": {
+        "summary": "Connections request",
         "operationId": "CentrifugoApi_Connections",
         "responses": {
           "200": {
@@ -152,7 +202,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/gatewayruntimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -167,12 +217,14 @@
           }
         ],
         "tags": [
-          "CentrifugoApi"
+          "stats",
+          "pro"
         ]
       }
     },
     "/delete_user_status": {
       "post": {
+        "summary": "Delete user status request",
         "operationId": "CentrifugoApi_DeleteUserStatus",
         "responses": {
           "200": {
@@ -184,7 +236,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/gatewayruntimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -199,12 +251,14 @@
           }
         ],
         "tags": [
-          "CentrifugoApi"
+          "user status",
+          "pro"
         ]
       }
     },
     "/device_list": {
       "post": {
+        "summary": "Device register request",
         "operationId": "CentrifugoApi_DeviceList",
         "responses": {
           "200": {
@@ -216,7 +270,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/gatewayruntimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -231,12 +285,14 @@
           }
         ],
         "tags": [
-          "CentrifugoApi"
+          "push notifications",
+          "pro"
         ]
       }
     },
     "/device_register": {
       "post": {
+        "summary": "Device register request",
         "operationId": "CentrifugoApi_DeviceRegister",
         "responses": {
           "200": {
@@ -248,7 +304,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/gatewayruntimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -263,12 +319,14 @@
           }
         ],
         "tags": [
-          "CentrifugoApi"
+          "push notifications",
+          "pro"
         ]
       }
     },
     "/device_remove": {
       "post": {
+        "summary": "Device register request",
         "operationId": "CentrifugoApi_DeviceRemove",
         "responses": {
           "200": {
@@ -280,7 +338,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/gatewayruntimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -295,12 +353,14 @@
           }
         ],
         "tags": [
-          "CentrifugoApi"
+          "push notifications",
+          "pro"
         ]
       }
     },
     "/device_update": {
       "post": {
+        "summary": "Device register request",
         "operationId": "CentrifugoApi_DeviceUpdate",
         "responses": {
           "200": {
@@ -312,7 +372,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/gatewayruntimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -327,12 +387,14 @@
           }
         ],
         "tags": [
-          "CentrifugoApi"
+          "push notifications",
+          "pro"
         ]
       }
     },
     "/disconnect": {
       "post": {
+        "summary": "Disconnect request",
         "operationId": "CentrifugoApi_Disconnect",
         "responses": {
           "200": {
@@ -344,7 +406,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/gatewayruntimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -359,12 +421,14 @@
           }
         ],
         "tags": [
-          "CentrifugoApi"
+          "connection management",
+          "oss"
         ]
       }
     },
     "/get_user_status": {
       "post": {
+        "summary": "Get user status request",
         "operationId": "CentrifugoApi_GetUserStatus",
         "responses": {
           "200": {
@@ -376,7 +440,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/gatewayruntimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -391,12 +455,14 @@
           }
         ],
         "tags": [
-          "CentrifugoApi"
+          "user status",
+          "pro"
         ]
       }
     },
     "/history": {
       "post": {
+        "summary": "History request",
         "operationId": "CentrifugoApi_History",
         "responses": {
           "200": {
@@ -408,7 +474,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/gatewayruntimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -423,12 +489,14 @@
           }
         ],
         "tags": [
-          "CentrifugoApi"
+          "history",
+          "oss"
         ]
       }
     },
     "/history_remove": {
       "post": {
+        "summary": "History remove request",
         "operationId": "CentrifugoApi_HistoryRemove",
         "responses": {
           "200": {
@@ -440,7 +508,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/gatewayruntimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -455,12 +523,14 @@
           }
         ],
         "tags": [
-          "CentrifugoApi"
+          "history",
+          "oss"
         ]
       }
     },
     "/info": {
       "post": {
+        "summary": "Info request",
         "operationId": "CentrifugoApi_Info",
         "responses": {
           "200": {
@@ -472,7 +542,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/gatewayruntimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -487,12 +557,14 @@
           }
         ],
         "tags": [
-          "CentrifugoApi"
+          "stats",
+          "oss"
         ]
       }
     },
     "/invalidate_user_tokens": {
       "post": {
+        "summary": "Invalidate user tokens request",
         "operationId": "CentrifugoApi_InvalidateUserTokens",
         "responses": {
           "200": {
@@ -504,7 +576,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/gatewayruntimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -519,12 +591,14 @@
           }
         ],
         "tags": [
-          "CentrifugoApi"
+          "token",
+          "pro"
         ]
       }
     },
     "/presence": {
       "post": {
+        "summary": "Presence request",
         "operationId": "CentrifugoApi_Presence",
         "responses": {
           "200": {
@@ -536,7 +610,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/gatewayruntimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -551,12 +625,14 @@
           }
         ],
         "tags": [
-          "CentrifugoApi"
+          "presence",
+          "oss"
         ]
       }
     },
     "/presence_stats": {
       "post": {
+        "summary": "Presence stats request",
         "operationId": "CentrifugoApi_PresenceStats",
         "responses": {
           "200": {
@@ -568,7 +644,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/gatewayruntimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -583,12 +659,14 @@
           }
         ],
         "tags": [
-          "CentrifugoApi"
+          "presence",
+          "oss"
         ]
       }
     },
     "/publish": {
       "post": {
+        "summary": "Publish request",
         "operationId": "CentrifugoApi_Publish",
         "responses": {
           "200": {
@@ -600,7 +678,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/gatewayruntimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -615,12 +693,14 @@
           }
         ],
         "tags": [
-          "CentrifugoApi"
+          "publication",
+          "oss"
         ]
       }
     },
     "/push_user_channel_list": {
       "post": {
+        "summary": "Device register request",
         "operationId": "CentrifugoApi_PushUserChannelList",
         "responses": {
           "200": {
@@ -632,7 +712,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/gatewayruntimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -647,12 +727,14 @@
           }
         ],
         "tags": [
-          "CentrifugoApi"
+          "push notifications",
+          "pro"
         ]
       }
     },
     "/push_user_channel_update": {
       "post": {
+        "summary": "Device register request",
         "operationId": "CentrifugoApi_PushUserChannelUpdate",
         "responses": {
           "200": {
@@ -664,7 +746,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/gatewayruntimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -679,12 +761,14 @@
           }
         ],
         "tags": [
-          "CentrifugoApi"
+          "push notifications",
+          "pro"
         ]
       }
     },
     "/refresh": {
       "post": {
+        "summary": "Refresh request",
         "operationId": "CentrifugoApi_Refresh",
         "responses": {
           "200": {
@@ -696,7 +780,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/gatewayruntimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -711,12 +795,14 @@
           }
         ],
         "tags": [
-          "CentrifugoApi"
+          "connection management",
+          "oss"
         ]
       }
     },
     "/revoke_token": {
       "post": {
+        "summary": "Revoke token request",
         "operationId": "CentrifugoApi_RevokeToken",
         "responses": {
           "200": {
@@ -728,7 +814,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/gatewayruntimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -743,44 +829,14 @@
           }
         ],
         "tags": [
-          "CentrifugoApi"
-        ]
-      }
-    },
-    "/rpc": {
-      "post": {
-        "operationId": "CentrifugoApi_RPC",
-        "responses": {
-          "200": {
-            "description": "A successful response.",
-            "schema": {
-              "$ref": "#/definitions/apiRPCResponse"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/gatewayruntimeError"
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "body",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/apiRPCRequest"
-            }
-          }
-        ],
-        "tags": [
-          "CentrifugoApi"
+          "token",
+          "pro"
         ]
       }
     },
     "/send_push_notification": {
       "post": {
+        "summary": "Device register request",
         "operationId": "CentrifugoApi_SendPushNotification",
         "responses": {
           "200": {
@@ -792,7 +848,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/gatewayruntimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -807,12 +863,14 @@
           }
         ],
         "tags": [
-          "CentrifugoApi"
+          "push notifications",
+          "pro"
         ]
       }
     },
     "/subscribe": {
       "post": {
+        "summary": "Subscribe request",
         "operationId": "CentrifugoApi_Subscribe",
         "responses": {
           "200": {
@@ -824,7 +882,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/gatewayruntimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -839,12 +897,14 @@
           }
         ],
         "tags": [
-          "CentrifugoApi"
+          "connection management",
+          "oss"
         ]
       }
     },
     "/unblock_user": {
       "post": {
+        "summary": "Unblock user request",
         "operationId": "CentrifugoApi_UnblockUser",
         "responses": {
           "200": {
@@ -856,7 +916,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/gatewayruntimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -871,12 +931,14 @@
           }
         ],
         "tags": [
-          "CentrifugoApi"
+          "user block",
+          "pro"
         ]
       }
     },
     "/unsubscribe": {
       "post": {
+        "summary": "Unsubscribe request",
         "operationId": "CentrifugoApi_Unsubscribe",
         "responses": {
           "200": {
@@ -888,7 +950,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/gatewayruntimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -903,12 +965,14 @@
           }
         ],
         "tags": [
-          "CentrifugoApi"
+          "connection management",
+          "oss"
         ]
       }
     },
     "/update_user_status": {
       "post": {
+        "summary": "Updated user status request",
         "operationId": "CentrifugoApi_UpdateUserStatus",
         "responses": {
           "200": {
@@ -920,7 +984,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/gatewayruntimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -935,7 +999,8 @@
           }
         ],
         "tags": [
-          "CentrifugoApi"
+          "user status",
+          "pro"
         ]
       }
     }
@@ -962,6 +1027,7 @@
         "commands": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/apiCommand"
           }
         }
@@ -973,6 +1039,7 @@
         "replies": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/apiReply"
           }
         }
@@ -981,7 +1048,7 @@
     "apiBlockUserRequest": {
       "type": "object",
       "properties": {
-        "expire_at": {
+        "expireAt": {
           "type": "string",
           "format": "int64"
         },
@@ -994,7 +1061,7 @@
       "type": "object",
       "properties": {
         "error": {
-          "$ref": "#/definitions/centrifugoapiError"
+          "$ref": "#/definitions/apiError"
         },
         "result": {
           "$ref": "#/definitions/apiBlockUserResult"
@@ -1027,7 +1094,7 @@
         "b64data": {
           "type": "string"
         },
-        "skip_history": {
+        "skipHistory": {
           "type": "boolean"
         },
         "tags": {
@@ -1042,7 +1109,7 @@
       "type": "object",
       "properties": {
         "error": {
-          "$ref": "#/definitions/centrifugoapiError"
+          "$ref": "#/definitions/apiError"
         },
         "result": {
           "$ref": "#/definitions/apiBroadcastResult"
@@ -1055,6 +1122,7 @@
         "responses": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/apiPublishResponse"
           }
         }
@@ -1072,7 +1140,7 @@
     "apiChannelInfo": {
       "type": "object",
       "properties": {
-        "num_clients": {
+        "numClients": {
           "type": "integer",
           "format": "int64"
         }
@@ -1090,7 +1158,7 @@
       "type": "object",
       "properties": {
         "error": {
-          "$ref": "#/definitions/centrifugoapiError"
+          "$ref": "#/definitions/apiError"
         },
         "result": {
           "$ref": "#/definitions/apiChannelsResult"
@@ -1117,11 +1185,11 @@
         "client": {
           "type": "string"
         },
-        "conn_info": {
+        "connInfo": {
           "type": "string",
           "format": "byte"
         },
-        "chan_info": {
+        "chanInfo": {
           "type": "string",
           "format": "byte"
         }
@@ -1148,13 +1216,13 @@
         "presence": {
           "$ref": "#/definitions/apiPresenceRequest"
         },
-        "presence_stats": {
+        "presenceStats": {
           "$ref": "#/definitions/apiPresenceStatsRequest"
         },
         "history": {
           "$ref": "#/definitions/apiHistoryRequest"
         },
-        "history_remove": {
+        "historyRemove": {
           "$ref": "#/definitions/apiHistoryRemoveRequest"
         },
         "info": {
@@ -1172,46 +1240,46 @@
         "connections": {
           "$ref": "#/definitions/apiConnectionsRequest"
         },
-        "update_user_status": {
+        "updateUserStatus": {
           "$ref": "#/definitions/apiUpdateUserStatusRequest"
         },
-        "get_user_status": {
+        "getUserStatus": {
           "$ref": "#/definitions/apiGetUserStatusRequest"
         },
-        "delete_user_status": {
+        "deleteUserStatus": {
           "$ref": "#/definitions/apiDeleteUserStatusRequest"
         },
-        "block_user": {
+        "blockUser": {
           "$ref": "#/definitions/apiBlockUserRequest"
         },
-        "unblock_user": {
+        "unblockUser": {
           "$ref": "#/definitions/apiUnblockUserRequest"
         },
-        "revoke_token": {
+        "revokeToken": {
           "$ref": "#/definitions/apiRevokeTokenRequest"
         },
-        "invalidate_user_tokens": {
+        "invalidateUserTokens": {
           "$ref": "#/definitions/apiInvalidateUserTokensRequest"
         },
-        "device_register": {
+        "deviceRegister": {
           "$ref": "#/definitions/apiDeviceRegisterRequest"
         },
-        "device_update": {
+        "deviceUpdate": {
           "$ref": "#/definitions/apiDeviceUpdateRequest"
         },
-        "device_remove": {
+        "deviceRemove": {
           "$ref": "#/definitions/apiDeviceRemoveRequest"
         },
-        "device_list": {
+        "deviceList": {
           "$ref": "#/definitions/apiDeviceListRequest"
         },
-        "push_user_channel_list": {
+        "pushUserChannelList": {
           "$ref": "#/definitions/apiPushUserChannelListRequest"
         },
-        "push_user_channel_update": {
+        "pushUserChannelUpdate": {
           "$ref": "#/definitions/apiPushUserChannelUpdateRequest"
         },
-        "send_push_notification": {
+        "sendPushNotification": {
           "$ref": "#/definitions/apiSendPushNotificationRequest"
         }
       }
@@ -1219,10 +1287,10 @@
     "apiConnectionInfo": {
       "type": "object",
       "properties": {
-        "app_name": {
+        "appName": {
           "type": "string"
         },
-        "app_version": {
+        "appVersion": {
           "type": "string"
         },
         "transport": {
@@ -1249,10 +1317,10 @@
             "$ref": "#/definitions/apiChannelContext"
           }
         },
-        "connection_token": {
+        "connectionToken": {
           "$ref": "#/definitions/apiConnectionTokenInfo"
         },
-        "subscription_tokens": {
+        "subscriptionTokens": {
           "type": "object",
           "additionalProperties": {
             "$ref": "#/definitions/apiSubscriptionTokenInfo"
@@ -1270,7 +1338,7 @@
         "uid": {
           "type": "string"
         },
-        "issued_at": {
+        "issuedAt": {
           "type": "string",
           "format": "int64"
         }
@@ -1291,7 +1359,7 @@
       "type": "object",
       "properties": {
         "error": {
-          "$ref": "#/definitions/centrifugoapiError"
+          "$ref": "#/definitions/apiError"
         },
         "result": {
           "$ref": "#/definitions/apiConnectionsResult"
@@ -1324,7 +1392,7 @@
       "type": "object",
       "properties": {
         "error": {
-          "$ref": "#/definitions/centrifugoapiError"
+          "$ref": "#/definitions/apiError"
         },
         "result": {
           "$ref": "#/definitions/apiDeleteUserStatusResult"
@@ -1376,7 +1444,8 @@
       "type": "object",
       "properties": {
         "op": {
-          "type": "string"
+          "type": "string",
+          "title": "add | remove | set"
         },
         "channels": {
           "type": "array",
@@ -1401,9 +1470,10 @@
             "type": "string"
           }
         },
-        "provider_tokens": {
+        "providerTokens": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/apiDeviceProviderTokens"
           }
         },
@@ -1432,13 +1502,13 @@
           "type": "integer",
           "format": "int32"
         },
-        "include_channels": {
+        "includeChannels": {
           "type": "boolean"
         },
-        "include_meta": {
+        "includeMeta": {
           "type": "boolean"
         },
-        "include_tags": {
+        "includeTags": {
           "type": "boolean"
         }
       }
@@ -1447,7 +1517,7 @@
       "type": "object",
       "properties": {
         "error": {
-          "$ref": "#/definitions/centrifugoapiError"
+          "$ref": "#/definitions/apiError"
         },
         "result": {
           "$ref": "#/definitions/apiDeviceListResult"
@@ -1460,10 +1530,11 @@
         "items": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/apiDevice"
           }
         },
-        "has_more": {
+        "hasMore": {
           "type": "boolean"
         }
       }
@@ -1535,7 +1606,7 @@
       "type": "object",
       "properties": {
         "error": {
-          "$ref": "#/definitions/centrifugoapiError"
+          "$ref": "#/definitions/apiError"
         },
         "result": {
           "$ref": "#/definitions/apiDeviceRegisterResult"
@@ -1565,9 +1636,10 @@
             "type": "string"
           }
         },
-        "provider_tokens": {
+        "providerTokens": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/apiDeviceProviderTokens"
           }
         }
@@ -1577,7 +1649,7 @@
       "type": "object",
       "properties": {
         "error": {
-          "$ref": "#/definitions/centrifugoapiError"
+          "$ref": "#/definitions/apiError"
         },
         "result": {
           "$ref": "#/definitions/apiDeviceRemoveResult"
@@ -1591,7 +1663,8 @@
       "type": "object",
       "properties": {
         "op": {
-          "type": "string"
+          "type": "string",
+          "title": "add | remove | set"
         },
         "tags": {
           "type": "object",
@@ -1616,22 +1689,23 @@
             "type": "string"
           }
         },
-        "provider_tokens": {
+        "providerTokens": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/apiDeviceProviderTokens"
           }
         },
-        "user_update": {
+        "userUpdate": {
           "$ref": "#/definitions/apiDeviceUserUpdate"
         },
-        "meta_update": {
+        "metaUpdate": {
           "$ref": "#/definitions/apiDeviceMetaUpdate"
         },
-        "tags_update": {
+        "tagsUpdate": {
           "$ref": "#/definitions/apiDeviceTagsUpdate"
         },
-        "channels_update": {
+        "channelsUpdate": {
           "$ref": "#/definitions/apiDeviceChannelsUpdate"
         }
       }
@@ -1640,7 +1714,7 @@
       "type": "object",
       "properties": {
         "error": {
-          "$ref": "#/definitions/centrifugoapiError"
+          "$ref": "#/definitions/apiError"
         },
         "result": {
           "$ref": "#/definitions/apiDeviceUpdateResult"
@@ -1700,7 +1774,7 @@
       "type": "object",
       "properties": {
         "error": {
-          "$ref": "#/definitions/centrifugoapiError"
+          "$ref": "#/definitions/apiError"
         },
         "result": {
           "$ref": "#/definitions/apiDisconnectResult"
@@ -1709,6 +1783,18 @@
     },
     "apiDisconnectResult": {
       "type": "object"
+    },
+    "apiError": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "message": {
+          "type": "string"
+        }
+      }
     },
     "apiFcmPushNotification": {
       "type": "object",
@@ -1734,7 +1820,7 @@
       "type": "object",
       "properties": {
         "error": {
-          "$ref": "#/definitions/centrifugoapiError"
+          "$ref": "#/definitions/apiError"
         },
         "result": {
           "$ref": "#/definitions/apiGetUserStatusResult"
@@ -1747,6 +1833,7 @@
         "statuses": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/apiUserStatus"
           }
         }
@@ -1764,7 +1851,7 @@
       "type": "object",
       "properties": {
         "error": {
-          "$ref": "#/definitions/centrifugoapiError"
+          "$ref": "#/definitions/apiError"
         },
         "result": {
           "$ref": "#/definitions/apiHistoryRemoveResult"
@@ -1796,7 +1883,7 @@
       "type": "object",
       "properties": {
         "error": {
-          "$ref": "#/definitions/centrifugoapiError"
+          "$ref": "#/definitions/apiError"
         },
         "result": {
           "$ref": "#/definitions/apiHistoryResult"
@@ -1809,6 +1896,7 @@
         "publications": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/apiPublication"
           }
         },
@@ -1837,7 +1925,7 @@
       "type": "object",
       "properties": {
         "error": {
-          "$ref": "#/definitions/centrifugoapiError"
+          "$ref": "#/definitions/apiError"
         },
         "result": {
           "$ref": "#/definitions/apiInfoResult"
@@ -1850,6 +1938,7 @@
         "nodes": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/apiNodeResult"
           }
         }
@@ -1858,14 +1947,14 @@
     "apiInvalidateUserTokensRequest": {
       "type": "object",
       "properties": {
-        "expire_at": {
+        "expireAt": {
           "type": "string",
           "format": "int64"
         },
         "user": {
           "type": "string"
         },
-        "issued_before": {
+        "issuedBefore": {
           "type": "string",
           "format": "int64"
         },
@@ -1878,7 +1967,7 @@
       "type": "object",
       "properties": {
         "error": {
-          "$ref": "#/definitions/centrifugoapiError"
+          "$ref": "#/definitions/apiError"
         },
         "result": {
           "$ref": "#/definitions/apiInvalidateUserTokensResult"
@@ -1916,15 +2005,15 @@
         "version": {
           "type": "string"
         },
-        "num_clients": {
+        "numClients": {
           "type": "integer",
           "format": "int64"
         },
-        "num_users": {
+        "numUsers": {
           "type": "integer",
           "format": "int64"
         },
-        "num_channels": {
+        "numChannels": {
           "type": "integer",
           "format": "int64"
         },
@@ -1938,7 +2027,7 @@
         "process": {
           "$ref": "#/definitions/apiProcess"
         },
-        "num_subs": {
+        "numSubs": {
           "type": "integer",
           "format": "int64"
         }
@@ -1956,7 +2045,7 @@
       "type": "object",
       "properties": {
         "error": {
-          "$ref": "#/definitions/centrifugoapiError"
+          "$ref": "#/definitions/apiError"
         },
         "result": {
           "$ref": "#/definitions/apiPresenceResult"
@@ -1986,7 +2075,7 @@
       "type": "object",
       "properties": {
         "error": {
-          "$ref": "#/definitions/centrifugoapiError"
+          "$ref": "#/definitions/apiError"
         },
         "result": {
           "$ref": "#/definitions/apiPresenceStatsResult"
@@ -1996,11 +2085,11 @@
     "apiPresenceStatsResult": {
       "type": "object",
       "properties": {
-        "num_clients": {
+        "numClients": {
           "type": "integer",
           "format": "int64"
         },
-        "num_users": {
+        "numUsers": {
           "type": "integer",
           "format": "int64"
         }
@@ -2053,7 +2142,7 @@
         "b64data": {
           "type": "string"
         },
-        "skip_history": {
+        "skipHistory": {
           "type": "boolean"
         },
         "tags": {
@@ -2068,7 +2157,7 @@
       "type": "object",
       "properties": {
         "error": {
-          "$ref": "#/definitions/centrifugoapiError"
+          "$ref": "#/definitions/apiError"
         },
         "result": {
           "$ref": "#/definitions/apiPublishResult"
@@ -2102,7 +2191,7 @@
         "uid": {
           "type": "string"
         },
-        "expire_at": {
+        "expireAt": {
           "type": "string",
           "format": "int64"
         }
@@ -2111,7 +2200,7 @@
     "apiPushRecipient": {
       "type": "object",
       "properties": {
-        "device_ids": {
+        "deviceIds": {
           "type": "array",
           "items": {
             "type": "string"
@@ -2123,31 +2212,31 @@
             "type": "string"
           }
         },
-        "fcm_tokens": {
+        "fcmTokens": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "fcm_topic": {
+        "fcmTopic": {
           "type": "string"
         },
-        "fcm_condition": {
+        "fcmCondition": {
           "type": "string"
         },
-        "hms_tokens": {
+        "hmsTokens": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "hms_topic": {
+        "hmsTopic": {
           "type": "string"
         },
-        "hms_condition": {
+        "hmsCondition": {
           "type": "string"
         },
-        "apns_tokens": {
+        "apnsTokens": {
           "type": "array",
           "items": {
             "type": "string"
@@ -2197,7 +2286,7 @@
       "type": "object",
       "properties": {
         "error": {
-          "$ref": "#/definitions/centrifugoapiError"
+          "$ref": "#/definitions/apiError"
         },
         "result": {
           "$ref": "#/definitions/apiPushUserChannelListResult"
@@ -2210,10 +2299,11 @@
         "items": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/apiPushUserChannel"
           }
         },
-        "has_more": {
+        "hasMore": {
           "type": "boolean"
         }
       }
@@ -2225,7 +2315,8 @@
           "type": "string"
         },
         "op": {
-          "type": "string"
+          "type": "string",
+          "title": "add | remove | set"
         },
         "channels": {
           "type": "array",
@@ -2239,7 +2330,7 @@
       "type": "object",
       "properties": {
         "error": {
-          "$ref": "#/definitions/centrifugoapiError"
+          "$ref": "#/definitions/apiError"
         },
         "result": {
           "$ref": "#/definitions/apiPushUserChannelUpdateResult"
@@ -2258,17 +2349,6 @@
         "params": {
           "type": "string",
           "format": "byte"
-        }
-      }
-    },
-    "apiRPCResponse": {
-      "type": "object",
-      "properties": {
-        "error": {
-          "$ref": "#/definitions/centrifugoapiError"
-        },
-        "result": {
-          "$ref": "#/definitions/apiRPCResult"
         }
       }
     },
@@ -2292,7 +2372,7 @@
         "expired": {
           "type": "boolean"
         },
-        "expire_at": {
+        "expireAt": {
           "type": "string",
           "format": "int64"
         },
@@ -2309,7 +2389,7 @@
       "type": "object",
       "properties": {
         "error": {
-          "$ref": "#/definitions/centrifugoapiError"
+          "$ref": "#/definitions/apiError"
         },
         "result": {
           "$ref": "#/definitions/apiRefreshResult"
@@ -2340,13 +2420,13 @@
         "presence": {
           "$ref": "#/definitions/apiPresenceResult"
         },
-        "presence_stats": {
+        "presenceStats": {
           "$ref": "#/definitions/apiPresenceStatsResult"
         },
         "history": {
           "$ref": "#/definitions/apiHistoryResult"
         },
-        "history_remove": {
+        "historyRemove": {
           "$ref": "#/definitions/apiHistoryRemoveResult"
         },
         "info": {
@@ -2364,46 +2444,46 @@
         "connections": {
           "$ref": "#/definitions/apiConnectionsResult"
         },
-        "update_user_status": {
+        "updateUserStatus": {
           "$ref": "#/definitions/apiUpdateUserStatusResult"
         },
-        "get_user_status": {
+        "getUserStatus": {
           "$ref": "#/definitions/apiGetUserStatusResult"
         },
-        "delete_user_status": {
+        "deleteUserStatus": {
           "$ref": "#/definitions/apiDeleteUserStatusResult"
         },
-        "block_user": {
+        "blockUser": {
           "$ref": "#/definitions/apiBlockUserResult"
         },
-        "unblock_user": {
+        "unblockUser": {
           "$ref": "#/definitions/apiUnblockUserResult"
         },
-        "revoke_token": {
+        "revokeToken": {
           "$ref": "#/definitions/apiRevokeTokenResult"
         },
-        "invalidate_user_tokens": {
+        "invalidateUserTokens": {
           "$ref": "#/definitions/apiInvalidateUserTokensResult"
         },
-        "device_register": {
+        "deviceRegister": {
           "$ref": "#/definitions/apiDeviceRegisterResult"
         },
-        "device_update": {
+        "deviceUpdate": {
           "$ref": "#/definitions/apiDeviceUpdateResult"
         },
-        "device_remove": {
+        "deviceRemove": {
           "$ref": "#/definitions/apiDeviceRemoveResult"
         },
-        "device_list": {
+        "deviceList": {
           "$ref": "#/definitions/apiDeviceListResult"
         },
-        "push_user_channel_list": {
+        "pushUserChannelList": {
           "$ref": "#/definitions/apiPushUserChannelListResult"
         },
-        "push_user_channel_update": {
+        "pushUserChannelUpdate": {
           "$ref": "#/definitions/apiPushUserChannelUpdateResult"
         },
-        "send_push_notification": {
+        "sendPushNotification": {
           "$ref": "#/definitions/apiSendPushNotificationResult"
         }
       }
@@ -2411,7 +2491,7 @@
     "apiRevokeTokenRequest": {
       "type": "object",
       "properties": {
-        "expire_at": {
+        "expireAt": {
           "type": "string",
           "format": "int64"
         },
@@ -2424,7 +2504,7 @@
       "type": "object",
       "properties": {
         "error": {
-          "$ref": "#/definitions/centrifugoapiError"
+          "$ref": "#/definitions/apiError"
         },
         "result": {
           "$ref": "#/definitions/apiRevokeTokenResult"
@@ -2449,7 +2529,7 @@
       "type": "object",
       "properties": {
         "error": {
-          "$ref": "#/definitions/centrifugoapiError"
+          "$ref": "#/definitions/apiError"
         },
         "result": {
           "$ref": "#/definitions/apiSendPushNotificationResult"
@@ -2460,7 +2540,8 @@
       "type": "object",
       "properties": {
         "uid": {
-          "type": "string"
+          "type": "string",
+          "description": "Unique identifier of notification send request (not a FCM message id)."
         }
       }
     },
@@ -2482,16 +2563,16 @@
         "presence": {
           "$ref": "#/definitions/apiBoolValue"
         },
-        "join_leave": {
+        "joinLeave": {
           "$ref": "#/definitions/apiBoolValue"
         },
-        "force_recovery": {
+        "forceRecovery": {
           "$ref": "#/definitions/apiBoolValue"
         },
-        "force_positioning": {
+        "forcePositioning": {
           "$ref": "#/definitions/apiBoolValue"
         },
-        "force_push_join_leave": {
+        "forcePushJoinLeave": {
           "$ref": "#/definitions/apiBoolValue"
         }
       }
@@ -2505,7 +2586,7 @@
         "user": {
           "type": "string"
         },
-        "expire_at": {
+        "expireAt": {
           "type": "string",
           "format": "int64"
         },
@@ -2525,7 +2606,7 @@
         "b64data": {
           "type": "string"
         },
-        "recover_since": {
+        "recoverSince": {
           "$ref": "#/definitions/apiStreamPosition"
         },
         "override": {
@@ -2540,7 +2621,7 @@
       "type": "object",
       "properties": {
         "error": {
-          "$ref": "#/definitions/centrifugoapiError"
+          "$ref": "#/definitions/apiError"
         },
         "result": {
           "$ref": "#/definitions/apiSubscribeResult"
@@ -2556,7 +2637,7 @@
         "uid": {
           "type": "string"
         },
-        "issued_at": {
+        "issuedAt": {
           "type": "string",
           "format": "int64"
         }
@@ -2574,7 +2655,7 @@
       "type": "object",
       "properties": {
         "error": {
-          "$ref": "#/definitions/centrifugoapiError"
+          "$ref": "#/definitions/apiError"
         },
         "result": {
           "$ref": "#/definitions/apiUnblockUserResult"
@@ -2605,7 +2686,7 @@
       "type": "object",
       "properties": {
         "error": {
-          "$ref": "#/definitions/centrifugoapiError"
+          "$ref": "#/definitions/apiError"
         },
         "result": {
           "$ref": "#/definitions/apiUnsubscribeResult"
@@ -2630,7 +2711,7 @@
       "type": "object",
       "properties": {
         "error": {
-          "$ref": "#/definitions/centrifugoapiError"
+          "$ref": "#/definitions/apiError"
         },
         "result": {
           "$ref": "#/definitions/apiUpdateUserStatusResult"
@@ -2656,24 +2737,18 @@
         }
       }
     },
-    "centrifugoapiError": {
+    "protobufAny": {
       "type": "object",
       "properties": {
-        "code": {
-          "type": "integer",
-          "format": "int64"
-        },
-        "message": {
+        "@type": {
           "type": "string"
         }
-      }
+      },
+      "additionalProperties": {}
     },
-    "gatewayruntimeError": {
+    "rpcStatus": {
       "type": "object",
       "properties": {
-        "error": {
-          "type": "string"
-        },
         "code": {
           "type": "integer",
           "format": "int32"
@@ -2684,20 +2759,9 @@
         "details": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/protobufAny"
           }
-        }
-      }
-    },
-    "protobufAny": {
-      "type": "object",
-      "properties": {
-        "type_url": {
-          "type": "string"
-        },
-        "value": {
-          "type": "string",
-          "format": "byte"
         }
       }
     }
@@ -2708,5 +2772,10 @@
       "name": "Authorization",
       "in": "header"
     }
-  }
+  },
+  "security": [
+    {
+      "ApiKeyAuth": []
+    }
+  ]
 }

--- a/internal/apiproto/api.swagger.proto
+++ b/internal/apiproto/api.swagger.proto
@@ -46,7 +46,7 @@ option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
       name: "token"
     },
     {
-      name: "push notifications"
+      name: "push notification"
     },
     {
       name: "batch"
@@ -306,7 +306,7 @@ service CentrifugoApi {
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       summary: "Device register request";
-      tags: ["push notifications"];
+      tags: ["push notification"];
     };
   }
   rpc DeviceUpdate (DeviceUpdateRequest) returns (DeviceUpdateResponse) {
@@ -316,7 +316,7 @@ service CentrifugoApi {
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       summary: "Device register request";
-      tags: ["push notifications"];
+      tags: ["push notification"];
     };
   }
   rpc DeviceRemove (DeviceRemoveRequest) returns (DeviceRemoveResponse) {
@@ -326,7 +326,7 @@ service CentrifugoApi {
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       summary: "Device register request";
-      tags: ["push notifications"];
+      tags: ["push notification"];
     };
   }
   rpc DeviceList (DeviceListRequest) returns (DeviceListResponse) {
@@ -336,7 +336,7 @@ service CentrifugoApi {
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       summary: "Device register request";
-      tags: ["push notifications"];
+      tags: ["push notification"];
     };
   }
   rpc PushUserChannelList (PushUserChannelListRequest) returns (PushUserChannelListResponse) {
@@ -346,7 +346,7 @@ service CentrifugoApi {
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       summary: "Device register request";
-      tags: ["push notifications"];
+      tags: ["push notification"];
     };
   }
   rpc PushUserChannelUpdate (PushUserChannelUpdateRequest) returns (PushUserChannelUpdateResponse) {
@@ -356,7 +356,7 @@ service CentrifugoApi {
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       summary: "Device register request";
-      tags: ["push notifications"];
+      tags: ["push notification"];
     };
   }
   rpc SendPushNotification (SendPushNotificationRequest) returns (SendPushNotificationResponse) {
@@ -366,7 +366,7 @@ service CentrifugoApi {
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       summary: "Device register request";
-      tags: ["push notifications"];
+      tags: ["push notification"];
     };
   }
 }

--- a/internal/apiproto/api.swagger.proto
+++ b/internal/apiproto/api.swagger.proto
@@ -15,6 +15,44 @@ option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
   };
   consumes: "application/json";
   produces: "application/json";
+  tags: [
+    {
+      name: "publication"
+    },
+    {
+      name: "connection management"
+    },
+    {
+      name: "history"
+    },
+    {
+      name: "presence"
+    },
+    {
+      name: "stats"
+    },
+    {
+      name: "user status"
+    },
+    {
+      name: "user block"
+    },
+    {
+      name: "token"
+    },
+    {
+      name: "push notifications"
+    },
+    {
+      name: "batch"
+    },
+    {
+      name: "oss"
+    },
+    {
+      name: "pro"
+    }
+  ];
   security_definitions: {
     security: {
       key: "ApiKeyAuth";
@@ -25,6 +63,12 @@ option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
       }
     }
   }
+  security: {
+    security_requirement: {
+      key: "ApiKeyAuth";
+      value: {};
+    }
+  }
 };
 
 service CentrifugoApi {
@@ -33,11 +77,19 @@ service CentrifugoApi {
       post: "/batch",
       body: "*"
     };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Batch request";
+      tags: ["batch", "oss"];
+    };
   }
   rpc Publish (PublishRequest) returns (PublishResponse) {
     option (google.api.http) = {
       post: "/publish",
       body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Publish request";
+      tags: ["publication", "oss"];
     };
   }
   rpc Broadcast (BroadcastRequest) returns (BroadcastResponse) {
@@ -45,11 +97,19 @@ service CentrifugoApi {
       post: "/broadcast",
       body: "*"
     };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Broadcast request";
+      tags: ["publication", "oss"];
+    };
   }
   rpc Subscribe (SubscribeRequest) returns (SubscribeResponse) {
     option (google.api.http) = {
       post: "/subscribe",
       body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Subscribe request";
+      tags: ["connection management", "oss"];
     };
   }
   rpc Unsubscribe (UnsubscribeRequest) returns (UnsubscribeResponse) {
@@ -57,11 +117,19 @@ service CentrifugoApi {
       post: "/unsubscribe",
       body: "*"
     };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Unsubscribe request";
+      tags: ["connection management", "oss"];
+    };
   }
   rpc Disconnect (DisconnectRequest) returns (DisconnectResponse) {
     option (google.api.http) = {
       post: "/disconnect",
       body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Disconnect request";
+      tags: ["connection management", "oss"];
     };
   }
   rpc Presence (PresenceRequest) returns (PresenceResponse) {
@@ -69,11 +137,19 @@ service CentrifugoApi {
       post: "/presence",
       body: "*"
     };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Presence request";
+      tags: ["presence", "oss"];
+    };
   }
   rpc PresenceStats (PresenceStatsRequest) returns (PresenceStatsResponse) {
     option (google.api.http) = {
       post: "/presence_stats",
       body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Presence stats request";
+      tags: ["presence", "oss"];
     };
   }
   rpc History (HistoryRequest) returns (HistoryResponse) {
@@ -81,11 +157,19 @@ service CentrifugoApi {
       post: "/history",
       body: "*"
     };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "History request";
+      tags: ["history", "oss"];
+    };
   }
   rpc HistoryRemove (HistoryRemoveRequest) returns (HistoryRemoveResponse) {
     option (google.api.http) = {
       post: "/history_remove",
       body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "History remove request";
+      tags: ["history", "oss"];
     };
   }
   rpc Info (InfoRequest) returns (InfoResponse) {
@@ -93,11 +177,9 @@ service CentrifugoApi {
       post: "/info",
       body: "*"
     };
-  }
-  rpc RPC (RPCRequest) returns (RPCResponse) {
-    option (google.api.http) = {
-      post: "/rpc",
-      body: "*"
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Info request";
+      tags: ["stats", "oss"];
     };
   }
   rpc Refresh (RefreshRequest) returns (RefreshResponse) {
@@ -105,11 +187,19 @@ service CentrifugoApi {
       post: "/refresh",
       body: "*"
     };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Refresh request";
+      tags: ["connection management", "oss"];
+    };
   }
   rpc Channels (ChannelsRequest) returns (ChannelsResponse) {
     option (google.api.http) = {
       post: "/channels",
       body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Channels request";
+      tags: ["stats", "oss"];
     };
   }
   rpc Connections (ConnectionsRequest) returns (ConnectionsResponse) {
@@ -117,11 +207,19 @@ service CentrifugoApi {
       post: "/connections",
       body: "*"
     };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Connections request";
+      tags: ["stats", "pro"];
+    };
   }
   rpc UpdateUserStatus (UpdateUserStatusRequest) returns (UpdateUserStatusResponse) {
     option (google.api.http) = {
       post: "/update_user_status",
       body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Updated user status request";
+      tags: ["user status", "pro"];
     };
   }
   rpc GetUserStatus (GetUserStatusRequest) returns (GetUserStatusResponse) {
@@ -129,11 +227,19 @@ service CentrifugoApi {
       post: "/get_user_status",
       body: "*"
     };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Get user status request";
+      tags: ["user status", "pro"];
+    };
   }
   rpc DeleteUserStatus (DeleteUserStatusRequest) returns (DeleteUserStatusResponse) {
     option (google.api.http) = {
       post: "/delete_user_status",
       body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Delete user status request";
+      tags: ["user status", "pro"];
     };
   }
   rpc BlockUser (BlockUserRequest) returns (BlockUserResponse) {
@@ -141,11 +247,19 @@ service CentrifugoApi {
       post: "/block_user",
       body: "*"
     };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Block user request";
+      tags: ["user block", "pro"];
+    };
   }
   rpc UnblockUser (UnblockUserRequest) returns (UnblockUserResponse) {
     option (google.api.http) = {
       post: "/unblock_user",
       body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Unblock user request";
+      tags: ["user block", "pro"];
     };
   }
   rpc RevokeToken (RevokeTokenRequest) returns (RevokeTokenResponse) {
@@ -153,11 +267,19 @@ service CentrifugoApi {
       post: "/revoke_token",
       body: "*"
     };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Revoke token request";
+      tags: ["token", "pro"];
+    };
   }
   rpc InvalidateUserTokens (InvalidateUserTokensRequest) returns (InvalidateUserTokensResponse) {
     option (google.api.http) = {
       post: "/invalidate_user_tokens",
       body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Invalidate user tokens request";
+      tags: ["token", "pro"];
     };
   }
   rpc DeviceRegister (DeviceRegisterRequest) returns (DeviceRegisterResponse) {
@@ -165,11 +287,19 @@ service CentrifugoApi {
       post: "/device_register",
       body: "*"
     };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Device register request";
+      tags: ["push notifications", "pro"];
+    };
   }
   rpc DeviceUpdate (DeviceUpdateRequest) returns (DeviceUpdateResponse) {
     option (google.api.http) = {
       post: "/device_update",
       body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Device register request";
+      tags: ["push notifications", "pro"];
     };
   }
   rpc DeviceRemove (DeviceRemoveRequest) returns (DeviceRemoveResponse) {
@@ -177,11 +307,19 @@ service CentrifugoApi {
       post: "/device_remove",
       body: "*"
     };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Device register request";
+      tags: ["push notifications", "pro"];
+    };
   }
   rpc DeviceList (DeviceListRequest) returns (DeviceListResponse) {
     option (google.api.http) = {
       post: "/device_list",
       body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Device register request";
+      tags: ["push notifications", "pro"];
     };
   }
   rpc PushUserChannelList (PushUserChannelListRequest) returns (PushUserChannelListResponse) {
@@ -189,17 +327,29 @@ service CentrifugoApi {
       post: "/push_user_channel_list",
       body: "*"
     };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Device register request";
+      tags: ["push notifications", "pro"];
+    };
   }
   rpc PushUserChannelUpdate (PushUserChannelUpdateRequest) returns (PushUserChannelUpdateResponse) {
     option (google.api.http) = {
       post: "/push_user_channel_update",
       body: "*"
     };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Device register request";
+      tags: ["push notifications", "pro"];
+    };
   }
   rpc SendPushNotification (SendPushNotificationRequest) returns (SendPushNotificationResponse) {
     option (google.api.http) = {
       post: "/send_push_notification",
       body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Device register request";
+      tags: ["push notifications","pro"];
     };
   }
 }

--- a/internal/apiproto/api.swagger.proto
+++ b/internal/apiproto/api.swagger.proto
@@ -46,14 +46,26 @@ option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
     },
     {
       name: "batch"
-    },
-    {
-      name: "oss"
-    },
-    {
-      name: "pro"
     }
   ];
+  responses: {
+    key: "400";
+    value: {
+      description: "Returned in case of invalid request."
+    }
+  }
+  responses: {
+    key: "401";
+    value: {
+      description: "Returned in case of missing auth."
+    }
+  }
+  responses: {
+    key: "500";
+    value: {
+      description: "Returned in case of internal server error."
+    }
+  }
   security_definitions: {
     security: {
       key: "ApiKeyAuth";
@@ -80,7 +92,7 @@ service CentrifugoApi {
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       summary: "Batch request";
-      tags: ["batch", "oss"];
+      tags: ["batch"];
     };
   }
   rpc Publish (PublishRequest) returns (PublishResponse) {
@@ -90,7 +102,7 @@ service CentrifugoApi {
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       summary: "Publish request";
-      tags: ["publication", "oss"];
+      tags: ["publication"];
     };
   }
   rpc Broadcast (BroadcastRequest) returns (BroadcastResponse) {
@@ -100,7 +112,7 @@ service CentrifugoApi {
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       summary: "Broadcast request";
-      tags: ["publication", "oss"];
+      tags: ["publication"];
     };
   }
   rpc Subscribe (SubscribeRequest) returns (SubscribeResponse) {
@@ -110,7 +122,7 @@ service CentrifugoApi {
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       summary: "Subscribe request";
-      tags: ["connection management", "oss"];
+      tags: ["connection management"];
     };
   }
   rpc Unsubscribe (UnsubscribeRequest) returns (UnsubscribeResponse) {
@@ -120,7 +132,7 @@ service CentrifugoApi {
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       summary: "Unsubscribe request";
-      tags: ["connection management", "oss"];
+      tags: ["connection management"];
     };
   }
   rpc Disconnect (DisconnectRequest) returns (DisconnectResponse) {
@@ -130,7 +142,7 @@ service CentrifugoApi {
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       summary: "Disconnect request";
-      tags: ["connection management", "oss"];
+      tags: ["connection management"];
     };
   }
   rpc Presence (PresenceRequest) returns (PresenceResponse) {
@@ -140,7 +152,7 @@ service CentrifugoApi {
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       summary: "Presence request";
-      tags: ["presence", "oss"];
+      tags: ["presence"];
     };
   }
   rpc PresenceStats (PresenceStatsRequest) returns (PresenceStatsResponse) {
@@ -150,7 +162,7 @@ service CentrifugoApi {
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       summary: "Presence stats request";
-      tags: ["presence", "oss"];
+      tags: ["presence"];
     };
   }
   rpc History (HistoryRequest) returns (HistoryResponse) {
@@ -160,7 +172,7 @@ service CentrifugoApi {
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       summary: "History request";
-      tags: ["history", "oss"];
+      tags: ["history"];
     };
   }
   rpc HistoryRemove (HistoryRemoveRequest) returns (HistoryRemoveResponse) {
@@ -170,7 +182,7 @@ service CentrifugoApi {
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       summary: "History remove request";
-      tags: ["history", "oss"];
+      tags: ["history"];
     };
   }
   rpc Info (InfoRequest) returns (InfoResponse) {
@@ -180,7 +192,7 @@ service CentrifugoApi {
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       summary: "Info request";
-      tags: ["stats", "oss"];
+      tags: ["stats"];
     };
   }
   rpc Refresh (RefreshRequest) returns (RefreshResponse) {
@@ -190,7 +202,7 @@ service CentrifugoApi {
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       summary: "Refresh request";
-      tags: ["connection management", "oss"];
+      tags: ["connection management"];
     };
   }
   rpc Channels (ChannelsRequest) returns (ChannelsResponse) {
@@ -200,7 +212,7 @@ service CentrifugoApi {
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       summary: "Channels request";
-      tags: ["stats", "oss"];
+      tags: ["stats"];
     };
   }
   rpc Connections (ConnectionsRequest) returns (ConnectionsResponse) {
@@ -210,7 +222,7 @@ service CentrifugoApi {
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       summary: "Connections request";
-      tags: ["stats", "pro"];
+      tags: ["stats"];
     };
   }
   rpc UpdateUserStatus (UpdateUserStatusRequest) returns (UpdateUserStatusResponse) {
@@ -220,7 +232,7 @@ service CentrifugoApi {
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       summary: "Updated user status request";
-      tags: ["user status", "pro"];
+      tags: ["user status"];
     };
   }
   rpc GetUserStatus (GetUserStatusRequest) returns (GetUserStatusResponse) {
@@ -230,7 +242,7 @@ service CentrifugoApi {
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       summary: "Get user status request";
-      tags: ["user status", "pro"];
+      tags: ["user status"];
     };
   }
   rpc DeleteUserStatus (DeleteUserStatusRequest) returns (DeleteUserStatusResponse) {
@@ -240,7 +252,7 @@ service CentrifugoApi {
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       summary: "Delete user status request";
-      tags: ["user status", "pro"];
+      tags: ["user status"];
     };
   }
   rpc BlockUser (BlockUserRequest) returns (BlockUserResponse) {
@@ -250,7 +262,7 @@ service CentrifugoApi {
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       summary: "Block user request";
-      tags: ["user block", "pro"];
+      tags: ["user block"];
     };
   }
   rpc UnblockUser (UnblockUserRequest) returns (UnblockUserResponse) {
@@ -260,7 +272,7 @@ service CentrifugoApi {
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       summary: "Unblock user request";
-      tags: ["user block", "pro"];
+      tags: ["user block"];
     };
   }
   rpc RevokeToken (RevokeTokenRequest) returns (RevokeTokenResponse) {
@@ -270,7 +282,7 @@ service CentrifugoApi {
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       summary: "Revoke token request";
-      tags: ["token", "pro"];
+      tags: ["token"];
     };
   }
   rpc InvalidateUserTokens (InvalidateUserTokensRequest) returns (InvalidateUserTokensResponse) {
@@ -280,7 +292,7 @@ service CentrifugoApi {
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       summary: "Invalidate user tokens request";
-      tags: ["token", "pro"];
+      tags: ["token"];
     };
   }
   rpc DeviceRegister (DeviceRegisterRequest) returns (DeviceRegisterResponse) {
@@ -290,7 +302,7 @@ service CentrifugoApi {
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       summary: "Device register request";
-      tags: ["push notifications", "pro"];
+      tags: ["push notifications"];
     };
   }
   rpc DeviceUpdate (DeviceUpdateRequest) returns (DeviceUpdateResponse) {
@@ -300,7 +312,7 @@ service CentrifugoApi {
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       summary: "Device register request";
-      tags: ["push notifications", "pro"];
+      tags: ["push notifications"];
     };
   }
   rpc DeviceRemove (DeviceRemoveRequest) returns (DeviceRemoveResponse) {
@@ -310,7 +322,7 @@ service CentrifugoApi {
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       summary: "Device register request";
-      tags: ["push notifications", "pro"];
+      tags: ["push notifications"];
     };
   }
   rpc DeviceList (DeviceListRequest) returns (DeviceListResponse) {
@@ -320,7 +332,7 @@ service CentrifugoApi {
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       summary: "Device register request";
-      tags: ["push notifications", "pro"];
+      tags: ["push notifications"];
     };
   }
   rpc PushUserChannelList (PushUserChannelListRequest) returns (PushUserChannelListResponse) {
@@ -330,7 +342,7 @@ service CentrifugoApi {
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       summary: "Device register request";
-      tags: ["push notifications", "pro"];
+      tags: ["push notifications"];
     };
   }
   rpc PushUserChannelUpdate (PushUserChannelUpdateRequest) returns (PushUserChannelUpdateResponse) {
@@ -340,7 +352,7 @@ service CentrifugoApi {
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       summary: "Device register request";
-      tags: ["push notifications", "pro"];
+      tags: ["push notifications"];
     };
   }
   rpc SendPushNotification (SendPushNotificationRequest) returns (SendPushNotificationResponse) {
@@ -350,7 +362,7 @@ service CentrifugoApi {
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       summary: "Device register request";
-      tags: ["push notifications","pro"];
+      tags: ["push notifications"];
     };
   }
 }

--- a/internal/apiproto/api.swagger.proto
+++ b/internal/apiproto/api.swagger.proto
@@ -13,6 +13,10 @@ option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
     version: "5.0";
     description: "";
   };
+  external_docs: {
+    url: "https://centrifugal.dev/docs/server/server_api";
+    description: "More about Centrifugo HTTP API";
+  }
   consumes: "application/json";
   produces: "application/json";
   base_path: "/api";
@@ -91,7 +95,7 @@ service CentrifugoApi {
       body: "*"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      summary: "Batch request";
+      summary: "Batch request (send many commands in one request)";
       tags: ["batch"];
     };
   }
@@ -101,7 +105,7 @@ service CentrifugoApi {
       body: "*"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      summary: "Publish request";
+      summary: "Publish data into channel";
       tags: ["publication"];
     };
   }
@@ -111,7 +115,7 @@ service CentrifugoApi {
       body: "*"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      summary: "Broadcast request";
+      summary: "Broadcast allows publishing same data into many channels";
       tags: ["publication"];
     };
   }
@@ -121,7 +125,7 @@ service CentrifugoApi {
       body: "*"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      summary: "Subscribe request";
+      summary: "Subscribe connection(s) to a channel";
       tags: ["connection management"];
     };
   }
@@ -131,7 +135,7 @@ service CentrifugoApi {
       body: "*"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      summary: "Unsubscribe request";
+      summary: "Unsubscribe connection(s) from channel";
       tags: ["connection management"];
     };
   }
@@ -141,7 +145,7 @@ service CentrifugoApi {
       body: "*"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      summary: "Disconnect request";
+      summary: "Disconnect client(s) from server";
       tags: ["connection management"];
     };
   }
@@ -151,7 +155,7 @@ service CentrifugoApi {
       body: "*"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      summary: "Presence request";
+      summary: "Presence information for a channel";
       tags: ["presence"];
     };
   }
@@ -161,7 +165,7 @@ service CentrifugoApi {
       body: "*"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      summary: "Presence stats request";
+      summary: "Presence stats information for a channel";
       tags: ["presence"];
     };
   }
@@ -171,7 +175,7 @@ service CentrifugoApi {
       body: "*"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      summary: "History request";
+      summary: "History for a channel";
       tags: ["history"];
     };
   }
@@ -181,7 +185,7 @@ service CentrifugoApi {
       body: "*"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      summary: "History remove request";
+      summary: "Remove history for a channel";
       tags: ["history"];
     };
   }
@@ -191,7 +195,7 @@ service CentrifugoApi {
       body: "*"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      summary: "Info request";
+      summary: "Info shows details about server nodes";
       tags: ["stats"];
     };
   }
@@ -201,7 +205,7 @@ service CentrifugoApi {
       body: "*"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      summary: "Refresh request";
+      summary: "Refresh connection(s) by server-side call";
       tags: ["connection management"];
     };
   }

--- a/internal/apiproto/api.swagger.proto
+++ b/internal/apiproto/api.swagger.proto
@@ -15,6 +15,7 @@ option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
   };
   consumes: "application/json";
   produces: "application/json";
+  base_path: "/api";
   tags: [
     {
       name: "publication"

--- a/internal/apiproto/api.swagger.proto
+++ b/internal/apiproto/api.swagger.proto
@@ -1,0 +1,920 @@
+syntax = "proto3";
+
+package centrifugal.centrifugo.api;
+
+option go_package = "./;apiproto";
+
+import "google/api/annotations.proto";
+import "protoc-gen-openapiv2/options/annotations.proto";
+
+option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
+  info: {
+    title: "Centrifugo server HTTP API";
+    version: "5.0";
+    description: "";
+  };
+  consumes: "application/json";
+  produces: "application/json";
+  security_definitions: {
+    security: {
+      key: "ApiKeyAuth";
+      value: {
+        type: TYPE_API_KEY;
+        in: IN_HEADER;
+        name: "Authorization";
+      }
+    }
+  }
+};
+
+service CentrifugoApi {
+  rpc Batch(BatchRequest) returns (BatchResponse) {
+    option (google.api.http) = {
+      post: "/batch",
+      body: "*"
+    };
+  }
+  rpc Publish (PublishRequest) returns (PublishResponse) {
+    option (google.api.http) = {
+      post: "/publish",
+      body: "*"
+    };
+  }
+  rpc Broadcast (BroadcastRequest) returns (BroadcastResponse) {
+    option (google.api.http) = {
+      post: "/broadcast",
+      body: "*"
+    };
+  }
+  rpc Subscribe (SubscribeRequest) returns (SubscribeResponse) {
+    option (google.api.http) = {
+      post: "/subscribe",
+      body: "*"
+    };
+  }
+  rpc Unsubscribe (UnsubscribeRequest) returns (UnsubscribeResponse) {
+    option (google.api.http) = {
+      post: "/unsubscribe",
+      body: "*"
+    };
+  }
+  rpc Disconnect (DisconnectRequest) returns (DisconnectResponse) {
+    option (google.api.http) = {
+      post: "/disconnect",
+      body: "*"
+    };
+  }
+  rpc Presence (PresenceRequest) returns (PresenceResponse) {
+    option (google.api.http) = {
+      post: "/presence",
+      body: "*"
+    };
+  }
+  rpc PresenceStats (PresenceStatsRequest) returns (PresenceStatsResponse) {
+    option (google.api.http) = {
+      post: "/presence_stats",
+      body: "*"
+    };
+  }
+  rpc History (HistoryRequest) returns (HistoryResponse) {
+    option (google.api.http) = {
+      post: "/history",
+      body: "*"
+    };
+  }
+  rpc HistoryRemove (HistoryRemoveRequest) returns (HistoryRemoveResponse) {
+    option (google.api.http) = {
+      post: "/history_remove",
+      body: "*"
+    };
+  }
+  rpc Info (InfoRequest) returns (InfoResponse) {
+    option (google.api.http) = {
+      post: "/info",
+      body: "*"
+    };
+  }
+  rpc RPC (RPCRequest) returns (RPCResponse) {
+    option (google.api.http) = {
+      post: "/rpc",
+      body: "*"
+    };
+  }
+  rpc Refresh (RefreshRequest) returns (RefreshResponse) {
+    option (google.api.http) = {
+      post: "/refresh",
+      body: "*"
+    };
+  }
+  rpc Channels (ChannelsRequest) returns (ChannelsResponse) {
+    option (google.api.http) = {
+      post: "/channels",
+      body: "*"
+    };
+  }
+  rpc Connections (ConnectionsRequest) returns (ConnectionsResponse) {
+    option (google.api.http) = {
+      post: "/connections",
+      body: "*"
+    };
+  }
+  rpc UpdateUserStatus (UpdateUserStatusRequest) returns (UpdateUserStatusResponse) {
+    option (google.api.http) = {
+      post: "/update_user_status",
+      body: "*"
+    };
+  }
+  rpc GetUserStatus (GetUserStatusRequest) returns (GetUserStatusResponse) {
+    option (google.api.http) = {
+      post: "/get_user_status",
+      body: "*"
+    };
+  }
+  rpc DeleteUserStatus (DeleteUserStatusRequest) returns (DeleteUserStatusResponse) {
+    option (google.api.http) = {
+      post: "/delete_user_status",
+      body: "*"
+    };
+  }
+  rpc BlockUser (BlockUserRequest) returns (BlockUserResponse) {
+    option (google.api.http) = {
+      post: "/block_user",
+      body: "*"
+    };
+  }
+  rpc UnblockUser (UnblockUserRequest) returns (UnblockUserResponse) {
+    option (google.api.http) = {
+      post: "/unblock_user",
+      body: "*"
+    };
+  }
+  rpc RevokeToken (RevokeTokenRequest) returns (RevokeTokenResponse) {
+    option (google.api.http) = {
+      post: "/revoke_token",
+      body: "*"
+    };
+  }
+  rpc InvalidateUserTokens (InvalidateUserTokensRequest) returns (InvalidateUserTokensResponse) {
+    option (google.api.http) = {
+      post: "/invalidate_user_tokens",
+      body: "*"
+    };
+  }
+  rpc DeviceRegister (DeviceRegisterRequest) returns (DeviceRegisterResponse) {
+    option (google.api.http) = {
+      post: "/device_register",
+      body: "*"
+    };
+  }
+  rpc DeviceUpdate (DeviceUpdateRequest) returns (DeviceUpdateResponse) {
+    option (google.api.http) = {
+      post: "/device_update",
+      body: "*"
+    };
+  }
+  rpc DeviceRemove (DeviceRemoveRequest) returns (DeviceRemoveResponse) {
+    option (google.api.http) = {
+      post: "/device_remove",
+      body: "*"
+    };
+  }
+  rpc DeviceList (DeviceListRequest) returns (DeviceListResponse) {
+    option (google.api.http) = {
+      post: "/device_list",
+      body: "*"
+    };
+  }
+  rpc PushUserChannelList (PushUserChannelListRequest) returns (PushUserChannelListResponse) {
+    option (google.api.http) = {
+      post: "/push_user_channel_list",
+      body: "*"
+    };
+  }
+  rpc PushUserChannelUpdate (PushUserChannelUpdateRequest) returns (PushUserChannelUpdateResponse) {
+    option (google.api.http) = {
+      post: "/push_user_channel_update",
+      body: "*"
+    };
+  }
+  rpc SendPushNotification (SendPushNotificationRequest) returns (SendPushNotificationResponse) {
+    option (google.api.http) = {
+      post: "/send_push_notification",
+      body: "*"
+    };
+  }
+}
+
+message Command {
+  PublishRequest publish = 4;
+  BroadcastRequest broadcast = 5;
+  SubscribeRequest subscribe = 6;
+  UnsubscribeRequest unsubscribe = 7;
+  DisconnectRequest disconnect = 8;
+  PresenceRequest presence = 9;
+  PresenceStatsRequest presence_stats = 10;
+  HistoryRequest history = 11;
+  HistoryRemoveRequest history_remove = 12;
+  InfoRequest info = 13;
+  RPCRequest rpc = 14;
+  RefreshRequest refresh = 15;
+  ChannelsRequest channels = 16;
+  ConnectionsRequest connections = 17;
+  UpdateUserStatusRequest update_user_status = 18;
+  GetUserStatusRequest get_user_status = 19;
+  DeleteUserStatusRequest delete_user_status = 20;
+  BlockUserRequest block_user = 21;
+  UnblockUserRequest unblock_user = 22;
+  RevokeTokenRequest revoke_token = 23;
+  InvalidateUserTokensRequest invalidate_user_tokens = 24;
+  DeviceRegisterRequest device_register = 25;
+  DeviceUpdateRequest device_update = 26;
+  DeviceRemoveRequest device_remove = 27;
+  DeviceListRequest device_list = 28;
+  PushUserChannelListRequest push_user_channel_list = 29;
+  PushUserChannelUpdateRequest push_user_channel_update = 30;
+  SendPushNotificationRequest send_push_notification = 31;
+}
+
+message Error {
+  uint32 code = 1;
+  string message = 2;
+}
+
+message Reply {
+  PublishResult publish = 4;
+  BroadcastResult broadcast = 5;
+  SubscribeResult subscribe = 6;
+  UnsubscribeResult unsubscribe = 7;
+  DisconnectResult disconnect = 8;
+  PresenceResult presence = 9;
+  PresenceStatsResult presence_stats = 10;
+  HistoryResult history = 11;
+  HistoryRemoveResult history_remove = 12;
+  InfoResult info = 13;
+  RPCResult rpc = 14;
+  RefreshResult refresh = 15;
+  ChannelsResult channels = 16;
+  ConnectionsResult connections = 17;
+  UpdateUserStatusResult update_user_status = 18;
+  GetUserStatusResult get_user_status = 19;
+  DeleteUserStatusResult delete_user_status = 20;
+  BlockUserResult block_user = 21;
+  UnblockUserResult unblock_user = 22;
+  RevokeTokenResult revoke_token = 23;
+  InvalidateUserTokensResult invalidate_user_tokens = 24;
+  DeviceRegisterResult device_register = 25;
+  DeviceUpdateResult device_update = 26;
+  DeviceRemoveResult device_remove = 27;
+  DeviceListResult device_list = 28;
+  PushUserChannelListResult push_user_channel_list = 29;
+  PushUserChannelUpdateResult push_user_channel_update = 30;
+  SendPushNotificationResult send_push_notification = 31;
+}
+
+message BoolValue {
+  bool value = 1;
+}
+
+message Int32Value {
+  int32 value = 1;
+}
+
+message SubscribeOptionOverride {
+  BoolValue presence = 1;
+  BoolValue join_leave = 2;
+  BoolValue force_recovery = 3;
+  BoolValue force_positioning = 4;
+  BoolValue force_push_join_leave = 5;
+}
+
+message BatchRequest {
+  repeated Command commands = 1;
+}
+
+message BatchResponse {
+  repeated Reply replies = 1;
+}
+
+message PublishRequest {
+  string channel = 1;
+  bytes data = 2;
+  string b64data = 3;
+  bool skip_history = 4;
+  map<string, string> tags = 5;
+}
+
+message PublishResponse {
+  Error error = 1;
+  PublishResult result = 2;
+}
+
+message PublishResult {
+  uint64 offset = 1;
+  string epoch = 2;
+}
+
+message BroadcastRequest {
+  repeated string channels = 1;
+  bytes data = 2;
+  string b64data = 3;
+  bool skip_history = 4;
+  map<string, string> tags = 5;
+}
+
+message BroadcastResponse {
+  Error error = 1;
+  BroadcastResult result = 2;
+}
+
+message BroadcastResult {
+  repeated PublishResponse responses = 1;
+}
+
+message SubscribeRequest {
+  string channel = 1;
+  string user = 2;
+  int64 expire_at = 3;
+  bytes info = 4;
+  string b64info = 5;
+  string client = 6;
+  bytes data = 7;
+  string b64data = 8;
+  StreamPosition recover_since = 9;
+  SubscribeOptionOverride override = 10;
+  string session = 11;
+}
+
+message SubscribeResponse {
+  Error error = 1;
+  SubscribeResult result = 2;
+}
+
+message SubscribeResult {}
+
+message UnsubscribeRequest {
+  string channel = 1;
+  string user = 2;
+  string client = 3;
+  string session = 4;
+}
+
+message UnsubscribeResponse {
+  Error error = 1;
+  UnsubscribeResult result = 2;
+}
+
+message UnsubscribeResult {}
+
+message Disconnect {
+  uint32 code = 1;
+  string reason = 2;
+  bool reconnect = 3;
+}
+
+message DisconnectRequest {
+  string user = 1;
+  Disconnect disconnect = 2;
+  string client = 3;
+  repeated string whitelist = 4;
+  string session = 5;
+}
+
+message DisconnectResponse {
+  Error error = 1;
+  DisconnectResult result = 2;
+}
+
+message DisconnectResult {}
+
+message PresenceRequest {
+  string channel = 1;
+}
+
+message PresenceResponse {
+  Error error = 1;
+  PresenceResult result = 2;
+}
+
+message ClientInfo {
+  string user = 1;
+  string client = 2;
+  bytes conn_info = 3;
+  bytes chan_info = 4;
+}
+
+message PresenceResult {
+  map<string, ClientInfo> presence = 1;
+}
+
+message PresenceStatsRequest {
+  string channel = 1;
+}
+
+message PresenceStatsResponse {
+  Error error = 1;
+  PresenceStatsResult result = 2;
+}
+
+message PresenceStatsResult {
+  uint32 num_clients = 1;
+  uint32 num_users = 2;
+}
+
+message StreamPosition {
+  uint64 offset = 1;
+  string epoch = 2;
+}
+
+message HistoryRequest {
+  string channel = 1;
+  int32 limit = 2;
+  StreamPosition since = 3;
+  bool reverse = 4;
+}
+
+message HistoryResponse {
+  Error error = 1;
+  HistoryResult result = 2;
+}
+
+message Publication {
+  // Removed: string uid = 1;
+  bytes data = 2;
+  ClientInfo info = 3;
+  uint64 offset = 4;
+  map<string, string> tags = 5;
+}
+
+message HistoryResult {
+  repeated Publication publications = 1;
+  string epoch = 2;
+  uint64 offset = 3;
+}
+
+message HistoryRemoveRequest {
+  string channel = 1;
+}
+
+message HistoryRemoveResponse {
+  Error error = 1;
+  HistoryRemoveResult result = 2;
+}
+
+message HistoryRemoveResult {}
+
+message InfoRequest {}
+
+message InfoResponse {
+  Error error = 1;
+  InfoResult result = 2;
+}
+
+message InfoResult {
+  repeated NodeResult nodes = 1;
+}
+
+message RPCRequest {
+  string method = 1;
+  bytes params = 2;
+}
+
+message RPCResponse {
+  Error error = 1;
+  RPCResult result = 2;
+}
+
+message RPCResult {
+  bytes data = 1;
+}
+
+message RefreshRequest {
+  string user = 1;
+  string client = 2;
+  bool expired = 3;
+  int64 expire_at = 4;
+  bytes info = 5;
+  string session = 6;
+}
+
+message RefreshResponse {
+  Error error = 1;
+  RefreshResult result = 2;
+}
+
+message RefreshResult {}
+
+message NodeResult {
+  string uid = 1;
+  string name = 2;
+  string version = 3;
+  uint32 num_clients = 4;
+  uint32 num_users = 5;
+  uint32 num_channels = 6;
+  uint32 uptime = 7;
+  Metrics metrics = 8;
+  Process process = 9;
+  uint32 num_subs = 10;
+}
+
+message Metrics {
+  double interval = 1;
+  map<string, double> items = 2;
+}
+
+message Process {
+  double cpu = 1;
+  int64 rss = 2;
+}
+
+message ChannelsRequest {
+  string pattern = 1;
+}
+
+message ChannelsResponse {
+  Error error = 1;
+  ChannelsResult result = 2;
+}
+
+message ChannelsResult {
+  map<string, ChannelInfo> channels = 1;
+}
+
+message ChannelInfo {
+  uint32 num_clients = 1;
+}
+
+message ConnectionsRequest {
+  string user = 1;
+  string expression = 2;
+}
+
+message ConnectionsResponse {
+  Error error = 1;
+  ConnectionsResult result = 2;
+}
+
+message ConnectionsResult {
+  map<string, ConnectionInfo> connections = 1;
+}
+
+message ConnectionInfo {
+  string app_name = 1;
+  string app_version = 2;
+  string transport = 3;
+  string protocol = 4;
+  // 5-7 dropped for backwards compatibility.
+  string user = 8;
+  ConnectionState state = 9;
+}
+
+message ConnectionState {
+  map<string, ChannelContext> channels = 1;
+  ConnectionTokenInfo connection_token = 2;
+  map<string, SubscriptionTokenInfo> subscription_tokens = 3;
+  bytes meta = 4;
+}
+
+message ChannelContext {
+  uint32 source = 1;
+}
+
+message ConnectionTokenInfo {
+  string uid = 1;
+  int64 issued_at = 2;
+}
+
+message SubscriptionTokenInfo {
+  string uid = 1;
+  int64 issued_at = 2;
+}
+
+message UpdateUserStatusRequest {
+  repeated string users = 1;
+}
+
+message UpdateUserStatusResponse {
+  Error error = 1;
+  UpdateUserStatusResult result = 2;
+}
+
+message UpdateUserStatusResult {}
+
+message GetUserStatusRequest {
+  repeated string users = 1;
+}
+
+message GetUserStatusResponse {
+  Error error = 1;
+  GetUserStatusResult result = 2;
+}
+
+message GetUserStatusResult {
+  repeated UserStatus statuses = 1;
+}
+
+message UserStatus {
+  string user = 1;
+  int64 active = 2;
+  int64 online = 3;
+}
+
+message DeleteUserStatusRequest {
+  repeated string users = 1;
+}
+
+message DeleteUserStatusResponse {
+  Error error = 1;
+  DeleteUserStatusResult result = 2;
+}
+
+message DeleteUserStatusResult {
+}
+
+message BlockUserRequest {
+  int64 expire_at = 1;
+  string user = 2;
+}
+
+message BlockUserResult {}
+
+message BlockUserResponse {
+  Error error = 1;
+  BlockUserResult result = 2;
+}
+
+message UnblockUserRequest {
+  string user = 1;
+}
+
+message UnblockUserResult {}
+
+message UnblockUserResponse {
+  Error error = 1;
+  UnblockUserResult result = 2;
+}
+
+message RevokeTokenRequest {
+  int64 expire_at = 1;
+  string uid = 2;
+}
+
+message RevokeTokenResult {}
+
+message RevokeTokenResponse {
+  Error error = 1;
+  RevokeTokenResult result = 2;
+}
+
+message InvalidateUserTokensRequest {
+  int64 expire_at = 1;
+  string user = 2;
+  int64 issued_before = 3;
+  string channel = 4;
+}
+
+message InvalidateUserTokensResult {}
+
+message InvalidateUserTokensResponse {
+  Error error = 1;
+  InvalidateUserTokensResult result = 2;
+}
+
+message DeviceRegisterRequest {
+  string id = 1;
+  string provider = 2;
+  string token = 3;
+  string platform = 4;
+  string user = 5;
+  map<string, string> meta = 6;
+  map<string, string> tags = 7;
+  repeated string channels = 8;
+}
+
+message DeviceUpdateRequest {
+  repeated string ids = 1;
+  repeated string users = 2;
+  repeated DeviceProviderTokens provider_tokens = 3;
+
+  DeviceUserUpdate user_update = 4;
+  DeviceMetaUpdate meta_update = 5;
+  DeviceTagsUpdate tags_update = 6;
+  DeviceChannelsUpdate channels_update = 7;
+}
+
+message DeviceRemoveRequest {
+  repeated string ids = 1;
+  repeated string users = 2;
+  repeated DeviceProviderTokens provider_tokens = 3;
+}
+
+message DeviceUserUpdate {
+  string user = 1;
+}
+
+message DeviceMetaUpdate {
+  map<string, string> meta = 1;
+}
+
+message DeviceChannelsUpdate {
+  string op = 1; // add | remove | set
+  repeated string channels = 2;
+}
+
+message DeviceTagsUpdate {
+  string op = 1; // add | remove | set
+  map<string, string> tags = 2;
+}
+
+message DeviceProviderTokens {
+  string provider = 1;
+  repeated string tokens = 2;
+}
+
+message DeviceListRequest {
+  repeated string ids = 1;
+  repeated string providers = 2;
+  repeated DeviceProviderTokens provider_tokens= 3;
+  repeated string platforms = 4;
+  repeated string users = 5;
+  repeated string channels = 6;
+  string since = 7;
+  int32 limit = 8;
+  bool include_channels = 10;
+  bool include_meta = 11;
+  bool include_tags = 12;
+}
+
+message DeviceChannelListRequest {
+  repeated string device_ids = 1;
+  repeated string device_providers = 2;
+  repeated DeviceProviderTokens device_provider_tokens= 3;
+  repeated string device_platforms = 4;
+  repeated string device_users = 5;
+  repeated string channels = 6;
+  string since = 8;
+  int32 limit = 9;
+  bool include_device = 10;
+}
+
+message PushUserChannelListRequest {
+  repeated string users = 1;
+  repeated string channels = 2;
+  string since = 3;
+  int32 limit = 4;
+}
+
+message PushUserChannelUpdateRequest {
+  string user = 1;
+  string op = 2; // add | remove | set
+  repeated string channels = 3;
+}
+
+message DeviceRegisterResponse {
+  Error error = 1;
+  DeviceRegisterResult result = 2;
+}
+
+message DeviceUpdateResponse {
+  Error error = 1;
+  DeviceUpdateResult result = 2;
+}
+
+message DeviceRemoveResponse {
+  Error error = 1;
+  DeviceRemoveResult result = 2;
+}
+
+message DeviceListResponse {
+  Error error = 1;
+  DeviceListResult result = 2;
+}
+
+message DeviceChannelListResponse {
+  Error error = 1;
+  DeviceChannelListResult result = 2;
+}
+
+message PushUserChannelListResponse {
+  Error error = 1;
+  PushUserChannelListResult result = 2;
+}
+
+message PushUserChannelUpdateResponse {
+  Error error = 1;
+  PushUserChannelUpdateResult result = 2;
+}
+
+message DeviceRegisterResult {
+  Device device = 1;
+}
+
+message DeviceUpdateResult {
+}
+
+message DeviceRemoveResult {
+}
+
+message DeviceListResult {
+  repeated Device items = 1;
+  bool has_more = 2;
+}
+
+message Device {
+  string id = 1;
+  string platform = 2;
+  string provider = 3;
+  string token = 4;
+  string user = 5;
+
+  map<string, string> meta = 6;
+  repeated string channels = 7;
+  map<string, string> tags = 8;
+}
+
+message DeviceChannelListResult {
+  repeated DeviceChannel items = 1;
+  bool has_more = 2;
+}
+
+message DeviceChannel {
+  string id = 1;
+  string channel = 2;
+  Device device = 3;
+}
+
+message PushUserChannelListResult {
+  repeated PushUserChannel items = 1;
+  bool has_more = 2;
+}
+
+message PushUserChannelUpdateResult {
+}
+
+message PushUserChannel {
+  string id = 1;
+  string user = 2;
+  string channel = 3;
+}
+
+message DeviceTagListResult {
+  repeated DeviceTag items = 1;
+  bool has_more = 2;
+}
+
+message DeviceTag {
+  string id = 1;
+  string key = 2;
+  string value = 3;
+  Device device = 4;
+}
+
+message PushRecipient {
+  repeated string device_ids = 1;
+  repeated string channels = 2;
+
+  repeated string fcm_tokens = 3;
+  string fcm_topic = 4;
+  string fcm_condition = 5;
+
+  repeated string hms_tokens = 6;
+  string hms_topic = 7;
+  string hms_condition = 8;
+
+  repeated string apns_tokens = 9;
+}
+
+message PushNotification {
+  FcmPushNotification fcm = 1;
+  HmsPushNotification hms = 2;
+  ApnsPushNotification apns = 3;
+
+  string uid = 4;
+  int64 expire_at = 5;
+}
+
+message FcmPushNotification {
+  bytes message = 1;
+}
+
+message HmsPushNotification {
+  bytes message = 1;
+}
+
+message ApnsPushNotification {
+  map<string, string> headers = 1;
+  bytes payload = 2;
+}
+
+message SendPushNotificationRequest {
+  PushRecipient recipient = 1;
+  PushNotification notification = 2;
+}
+
+message SendPushNotificationResponse {
+  Error error = 1;
+  SendPushNotificationResult result = 2;
+}
+
+message SendPushNotificationResult {
+  string uid = 1; // Unique identifier of notification send request (not a FCM message id).
+}

--- a/internal/apiproto/api.swagger.proto
+++ b/internal/apiproto/api.swagger.proto
@@ -76,7 +76,7 @@ option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
       value: {
         type: TYPE_API_KEY;
         in: IN_HEADER;
-        name: "Authorization";
+        name: "X-API-Key";
       }
     }
   }

--- a/internal/apiproto/generate_swagger.sh
+++ b/internal/apiproto/generate_swagger.sh
@@ -4,7 +4,7 @@ set -e
 
 #go install github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2@latest
 
-protoc --openapiv2_out=disable_default_errors=true,disable_service_tags=true,openapi_naming_strategy=fqn,json_names_for_fields=false,allow_merge=true,merge_file_name=api:. ./api.swagger.proto
+protoc --openapiv2_out=disable_default_errors=true,disable_service_tags=true,openapi_naming_strategy=simple,json_names_for_fields=false,allow_merge=true,merge_file_name=api:. ./api.swagger.proto
 
 search='(:\s+{\s+"type":\s)"string",\s+"format":\s"byte"'
 replace='\1"object"'

--- a/internal/apiproto/generate_swagger.sh
+++ b/internal/apiproto/generate_swagger.sh
@@ -2,14 +2,11 @@
 
 set -e
 
-# go install \
-#        github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway \
-#        github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger \
-#        github.com/golang/protobuf/protoc-gen-go
+#go install github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway@latest
+#go install github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger@latest
 
+protoc --swagger_out=allow_merge=true,merge_file_name=api:. ./api.swagger.proto
 
-protoc --swagger_out=allow_merge=true,merge_file_name=api:. ./api.proto
-#search='"data":[ \t\n]*{[ \t\n]*"type": "string",[ \t\n]*"format": "byte"[ \t\n]*}'
 search='("data":\s+{\s+"type":\s)"string",\s+"format":\s"byte"'
 replace='\1"object"'
 

--- a/internal/apiproto/generate_swagger.sh
+++ b/internal/apiproto/generate_swagger.sh
@@ -5,9 +5,9 @@ set -e
 #go install github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway@latest
 #go install github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2@latest
 
-protoc --openapiv2_out=allow_merge=true,merge_file_name=api:. ./api.swagger.proto
+protoc --openapiv2_out=json_names_for_fields=false,allow_merge=true,merge_file_name=api:. ./api.swagger.proto
 
-search='("data":\s+{\s+"type":\s)"string",\s+"format":\s"byte"'
+search='(:\s+{\s+"type":\s)"string",\s+"format":\s"byte"'
 replace='\1"object"'
 
 python - << EOF
@@ -25,6 +25,31 @@ def replace(filePath, text, subs, flags=0):
         file.write(file_contents)
 
     
+file_path="api.swagger.json"
+text=r'$search'
+subs=r'$replace'
+#calling the replace method
+replace(file_path, text, subs, flags=re.MULTILINE | re.DOTALL)
+EOF
+
+search='(:\s+{\s+"type":\s)"string",\s+"format":\s"uint64"'
+replace='\1"integer"'
+
+python - << EOF
+import re
+
+#defining the replace method
+def replace(filePath, text, subs, flags=0):
+    with open(file_path, "r+") as file:
+        #read the file contents
+        file_contents = file.read()
+        text_pattern = re.compile(text, flags)
+        file_contents = text_pattern.sub(subs, file_contents)
+        file.seek(0)
+        file.truncate()
+        file.write(file_contents)
+
+
 file_path="api.swagger.json"
 text=r'$search'
 subs=r'$replace'

--- a/internal/apiproto/generate_swagger.sh
+++ b/internal/apiproto/generate_swagger.sh
@@ -10,9 +10,6 @@ protoc --openapiv2_out=allow_merge=true,merge_file_name=api:. ./api.swagger.prot
 search='("data":\s+{\s+"type":\s)"string",\s+"format":\s"byte"'
 replace='\1"object"'
 
-echo $search
-echo $replace
-
 python - << EOF
 import re
 

--- a/internal/apiproto/generate_swagger.sh
+++ b/internal/apiproto/generate_swagger.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+set -e
+
+# go install \
+#        github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway \
+#        github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger \
+#        github.com/golang/protobuf/protoc-gen-go
+
+
+protoc --swagger_out=allow_merge=true,merge_file_name=api:. ./api.proto
+#search='"data":[ \t\n]*{[ \t\n]*"type": "string",[ \t\n]*"format": "byte"[ \t\n]*}'
+search='("data":\s+{\s+"type":\s)"string",\s+"format":\s"byte"'
+replace='\1"object"'
+
+echo $search
+echo $replace
+
+python - << EOF
+import re
+
+#defining the replace method
+def replace(filePath, text, subs, flags=0):
+    with open(file_path, "r+") as file:
+        #read the file contents
+        file_contents = file.read()
+        text_pattern = re.compile(text, flags)
+        file_contents = text_pattern.sub(subs, file_contents)
+        file.seek(0)
+        file.truncate()
+        file.write(file_contents)
+
+    
+file_path="api.swagger.json"
+text=r'$search'
+subs=r'$replace'
+#calling the replace method
+replace(file_path, text, subs, flags=re.MULTILINE | re.DOTALL)
+EOF

--- a/internal/apiproto/generate_swagger.sh
+++ b/internal/apiproto/generate_swagger.sh
@@ -3,9 +3,9 @@
 set -e
 
 #go install github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway@latest
-#go install github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger@latest
+#go install github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2@latest
 
-protoc --swagger_out=allow_merge=true,merge_file_name=api:. ./api.swagger.proto
+protoc --openapiv2_out=allow_merge=true,merge_file_name=api:. ./api.swagger.proto
 
 search='("data":\s+{\s+"type":\s)"string",\s+"format":\s"byte"'
 replace='\1"object"'

--- a/internal/apiproto/generate_swagger.sh
+++ b/internal/apiproto/generate_swagger.sh
@@ -2,7 +2,6 @@
 
 set -e
 
-#go install github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway@latest
 #go install github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2@latest
 
 protoc --openapiv2_out=json_names_for_fields=false,allow_merge=true,merge_file_name=api:. ./api.swagger.proto

--- a/internal/apiproto/generate_swagger.sh
+++ b/internal/apiproto/generate_swagger.sh
@@ -4,7 +4,7 @@ set -e
 
 #go install github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2@latest
 
-protoc --openapiv2_out=json_names_for_fields=false,allow_merge=true,merge_file_name=api:. ./api.swagger.proto
+protoc --openapiv2_out=disable_default_errors=true,disable_service_tags=true,openapi_naming_strategy=fqn,json_names_for_fields=false,allow_merge=true,merge_file_name=api:. ./api.swagger.proto
 
 search='(:\s+{\s+"type":\s)"string",\s+"format":\s"byte"'
 replace='\1"object"'
@@ -32,6 +32,31 @@ replace(file_path, text, subs, flags=re.MULTILINE | re.DOTALL)
 EOF
 
 search='(:\s+{\s+"type":\s)"string",\s+"format":\s"uint64"'
+replace='\1"integer"'
+
+python - << EOF
+import re
+
+#defining the replace method
+def replace(filePath, text, subs, flags=0):
+    with open(file_path, "r+") as file:
+        #read the file contents
+        file_contents = file.read()
+        text_pattern = re.compile(text, flags)
+        file_contents = text_pattern.sub(subs, file_contents)
+        file.seek(0)
+        file.truncate()
+        file.write(file_contents)
+
+
+file_path="api.swagger.json"
+text=r'$search'
+subs=r'$replace'
+#calling the replace method
+replace(file_path, text, subs, flags=re.MULTILINE | re.DOTALL)
+EOF
+
+search='(:\s+{\s+"type":\s)"string",\s+"format":\s"int64"'
 replace='\1"integer"'
 
 python - << EOF

--- a/internal/apiproto/google/api/annotations.proto
+++ b/internal/apiproto/google/api/annotations.proto
@@ -1,0 +1,31 @@
+// Copyright 2015 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package google.api;
+
+import "google/api/http.proto";
+import "google/protobuf/descriptor.proto";
+
+option go_package = "google.golang.org/genproto/googleapis/api/annotations;annotations";
+option java_multiple_files = true;
+option java_outer_classname = "AnnotationsProto";
+option java_package = "com.google.api";
+option objc_class_prefix = "GAPI";
+
+extend google.protobuf.MethodOptions {
+  // See `HttpRule`.
+  HttpRule http = 72295728;
+}

--- a/internal/apiproto/google/api/http.proto
+++ b/internal/apiproto/google/api/http.proto
@@ -1,0 +1,375 @@
+// Copyright 2015 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package google.api;
+
+option cc_enable_arenas = true;
+option go_package = "google.golang.org/genproto/googleapis/api/annotations;annotations";
+option java_multiple_files = true;
+option java_outer_classname = "HttpProto";
+option java_package = "com.google.api";
+option objc_class_prefix = "GAPI";
+
+// Defines the HTTP configuration for an API service. It contains a list of
+// [HttpRule][google.api.HttpRule], each specifying the mapping of an RPC method
+// to one or more HTTP REST API methods.
+message Http {
+  // A list of HTTP configuration rules that apply to individual API methods.
+  //
+  // **NOTE:** All service configuration rules follow "last one wins" order.
+  repeated HttpRule rules = 1;
+
+  // When set to true, URL path parameters will be fully URI-decoded except in
+  // cases of single segment matches in reserved expansion, where "%2F" will be
+  // left encoded.
+  //
+  // The default behavior is to not decode RFC 6570 reserved characters in multi
+  // segment matches.
+  bool fully_decode_reserved_expansion = 2;
+}
+
+// # gRPC Transcoding
+//
+// gRPC Transcoding is a feature for mapping between a gRPC method and one or
+// more HTTP REST endpoints. It allows developers to build a single API service
+// that supports both gRPC APIs and REST APIs. Many systems, including [Google
+// APIs](https://github.com/googleapis/googleapis),
+// [Cloud Endpoints](https://cloud.google.com/endpoints), [gRPC
+// Gateway](https://github.com/grpc-ecosystem/grpc-gateway),
+// and [Envoy](https://github.com/envoyproxy/envoy) proxy support this feature
+// and use it for large scale production services.
+//
+// `HttpRule` defines the schema of the gRPC/REST mapping. The mapping specifies
+// how different portions of the gRPC request message are mapped to the URL
+// path, URL query parameters, and HTTP request body. It also controls how the
+// gRPC response message is mapped to the HTTP response body. `HttpRule` is
+// typically specified as an `google.api.http` annotation on the gRPC method.
+//
+// Each mapping specifies a URL path template and an HTTP method. The path
+// template may refer to one or more fields in the gRPC request message, as long
+// as each field is a non-repeated field with a primitive (non-message) type.
+// The path template controls how fields of the request message are mapped to
+// the URL path.
+//
+// Example:
+//
+//     service Messaging {
+//       rpc GetMessage(GetMessageRequest) returns (Message) {
+//         option (google.api.http) = {
+//             get: "/v1/{name=messages/*}"
+//         };
+//       }
+//     }
+//     message GetMessageRequest {
+//       string name = 1; // Mapped to URL path.
+//     }
+//     message Message {
+//       string text = 1; // The resource content.
+//     }
+//
+// This enables an HTTP REST to gRPC mapping as below:
+//
+// HTTP | gRPC
+// -----|-----
+// `GET /v1/messages/123456`  | `GetMessage(name: "messages/123456")`
+//
+// Any fields in the request message which are not bound by the path template
+// automatically become HTTP query parameters if there is no HTTP request body.
+// For example:
+//
+//     service Messaging {
+//       rpc GetMessage(GetMessageRequest) returns (Message) {
+//         option (google.api.http) = {
+//             get:"/v1/messages/{message_id}"
+//         };
+//       }
+//     }
+//     message GetMessageRequest {
+//       message SubMessage {
+//         string subfield = 1;
+//       }
+//       string message_id = 1; // Mapped to URL path.
+//       int64 revision = 2;    // Mapped to URL query parameter `revision`.
+//       SubMessage sub = 3;    // Mapped to URL query parameter `sub.subfield`.
+//     }
+//
+// This enables a HTTP JSON to RPC mapping as below:
+//
+// HTTP | gRPC
+// -----|-----
+// `GET /v1/messages/123456?revision=2&sub.subfield=foo` |
+// `GetMessage(message_id: "123456" revision: 2 sub: SubMessage(subfield:
+// "foo"))`
+//
+// Note that fields which are mapped to URL query parameters must have a
+// primitive type or a repeated primitive type or a non-repeated message type.
+// In the case of a repeated type, the parameter can be repeated in the URL
+// as `...?param=A&param=B`. In the case of a message type, each field of the
+// message is mapped to a separate parameter, such as
+// `...?foo.a=A&foo.b=B&foo.c=C`.
+//
+// For HTTP methods that allow a request body, the `body` field
+// specifies the mapping. Consider a REST update method on the
+// message resource collection:
+//
+//     service Messaging {
+//       rpc UpdateMessage(UpdateMessageRequest) returns (Message) {
+//         option (google.api.http) = {
+//           patch: "/v1/messages/{message_id}"
+//           body: "message"
+//         };
+//       }
+//     }
+//     message UpdateMessageRequest {
+//       string message_id = 1; // mapped to the URL
+//       Message message = 2;   // mapped to the body
+//     }
+//
+// The following HTTP JSON to RPC mapping is enabled, where the
+// representation of the JSON in the request body is determined by
+// protos JSON encoding:
+//
+// HTTP | gRPC
+// -----|-----
+// `PATCH /v1/messages/123456 { "text": "Hi!" }` | `UpdateMessage(message_id:
+// "123456" message { text: "Hi!" })`
+//
+// The special name `*` can be used in the body mapping to define that
+// every field not bound by the path template should be mapped to the
+// request body.  This enables the following alternative definition of
+// the update method:
+//
+//     service Messaging {
+//       rpc UpdateMessage(Message) returns (Message) {
+//         option (google.api.http) = {
+//           patch: "/v1/messages/{message_id}"
+//           body: "*"
+//         };
+//       }
+//     }
+//     message Message {
+//       string message_id = 1;
+//       string text = 2;
+//     }
+//
+//
+// The following HTTP JSON to RPC mapping is enabled:
+//
+// HTTP | gRPC
+// -----|-----
+// `PATCH /v1/messages/123456 { "text": "Hi!" }` | `UpdateMessage(message_id:
+// "123456" text: "Hi!")`
+//
+// Note that when using `*` in the body mapping, it is not possible to
+// have HTTP parameters, as all fields not bound by the path end in
+// the body. This makes this option more rarely used in practice when
+// defining REST APIs. The common usage of `*` is in custom methods
+// which don't use the URL at all for transferring data.
+//
+// It is possible to define multiple HTTP methods for one RPC by using
+// the `additional_bindings` option. Example:
+//
+//     service Messaging {
+//       rpc GetMessage(GetMessageRequest) returns (Message) {
+//         option (google.api.http) = {
+//           get: "/v1/messages/{message_id}"
+//           additional_bindings {
+//             get: "/v1/users/{user_id}/messages/{message_id}"
+//           }
+//         };
+//       }
+//     }
+//     message GetMessageRequest {
+//       string message_id = 1;
+//       string user_id = 2;
+//     }
+//
+// This enables the following two alternative HTTP JSON to RPC mappings:
+//
+// HTTP | gRPC
+// -----|-----
+// `GET /v1/messages/123456` | `GetMessage(message_id: "123456")`
+// `GET /v1/users/me/messages/123456` | `GetMessage(user_id: "me" message_id:
+// "123456")`
+//
+// ## Rules for HTTP mapping
+//
+// 1. Leaf request fields (recursive expansion nested messages in the request
+//    message) are classified into three categories:
+//    - Fields referred by the path template. They are passed via the URL path.
+//    - Fields referred by the [HttpRule.body][google.api.HttpRule.body]. They are passed via the HTTP
+//      request body.
+//    - All other fields are passed via the URL query parameters, and the
+//      parameter name is the field path in the request message. A repeated
+//      field can be represented as multiple query parameters under the same
+//      name.
+//  2. If [HttpRule.body][google.api.HttpRule.body] is "*", there is no URL query parameter, all fields
+//     are passed via URL path and HTTP request body.
+//  3. If [HttpRule.body][google.api.HttpRule.body] is omitted, there is no HTTP request body, all
+//     fields are passed via URL path and URL query parameters.
+//
+// ### Path template syntax
+//
+//     Template = "/" Segments [ Verb ] ;
+//     Segments = Segment { "/" Segment } ;
+//     Segment  = "*" | "**" | LITERAL | Variable ;
+//     Variable = "{" FieldPath [ "=" Segments ] "}" ;
+//     FieldPath = IDENT { "." IDENT } ;
+//     Verb     = ":" LITERAL ;
+//
+// The syntax `*` matches a single URL path segment. The syntax `**` matches
+// zero or more URL path segments, which must be the last part of the URL path
+// except the `Verb`.
+//
+// The syntax `Variable` matches part of the URL path as specified by its
+// template. A variable template must not contain other variables. If a variable
+// matches a single path segment, its template may be omitted, e.g. `{var}`
+// is equivalent to `{var=*}`.
+//
+// The syntax `LITERAL` matches literal text in the URL path. If the `LITERAL`
+// contains any reserved character, such characters should be percent-encoded
+// before the matching.
+//
+// If a variable contains exactly one path segment, such as `"{var}"` or
+// `"{var=*}"`, when such a variable is expanded into a URL path on the client
+// side, all characters except `[-_.~0-9a-zA-Z]` are percent-encoded. The
+// server side does the reverse decoding. Such variables show up in the
+// [Discovery
+// Document](https://developers.google.com/discovery/v1/reference/apis) as
+// `{var}`.
+//
+// If a variable contains multiple path segments, such as `"{var=foo/*}"`
+// or `"{var=**}"`, when such a variable is expanded into a URL path on the
+// client side, all characters except `[-_.~/0-9a-zA-Z]` are percent-encoded.
+// The server side does the reverse decoding, except "%2F" and "%2f" are left
+// unchanged. Such variables show up in the
+// [Discovery
+// Document](https://developers.google.com/discovery/v1/reference/apis) as
+// `{+var}`.
+//
+// ## Using gRPC API Service Configuration
+//
+// gRPC API Service Configuration (service config) is a configuration language
+// for configuring a gRPC service to become a user-facing product. The
+// service config is simply the YAML representation of the `google.api.Service`
+// proto message.
+//
+// As an alternative to annotating your proto file, you can configure gRPC
+// transcoding in your service config YAML files. You do this by specifying a
+// `HttpRule` that maps the gRPC method to a REST endpoint, achieving the same
+// effect as the proto annotation. This can be particularly useful if you
+// have a proto that is reused in multiple services. Note that any transcoding
+// specified in the service config will override any matching transcoding
+// configuration in the proto.
+//
+// Example:
+//
+//     http:
+//       rules:
+//         # Selects a gRPC method and applies HttpRule to it.
+//         - selector: example.v1.Messaging.GetMessage
+//           get: /v1/messages/{message_id}/{sub.subfield}
+//
+// ## Special notes
+//
+// When gRPC Transcoding is used to map a gRPC to JSON REST endpoints, the
+// proto to JSON conversion must follow the [proto3
+// specification](https://developers.google.com/protocol-buffers/docs/proto3#json).
+//
+// While the single segment variable follows the semantics of
+// [RFC 6570](https://tools.ietf.org/html/rfc6570) Section 3.2.2 Simple String
+// Expansion, the multi segment variable **does not** follow RFC 6570 Section
+// 3.2.3 Reserved Expansion. The reason is that the Reserved Expansion
+// does not expand special characters like `?` and `#`, which would lead
+// to invalid URLs. As the result, gRPC Transcoding uses a custom encoding
+// for multi segment variables.
+//
+// The path variables **must not** refer to any repeated or mapped field,
+// because client libraries are not capable of handling such variable expansion.
+//
+// The path variables **must not** capture the leading "/" character. The reason
+// is that the most common use case "{var}" does not capture the leading "/"
+// character. For consistency, all path variables must share the same behavior.
+//
+// Repeated message fields must not be mapped to URL query parameters, because
+// no client library can support such complicated mapping.
+//
+// If an API needs to use a JSON array for request or response body, it can map
+// the request or response body to a repeated field. However, some gRPC
+// Transcoding implementations may not support this feature.
+message HttpRule {
+  // Selects a method to which this rule applies.
+  //
+  // Refer to [selector][google.api.DocumentationRule.selector] for syntax details.
+  string selector = 1;
+
+  // Determines the URL pattern is matched by this rules. This pattern can be
+  // used with any of the {get|put|post|delete|patch} methods. A custom method
+  // can be defined using the 'custom' field.
+  oneof pattern {
+    // Maps to HTTP GET. Used for listing and getting information about
+    // resources.
+    string get = 2;
+
+    // Maps to HTTP PUT. Used for replacing a resource.
+    string put = 3;
+
+    // Maps to HTTP POST. Used for creating a resource or performing an action.
+    string post = 4;
+
+    // Maps to HTTP DELETE. Used for deleting a resource.
+    string delete = 5;
+
+    // Maps to HTTP PATCH. Used for updating a resource.
+    string patch = 6;
+
+    // The custom pattern is used for specifying an HTTP method that is not
+    // included in the `pattern` field, such as HEAD, or "*" to leave the
+    // HTTP method unspecified for this rule. The wild-card rule is useful
+    // for services that provide content to Web (HTML) clients.
+    CustomHttpPattern custom = 8;
+  }
+
+  // The name of the request field whose value is mapped to the HTTP request
+  // body, or `*` for mapping all request fields not captured by the path
+  // pattern to the HTTP body, or omitted for not having any HTTP request body.
+  //
+  // NOTE: the referred field must be present at the top-level of the request
+  // message type.
+  string body = 7;
+
+  // Optional. The name of the response field whose value is mapped to the HTTP
+  // response body. When omitted, the entire response message will be used
+  // as the HTTP response body.
+  //
+  // NOTE: The referred field must be present at the top-level of the response
+  // message type.
+  string response_body = 12;
+
+  // Additional HTTP bindings for the selector. Nested bindings must
+  // not contain an `additional_bindings` field themselves (that is,
+  // the nesting may only be one level deep).
+  repeated HttpRule additional_bindings = 11;
+}
+
+// A custom pattern is used for defining custom HTTP verb.
+message CustomHttpPattern {
+  // The name of this custom HTTP verb.
+  string kind = 1;
+
+  // The path matched by this custom verb.
+  string path = 2;
+}

--- a/internal/apiproto/protoc-gen-openapiv2/options/annotations.proto
+++ b/internal/apiproto/protoc-gen-openapiv2/options/annotations.proto
@@ -1,0 +1,44 @@
+syntax = "proto3";
+
+package grpc.gateway.protoc_gen_openapiv2.options;
+
+import "google/protobuf/descriptor.proto";
+import "protoc-gen-openapiv2/options/openapiv2.proto";
+
+option go_package = "github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2/options";
+
+extend google.protobuf.FileOptions {
+  // ID assigned by protobuf-global-extension-registry@google.com for gRPC-Gateway project.
+  //
+  // All IDs are the same, as assigned. It is okay that they are the same, as they extend
+  // different descriptor messages.
+  Swagger openapiv2_swagger = 1042;
+}
+extend google.protobuf.MethodOptions {
+  // ID assigned by protobuf-global-extension-registry@google.com for gRPC-Gateway project.
+  //
+  // All IDs are the same, as assigned. It is okay that they are the same, as they extend
+  // different descriptor messages.
+  Operation openapiv2_operation = 1042;
+}
+extend google.protobuf.MessageOptions {
+  // ID assigned by protobuf-global-extension-registry@google.com for gRPC-Gateway project.
+  //
+  // All IDs are the same, as assigned. It is okay that they are the same, as they extend
+  // different descriptor messages.
+  Schema openapiv2_schema = 1042;
+}
+extend google.protobuf.ServiceOptions {
+  // ID assigned by protobuf-global-extension-registry@google.com for gRPC-Gateway project.
+  //
+  // All IDs are the same, as assigned. It is okay that they are the same, as they extend
+  // different descriptor messages.
+  Tag openapiv2_tag = 1042;
+}
+extend google.protobuf.FieldOptions {
+  // ID assigned by protobuf-global-extension-registry@google.com for gRPC-Gateway project.
+  //
+  // All IDs are the same, as assigned. It is okay that they are the same, as they extend
+  // different descriptor messages.
+  JSONSchema openapiv2_field = 1042;
+}

--- a/internal/apiproto/protoc-gen-openapiv2/options/openapiv2.proto
+++ b/internal/apiproto/protoc-gen-openapiv2/options/openapiv2.proto
@@ -1,0 +1,720 @@
+syntax = "proto3";
+
+package grpc.gateway.protoc_gen_openapiv2.options;
+
+import "google/protobuf/struct.proto";
+
+option go_package = "github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2/options";
+
+// Scheme describes the schemes supported by the OpenAPI Swagger
+// and Operation objects.
+enum Scheme {
+  UNKNOWN = 0;
+  HTTP = 1;
+  HTTPS = 2;
+  WS = 3;
+  WSS = 4;
+}
+
+// `Swagger` is a representation of OpenAPI v2 specification's Swagger object.
+//
+// See: https://github.com/OAI/OpenAPI-Specification/blob/3.0.0/versions/2.0.md#swaggerObject
+//
+// Example:
+//
+//  option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
+//    info: {
+//      title: "Echo API";
+//      version: "1.0";
+//      description: "";
+//      contact: {
+//        name: "gRPC-Gateway project";
+//        url: "https://github.com/grpc-ecosystem/grpc-gateway";
+//        email: "none@example.com";
+//      };
+//      license: {
+//        name: "BSD 3-Clause License";
+//        url: "https://github.com/grpc-ecosystem/grpc-gateway/blob/main/LICENSE.txt";
+//      };
+//    };
+//    schemes: HTTPS;
+//    consumes: "application/json";
+//    produces: "application/json";
+//  };
+//
+message Swagger {
+  // Specifies the OpenAPI Specification version being used. It can be
+  // used by the OpenAPI UI and other clients to interpret the API listing. The
+  // value MUST be "2.0".
+  string swagger = 1;
+  // Provides metadata about the API. The metadata can be used by the
+  // clients if needed.
+  Info info = 2;
+  // The host (name or ip) serving the API. This MUST be the host only and does
+  // not include the scheme nor sub-paths. It MAY include a port. If the host is
+  // not included, the host serving the documentation is to be used (including
+  // the port). The host does not support path templating.
+  string host = 3;
+  // The base path on which the API is served, which is relative to the host. If
+  // it is not included, the API is served directly under the host. The value
+  // MUST start with a leading slash (/). The basePath does not support path
+  // templating.
+  // Note that using `base_path` does not change the endpoint paths that are
+  // generated in the resulting OpenAPI file. If you wish to use `base_path`
+  // with relatively generated OpenAPI paths, the `base_path` prefix must be
+  // manually removed from your `google.api.http` paths and your code changed to
+  // serve the API from the `base_path`.
+  string base_path = 4;
+  // The transfer protocol of the API. Values MUST be from the list: "http",
+  // "https", "ws", "wss". If the schemes is not included, the default scheme to
+  // be used is the one used to access the OpenAPI definition itself.
+  repeated Scheme schemes = 5;
+  // A list of MIME types the APIs can consume. This is global to all APIs but
+  // can be overridden on specific API calls. Value MUST be as described under
+  // Mime Types.
+  repeated string consumes = 6;
+  // A list of MIME types the APIs can produce. This is global to all APIs but
+  // can be overridden on specific API calls. Value MUST be as described under
+  // Mime Types.
+  repeated string produces = 7;
+  // field 8 is reserved for 'paths'.
+  reserved 8;
+  // field 9 is reserved for 'definitions', which at this time are already
+  // exposed as and customizable as proto messages.
+  reserved 9;
+  // An object to hold responses that can be used across operations. This
+  // property does not define global responses for all operations.
+  map<string, Response> responses = 10;
+  // Security scheme definitions that can be used across the specification.
+  SecurityDefinitions security_definitions = 11;
+  // A declaration of which security schemes are applied for the API as a whole.
+  // The list of values describes alternative security schemes that can be used
+  // (that is, there is a logical OR between the security requirements).
+  // Individual operations can override this definition.
+  repeated SecurityRequirement security = 12;
+  // A list of tags for API documentation control. Tags can be used for logical
+  // grouping of operations by resources or any other qualifier.
+  repeated Tag tags = 13;
+  // Additional external documentation.
+  ExternalDocumentation external_docs = 14;
+  // Custom properties that start with "x-" such as "x-foo" used to describe
+  // extra functionality that is not covered by the standard OpenAPI Specification.
+  // See: https://swagger.io/docs/specification/2-0/swagger-extensions/
+  map<string, google.protobuf.Value> extensions = 15;
+}
+
+// `Operation` is a representation of OpenAPI v2 specification's Operation object.
+//
+// See: https://github.com/OAI/OpenAPI-Specification/blob/3.0.0/versions/2.0.md#operationObject
+//
+// Example:
+//
+//  service EchoService {
+//    rpc Echo(SimpleMessage) returns (SimpleMessage) {
+//      option (google.api.http) = {
+//        get: "/v1/example/echo/{id}"
+//      };
+//
+//      option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+//        summary: "Get a message.";
+//        operation_id: "getMessage";
+//        tags: "echo";
+//        responses: {
+//          key: "200"
+//            value: {
+//            description: "OK";
+//          }
+//        }
+//      };
+//    }
+//  }
+message Operation {
+  // A list of tags for API documentation control. Tags can be used for logical
+  // grouping of operations by resources or any other qualifier.
+  repeated string tags = 1;
+  // A short summary of what the operation does. For maximum readability in the
+  // swagger-ui, this field SHOULD be less than 120 characters.
+  string summary = 2;
+  // A verbose explanation of the operation behavior. GFM syntax can be used for
+  // rich text representation.
+  string description = 3;
+  // Additional external documentation for this operation.
+  ExternalDocumentation external_docs = 4;
+  // Unique string used to identify the operation. The id MUST be unique among
+  // all operations described in the API. Tools and libraries MAY use the
+  // operationId to uniquely identify an operation, therefore, it is recommended
+  // to follow common programming naming conventions.
+  string operation_id = 5;
+  // A list of MIME types the operation can consume. This overrides the consumes
+  // definition at the OpenAPI Object. An empty value MAY be used to clear the
+  // global definition. Value MUST be as described under Mime Types.
+  repeated string consumes = 6;
+  // A list of MIME types the operation can produce. This overrides the produces
+  // definition at the OpenAPI Object. An empty value MAY be used to clear the
+  // global definition. Value MUST be as described under Mime Types.
+  repeated string produces = 7;
+  // field 8 is reserved for 'parameters'.
+  reserved 8;
+  // The list of possible responses as they are returned from executing this
+  // operation.
+  map<string, Response> responses = 9;
+  // The transfer protocol for the operation. Values MUST be from the list:
+  // "http", "https", "ws", "wss". The value overrides the OpenAPI Object
+  // schemes definition.
+  repeated Scheme schemes = 10;
+  // Declares this operation to be deprecated. Usage of the declared operation
+  // should be refrained. Default value is false.
+  bool deprecated = 11;
+  // A declaration of which security schemes are applied for this operation. The
+  // list of values describes alternative security schemes that can be used
+  // (that is, there is a logical OR between the security requirements). This
+  // definition overrides any declared top-level security. To remove a top-level
+  // security declaration, an empty array can be used.
+  repeated SecurityRequirement security = 12;
+  // Custom properties that start with "x-" such as "x-foo" used to describe
+  // extra functionality that is not covered by the standard OpenAPI Specification.
+  // See: https://swagger.io/docs/specification/2-0/swagger-extensions/
+  map<string, google.protobuf.Value> extensions = 13;
+  // Custom parameters such as HTTP request headers.
+  // See: https://swagger.io/docs/specification/2-0/describing-parameters/
+  // and https://swagger.io/specification/v2/#parameter-object.
+  Parameters parameters = 14;
+}
+
+// `Parameters` is a representation of OpenAPI v2 specification's parameters object.
+// Note: This technically breaks compatibility with the OpenAPI 2 definition structure as we only
+// allow header parameters to be set here since we do not want users specifying custom non-header
+// parameters beyond those inferred from the Protobuf schema.
+// See: https://swagger.io/specification/v2/#parameter-object
+message Parameters {
+  // `Headers` is one or more HTTP header parameter.
+  // See: https://swagger.io/docs/specification/2-0/describing-parameters/#header-parameters
+  repeated HeaderParameter headers = 1;
+}
+
+// `HeaderParameter` a HTTP header parameter.
+// See: https://swagger.io/specification/v2/#parameter-object
+message HeaderParameter {
+  // `Type` is a a supported HTTP header type.
+  // See https://swagger.io/specification/v2/#parameterType.
+  enum Type {
+    UNKNOWN = 0;
+    STRING = 1;
+    NUMBER = 2;
+    INTEGER = 3;
+    BOOLEAN = 4;
+  }
+
+  // `Name` is the header name.
+  string name = 1;
+  // `Description` is a short description of the header.
+  string description = 2;
+  // `Type` is the type of the object. The value MUST be one of "string", "number", "integer", or "boolean". The "array" type is not supported.
+  // See: https://swagger.io/specification/v2/#parameterType.
+  Type type = 3;
+  // `Format` The extending format for the previously mentioned type.
+  string format = 4;
+  // `Required` indicates if the header is optional
+  bool required = 5;
+  // field 6 is reserved for 'items', but in OpenAPI-specific way.
+  reserved 6;
+  // field 7 is reserved `Collection Format`. Determines the format of the array if type array is used.
+  reserved 7;
+}
+
+// `Header` is a representation of OpenAPI v2 specification's Header object.
+//
+// See: https://github.com/OAI/OpenAPI-Specification/blob/3.0.0/versions/2.0.md#headerObject
+//
+message Header {
+  // `Description` is a short description of the header.
+  string description = 1;
+  // The type of the object. The value MUST be one of "string", "number", "integer", or "boolean". The "array" type is not supported.
+  string type = 2;
+  // `Format` The extending format for the previously mentioned type.
+  string format = 3;
+  // field 4 is reserved for 'items', but in OpenAPI-specific way.
+  reserved 4;
+  // field 5 is reserved `Collection Format` Determines the format of the array if type array is used.
+  reserved 5;
+  // `Default` Declares the value of the header that the server will use if none is provided.
+  // See: https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-6.2.
+  // Unlike JSON Schema this value MUST conform to the defined type for the header.
+  string default = 6;
+  // field 7 is reserved for 'maximum'.
+  reserved 7;
+  // field 8 is reserved for 'exclusiveMaximum'.
+  reserved 8;
+  // field 9 is reserved for 'minimum'.
+  reserved 9;
+  // field 10 is reserved for 'exclusiveMinimum'.
+  reserved 10;
+  // field 11 is reserved for 'maxLength'.
+  reserved 11;
+  // field 12 is reserved for 'minLength'.
+  reserved 12;
+  // 'Pattern' See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.2.3.
+  string pattern = 13;
+  // field 14 is reserved for 'maxItems'.
+  reserved 14;
+  // field 15 is reserved for 'minItems'.
+  reserved 15;
+  // field 16 is reserved for 'uniqueItems'.
+  reserved 16;
+  // field 17 is reserved for 'enum'.
+  reserved 17;
+  // field 18 is reserved for 'multipleOf'.
+  reserved 18;
+}
+
+// `Response` is a representation of OpenAPI v2 specification's Response object.
+//
+// See: https://github.com/OAI/OpenAPI-Specification/blob/3.0.0/versions/2.0.md#responseObject
+//
+message Response {
+  // `Description` is a short description of the response.
+  // GFM syntax can be used for rich text representation.
+  string description = 1;
+  // `Schema` optionally defines the structure of the response.
+  // If `Schema` is not provided, it means there is no content to the response.
+  Schema schema = 2;
+  // `Headers` A list of headers that are sent with the response.
+  // `Header` name is expected to be a string in the canonical format of the MIME header key
+  // See: https://golang.org/pkg/net/textproto/#CanonicalMIMEHeaderKey
+  map<string, Header> headers = 3;
+  // `Examples` gives per-mimetype response examples.
+  // See: https://github.com/OAI/OpenAPI-Specification/blob/3.0.0/versions/2.0.md#example-object
+  map<string, string> examples = 4;
+  // Custom properties that start with "x-" such as "x-foo" used to describe
+  // extra functionality that is not covered by the standard OpenAPI Specification.
+  // See: https://swagger.io/docs/specification/2-0/swagger-extensions/
+  map<string, google.protobuf.Value> extensions = 5;
+}
+
+// `Info` is a representation of OpenAPI v2 specification's Info object.
+//
+// See: https://github.com/OAI/OpenAPI-Specification/blob/3.0.0/versions/2.0.md#infoObject
+//
+// Example:
+//
+//  option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
+//    info: {
+//      title: "Echo API";
+//      version: "1.0";
+//      description: "";
+//      contact: {
+//        name: "gRPC-Gateway project";
+//        url: "https://github.com/grpc-ecosystem/grpc-gateway";
+//        email: "none@example.com";
+//      };
+//      license: {
+//        name: "BSD 3-Clause License";
+//        url: "https://github.com/grpc-ecosystem/grpc-gateway/blob/main/LICENSE.txt";
+//      };
+//    };
+//    ...
+//  };
+//
+message Info {
+  // The title of the application.
+  string title = 1;
+  // A short description of the application. GFM syntax can be used for rich
+  // text representation.
+  string description = 2;
+  // The Terms of Service for the API.
+  string terms_of_service = 3;
+  // The contact information for the exposed API.
+  Contact contact = 4;
+  // The license information for the exposed API.
+  License license = 5;
+  // Provides the version of the application API (not to be confused
+  // with the specification version).
+  string version = 6;
+  // Custom properties that start with "x-" such as "x-foo" used to describe
+  // extra functionality that is not covered by the standard OpenAPI Specification.
+  // See: https://swagger.io/docs/specification/2-0/swagger-extensions/
+  map<string, google.protobuf.Value> extensions = 7;
+}
+
+// `Contact` is a representation of OpenAPI v2 specification's Contact object.
+//
+// See: https://github.com/OAI/OpenAPI-Specification/blob/3.0.0/versions/2.0.md#contactObject
+//
+// Example:
+//
+//  option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
+//    info: {
+//      ...
+//      contact: {
+//        name: "gRPC-Gateway project";
+//        url: "https://github.com/grpc-ecosystem/grpc-gateway";
+//        email: "none@example.com";
+//      };
+//      ...
+//    };
+//    ...
+//  };
+//
+message Contact {
+  // The identifying name of the contact person/organization.
+  string name = 1;
+  // The URL pointing to the contact information. MUST be in the format of a
+  // URL.
+  string url = 2;
+  // The email address of the contact person/organization. MUST be in the format
+  // of an email address.
+  string email = 3;
+}
+
+// `License` is a representation of OpenAPI v2 specification's License object.
+//
+// See: https://github.com/OAI/OpenAPI-Specification/blob/3.0.0/versions/2.0.md#licenseObject
+//
+// Example:
+//
+//  option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
+//    info: {
+//      ...
+//      license: {
+//        name: "BSD 3-Clause License";
+//        url: "https://github.com/grpc-ecosystem/grpc-gateway/blob/main/LICENSE.txt";
+//      };
+//      ...
+//    };
+//    ...
+//  };
+//
+message License {
+  // The license name used for the API.
+  string name = 1;
+  // A URL to the license used for the API. MUST be in the format of a URL.
+  string url = 2;
+}
+
+// `ExternalDocumentation` is a representation of OpenAPI v2 specification's
+// ExternalDocumentation object.
+//
+// See: https://github.com/OAI/OpenAPI-Specification/blob/3.0.0/versions/2.0.md#externalDocumentationObject
+//
+// Example:
+//
+//  option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
+//    ...
+//    external_docs: {
+//      description: "More about gRPC-Gateway";
+//      url: "https://github.com/grpc-ecosystem/grpc-gateway";
+//    }
+//    ...
+//  };
+//
+message ExternalDocumentation {
+  // A short description of the target documentation. GFM syntax can be used for
+  // rich text representation.
+  string description = 1;
+  // The URL for the target documentation. Value MUST be in the format
+  // of a URL.
+  string url = 2;
+}
+
+// `Schema` is a representation of OpenAPI v2 specification's Schema object.
+//
+// See: https://github.com/OAI/OpenAPI-Specification/blob/3.0.0/versions/2.0.md#schemaObject
+//
+message Schema {
+  JSONSchema json_schema = 1;
+  // Adds support for polymorphism. The discriminator is the schema property
+  // name that is used to differentiate between other schema that inherit this
+  // schema. The property name used MUST be defined at this schema and it MUST
+  // be in the required property list. When used, the value MUST be the name of
+  // this schema or any schema that inherits it.
+  string discriminator = 2;
+  // Relevant only for Schema "properties" definitions. Declares the property as
+  // "read only". This means that it MAY be sent as part of a response but MUST
+  // NOT be sent as part of the request. Properties marked as readOnly being
+  // true SHOULD NOT be in the required list of the defined schema. Default
+  // value is false.
+  bool read_only = 3;
+  // field 4 is reserved for 'xml'.
+  reserved 4;
+  // Additional external documentation for this schema.
+  ExternalDocumentation external_docs = 5;
+  // A free-form property to include an example of an instance for this schema in JSON.
+  // This is copied verbatim to the output.
+  string example = 6;
+}
+
+// `JSONSchema` represents properties from JSON Schema taken, and as used, in
+// the OpenAPI v2 spec.
+//
+// This includes changes made by OpenAPI v2.
+//
+// See: https://github.com/OAI/OpenAPI-Specification/blob/3.0.0/versions/2.0.md#schemaObject
+//
+// See also: https://cswr.github.io/JsonSchema/spec/basic_types/,
+// https://github.com/json-schema-org/json-schema-spec/blob/master/schema.json
+//
+// Example:
+//
+//  message SimpleMessage {
+//    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_schema) = {
+//      json_schema: {
+//        title: "SimpleMessage"
+//        description: "A simple message."
+//        required: ["id"]
+//      }
+//    };
+//
+//    // Id represents the message identifier.
+//    string id = 1; [
+//        (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+//          description: "The unique identifier of the simple message."
+//        }];
+//  }
+//
+message JSONSchema {
+  // field 1 is reserved for '$id', omitted from OpenAPI v2.
+  reserved 1;
+  // field 2 is reserved for '$schema', omitted from OpenAPI v2.
+  reserved 2;
+  // Ref is used to define an external reference to include in the message.
+  // This could be a fully qualified proto message reference, and that type must
+  // be imported into the protofile. If no message is identified, the Ref will
+  // be used verbatim in the output.
+  // For example:
+  //  `ref: ".google.protobuf.Timestamp"`.
+  string ref = 3;
+  // field 4 is reserved for '$comment', omitted from OpenAPI v2.
+  reserved 4;
+  // The title of the schema.
+  string title = 5;
+  // A short description of the schema.
+  string description = 6;
+  string default = 7;
+  bool read_only = 8;
+  // A free-form property to include a JSON example of this field. This is copied
+  // verbatim to the output swagger.json. Quotes must be escaped.
+  // This property is the same for 2.0 and 3.0.0 https://github.com/OAI/OpenAPI-Specification/blob/3.0.0/versions/3.0.0.md#schemaObject  https://github.com/OAI/OpenAPI-Specification/blob/3.0.0/versions/2.0.md#schemaObject
+  string example = 9;
+  double multiple_of = 10;
+  // Maximum represents an inclusive upper limit for a numeric instance. The
+  // value of MUST be a number,
+  double maximum = 11;
+  bool exclusive_maximum = 12;
+  // minimum represents an inclusive lower limit for a numeric instance. The
+  // value of MUST be a number,
+  double minimum = 13;
+  bool exclusive_minimum = 14;
+  uint64 max_length = 15;
+  uint64 min_length = 16;
+  string pattern = 17;
+  // field 18 is reserved for 'additionalItems', omitted from OpenAPI v2.
+  reserved 18;
+  // field 19 is reserved for 'items', but in OpenAPI-specific way.
+  // TODO(ivucica): add 'items'?
+  reserved 19;
+  uint64 max_items = 20;
+  uint64 min_items = 21;
+  bool unique_items = 22;
+  // field 23 is reserved for 'contains', omitted from OpenAPI v2.
+  reserved 23;
+  uint64 max_properties = 24;
+  uint64 min_properties = 25;
+  repeated string required = 26;
+  // field 27 is reserved for 'additionalProperties', but in OpenAPI-specific
+  // way. TODO(ivucica): add 'additionalProperties'?
+  reserved 27;
+  // field 28 is reserved for 'definitions', omitted from OpenAPI v2.
+  reserved 28;
+  // field 29 is reserved for 'properties', but in OpenAPI-specific way.
+  // TODO(ivucica): add 'additionalProperties'?
+  reserved 29;
+  // following fields are reserved, as the properties have been omitted from
+  // OpenAPI v2:
+  // patternProperties, dependencies, propertyNames, const
+  reserved 30 to 33;
+  // Items in 'array' must be unique.
+  repeated string array = 34;
+
+  enum JSONSchemaSimpleTypes {
+    UNKNOWN = 0;
+    ARRAY = 1;
+    BOOLEAN = 2;
+    INTEGER = 3;
+    NULL = 4;
+    NUMBER = 5;
+    OBJECT = 6;
+    STRING = 7;
+  }
+
+  repeated JSONSchemaSimpleTypes type = 35;
+  // `Format`
+  string format = 36;
+  // following fields are reserved, as the properties have been omitted from
+  // OpenAPI v2: contentMediaType, contentEncoding, if, then, else
+  reserved 37 to 41;
+  // field 42 is reserved for 'allOf', but in OpenAPI-specific way.
+  // TODO(ivucica): add 'allOf'?
+  reserved 42;
+  // following fields are reserved, as the properties have been omitted from
+  // OpenAPI v2:
+  // anyOf, oneOf, not
+  reserved 43 to 45;
+  // Items in `enum` must be unique https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.5.1
+  repeated string enum = 46;
+
+  // Additional field level properties used when generating the OpenAPI v2 file.
+  FieldConfiguration field_configuration = 1001;
+
+  // 'FieldConfiguration' provides additional field level properties used when generating the OpenAPI v2 file.
+  // These properties are not defined by OpenAPIv2, but they are used to control the generation.
+  message FieldConfiguration {
+    // Alternative parameter name when used as path parameter. If set, this will
+    // be used as the complete parameter name when this field is used as a path
+    // parameter. Use this to avoid having auto generated path parameter names
+    // for overlapping paths.
+    string path_param_name = 47;
+  }
+  // Custom properties that start with "x-" such as "x-foo" used to describe
+  // extra functionality that is not covered by the standard OpenAPI Specification.
+  // See: https://swagger.io/docs/specification/2-0/swagger-extensions/
+  map<string, google.protobuf.Value> extensions = 48;
+}
+
+// `Tag` is a representation of OpenAPI v2 specification's Tag object.
+//
+// See: https://github.com/OAI/OpenAPI-Specification/blob/3.0.0/versions/2.0.md#tagObject
+//
+message Tag {
+  // The name of the tag. Use it to allow override of the name of a
+  // global Tag object, then use that name to reference the tag throughout the
+  // OpenAPI file.
+  string name = 1;
+  // A short description for the tag. GFM syntax can be used for rich text
+  // representation.
+  string description = 2;
+  // Additional external documentation for this tag.
+  ExternalDocumentation external_docs = 3;
+  // Custom properties that start with "x-" such as "x-foo" used to describe
+  // extra functionality that is not covered by the standard OpenAPI Specification.
+  // See: https://swagger.io/docs/specification/2-0/swagger-extensions/
+  map<string, google.protobuf.Value> extensions = 4;
+}
+
+// `SecurityDefinitions` is a representation of OpenAPI v2 specification's
+// Security Definitions object.
+//
+// See: https://github.com/OAI/OpenAPI-Specification/blob/3.0.0/versions/2.0.md#securityDefinitionsObject
+//
+// A declaration of the security schemes available to be used in the
+// specification. This does not enforce the security schemes on the operations
+// and only serves to provide the relevant details for each scheme.
+message SecurityDefinitions {
+  // A single security scheme definition, mapping a "name" to the scheme it
+  // defines.
+  map<string, SecurityScheme> security = 1;
+}
+
+// `SecurityScheme` is a representation of OpenAPI v2 specification's
+// Security Scheme object.
+//
+// See: https://github.com/OAI/OpenAPI-Specification/blob/3.0.0/versions/2.0.md#securitySchemeObject
+//
+// Allows the definition of a security scheme that can be used by the
+// operations. Supported schemes are basic authentication, an API key (either as
+// a header or as a query parameter) and OAuth2's common flows (implicit,
+// password, application and access code).
+message SecurityScheme {
+  // The type of the security scheme. Valid values are "basic",
+  // "apiKey" or "oauth2".
+  enum Type {
+    TYPE_INVALID = 0;
+    TYPE_BASIC = 1;
+    TYPE_API_KEY = 2;
+    TYPE_OAUTH2 = 3;
+  }
+
+  // The location of the API key. Valid values are "query" or "header".
+  enum In {
+    IN_INVALID = 0;
+    IN_QUERY = 1;
+    IN_HEADER = 2;
+  }
+
+  // The flow used by the OAuth2 security scheme. Valid values are
+  // "implicit", "password", "application" or "accessCode".
+  enum Flow {
+    FLOW_INVALID = 0;
+    FLOW_IMPLICIT = 1;
+    FLOW_PASSWORD = 2;
+    FLOW_APPLICATION = 3;
+    FLOW_ACCESS_CODE = 4;
+  }
+
+  // The type of the security scheme. Valid values are "basic",
+  // "apiKey" or "oauth2".
+  Type type = 1;
+  // A short description for security scheme.
+  string description = 2;
+  // The name of the header or query parameter to be used.
+  // Valid for apiKey.
+  string name = 3;
+  // The location of the API key. Valid values are "query" or
+  // "header".
+  // Valid for apiKey.
+  In in = 4;
+  // The flow used by the OAuth2 security scheme. Valid values are
+  // "implicit", "password", "application" or "accessCode".
+  // Valid for oauth2.
+  Flow flow = 5;
+  // The authorization URL to be used for this flow. This SHOULD be in
+  // the form of a URL.
+  // Valid for oauth2/implicit and oauth2/accessCode.
+  string authorization_url = 6;
+  // The token URL to be used for this flow. This SHOULD be in the
+  // form of a URL.
+  // Valid for oauth2/password, oauth2/application and oauth2/accessCode.
+  string token_url = 7;
+  // The available scopes for the OAuth2 security scheme.
+  // Valid for oauth2.
+  Scopes scopes = 8;
+  // Custom properties that start with "x-" such as "x-foo" used to describe
+  // extra functionality that is not covered by the standard OpenAPI Specification.
+  // See: https://swagger.io/docs/specification/2-0/swagger-extensions/
+  map<string, google.protobuf.Value> extensions = 9;
+}
+
+// `SecurityRequirement` is a representation of OpenAPI v2 specification's
+// Security Requirement object.
+//
+// See: https://github.com/OAI/OpenAPI-Specification/blob/3.0.0/versions/2.0.md#securityRequirementObject
+//
+// Lists the required security schemes to execute this operation. The object can
+// have multiple security schemes declared in it which are all required (that
+// is, there is a logical AND between the schemes).
+//
+// The name used for each property MUST correspond to a security scheme
+// declared in the Security Definitions.
+message SecurityRequirement {
+  // If the security scheme is of type "oauth2", then the value is a list of
+  // scope names required for the execution. For other security scheme types,
+  // the array MUST be empty.
+  message SecurityRequirementValue {
+    repeated string scope = 1;
+  }
+  // Each name must correspond to a security scheme which is declared in
+  // the Security Definitions. If the security scheme is of type "oauth2",
+  // then the value is a list of scope names required for the execution.
+  // For other security scheme types, the array MUST be empty.
+  map<string, SecurityRequirementValue> security_requirement = 1;
+}
+
+// `Scopes` is a representation of OpenAPI v2 specification's Scopes object.
+//
+// See: https://github.com/OAI/OpenAPI-Specification/blob/3.0.0/versions/2.0.md#scopesObject
+//
+// Lists the available scopes for an OAuth2 security scheme.
+message Scopes {
+  // Maps between a name of a scope to a short description of it (as the value
+  // of the property).
+  map<string, string> scope = 1;
+}

--- a/internal/apiproto/readme.md
+++ b/internal/apiproto/readme.md
@@ -1,0 +1,48 @@
+## Generate HTTP API libraries from swagger spec: 
+
+```
+git clone --depth 1 -b master https://github.com/swagger-api/swagger-codegen.git
+cd swagger-codegen
+cp /path/to/api.swagger.json ./api.swagger.json
+```
+
+### Go library:
+
+```
+./run-in-docker.sh generate -i api.swagger.json -l go -o /gen/out/go-centrifugo -DpackageName=centrifugo
+ls out/go-centrifugo
+```
+
+Then:
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"test_project/centrifugo"
+)
+
+func main() {
+	client := centrifugo.NewAPIClient(&centrifugo.Configuration{
+		BasePath:      "http://localhost:8000/api",
+		DefaultHeader: map[string]string{"Authorization": "apikey "},
+	})
+	reply, resp, err := client.PublicationApi.CentrifugoApiPublish(context.Background(), centrifugo.PublishRequest{
+		Channel: "test",
+		Data:    map[string]string{},
+	})
+	if err != nil {
+		panic(err)
+	}
+	if resp.StatusCode != 200 {
+		panic(resp.StatusCode)
+	}
+	if reply.Error_ != nil {
+		panic(reply.Error_.Message)
+	}
+	fmt.Println("published successfully")
+}
+```

--- a/internal/apiproto/readme.md
+++ b/internal/apiproto/readme.md
@@ -21,14 +21,20 @@ package main
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"time"
 
 	"test_project/centrifugo"
 )
 
 func main() {
+	httpClient := &http.Client{Transport: &http.Transport{
+		MaxIdleConnsPerHost: 100,
+	}, Timeout: time.Second}
 	client := centrifugo.NewAPIClient(&centrifugo.Configuration{
 		BasePath:      "http://localhost:8000/api",
 		DefaultHeader: map[string]string{"Authorization": "apikey "},
+		HTTPClient:    httpClient,
 	})
 	reply, resp, err := client.PublicationApi.CentrifugoApiPublish(context.Background(), centrifugo.PublishRequest{
 		Channel: "test",
@@ -43,6 +49,6 @@ func main() {
 	if reply.Error_ != nil {
 		panic(reply.Error_.Message)
 	}
-	fmt.Println("published successfully")
+	fmt.Println("ok")
 }
 ```

--- a/internal/middleware/auth.go
+++ b/internal/middleware/auth.go
@@ -21,11 +21,18 @@ func APIKeyAuth(key string, h http.Handler) http.Handler {
 			return
 		}
 		authValid := false
-		authHeader := r.Header.Get("Authorization")
-		if authHeader != "" {
-			parts := strings.Fields(authHeader)
-			if len(parts) == 2 && strings.ToLower(parts[0]) == "apikey" && tools.SecureCompareString(key, parts[1]) {
+		authHeaderValue := r.Header.Get("X-API-Key")
+		if authHeaderValue != "" {
+			if tools.SecureCompareString(key, authHeaderValue) {
 				authValid = true
+			}
+		} else {
+			authHeaderAuthorization := r.Header.Get("Authorization")
+			if authHeaderAuthorization != "" {
+				parts := strings.Fields(authHeaderAuthorization)
+				if len(parts) == 2 && strings.ToLower(parts[0]) == "apikey" && tools.SecureCompareString(key, parts[1]) {
+					authValid = true
+				}
 			}
 		}
 		if !authValid && r.URL.RawQuery != "" {

--- a/internal/middleware/auth_test.go
+++ b/internal/middleware/auth_test.go
@@ -31,6 +31,25 @@ func TestAPIKeyAuthMissingAuthKey(t *testing.T) {
 	require.Equal(t, res.StatusCode, http.StatusUnauthorized)
 }
 
+func TestAPIKeyAuthXAPIKey(t *testing.T) {
+	ts := httptest.NewServer(APIKeyAuth("test", testHandler()))
+	defer ts.Close()
+
+	req, err := http.NewRequest("POST", ts.URL, nil)
+	require.NoError(t, err)
+	req.Header.Set("X-API-Key", "test")
+	res, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	require.Equal(t, res.StatusCode, http.StatusOK)
+
+	req, err = http.NewRequest("POST", ts.URL, nil)
+	require.NoError(t, err)
+	req.Header.Set("x-api-key", "test")
+	res, err = http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	require.Equal(t, res.StatusCode, http.StatusOK)
+}
+
 func TestAPIKeyAuthAuthorizationHeader(t *testing.T) {
 	ts := httptest.NewServer(APIKeyAuth("test", testHandler()))
 	defer ts.Close()

--- a/misc/scripts/generate.sh
+++ b/misc/scripts/generate.sh
@@ -8,6 +8,7 @@ fi
 
 cd internal/apiproto
 bash generate.sh
+bash generate_swagger.sh
 cd -
 
 cd internal/proxyproto

--- a/misc/scripts/update_swagger_web.sh
+++ b/misc/scripts/update_swagger_web.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# this script updates embedded swagger web interface.
+# Script intended to be run from the repo root folder:
+# ./misc/scripts/update_swagger_web.sh
+
+TMP_WORK_DIR=$(mktemp -d)
+
+# cleanup_exit removes all resources created during the process and exits with
+# the supplied returned code.
+cleanup_exit() {
+    rm -rf "$TMP_WORK_DIR"
+    exit "$1"
+}
+
+git clone -c advice.detachedHead=false --depth 1 --branch v4.18.1 --single-branch https://github.com/swagger-api/swagger-ui.git "$TMP_WORK_DIR"
+cp internal/apiproto/api.swagger.json "$TMP_WORK_DIR"/dist/swagger.json
+
+oldString="https://petstore.swagger.io/v2/"
+newString="./"
+sed -i '' "s|${oldString}|${newString}|g" "$TMP_WORK_DIR"/dist/swagger-initializer.js
+
+statik -src="$TMP_WORK_DIR"/dist -dest ./internal/ -package=swaggerui
+
+cleanup_exit 0

--- a/misc/scripts/update_web.sh
+++ b/misc/scripts/update_web.sh
@@ -1,20 +1,20 @@
 #!/bin/bash
 
-# this script updates embedded web interface. 
+# this script updates embedded web interface.
 # Script intended to be run from the repo root folder:
 # ./misc/scripts/update_web.sh
 
-TMP_WORK_DIR=`mktemp -d`
+TMP_WORK_DIR=$(mktemp -d)
 
 # cleanup_exit removes all resources created during the process and exits with
 # the supplied returned code.
 cleanup_exit() {
-    rm -rf $TMP_WORK_DIR
-    exit $1
+    rm -rf "$TMP_WORK_DIR"
+    exit "$1"
 }
 
-git clone https://github.com/centrifugal/web.git $TMP_WORK_DIR
+git clone -c advice.detachedHead=false --depth 1 --branch main --single-branch https://github.com/centrifugal/web.git "$TMP_WORK_DIR"
 
-statik -src=$TMP_WORK_DIR/dist -dest ./internal/ -package=webui
+statik -src="$TMP_WORK_DIR"/dist -dest ./internal/ -package=webui
 
 cleanup_exit 0


### PR DESCRIPTION
## Proposed changes

Generate Open API 2.0 schema from Protobuf definitions. Using separate .proto file to keep our main one clean. Optionally serve Swagger UI on `/swagger` path (when `"swagger": true`).

Having Open API spec will also allow generating API clients for Centrifugo v5 new HTTP API using [swagger-codegen](https://swagger.io/tools/swagger-codegen/) or similar tools.

TODO:

* [x] Support `X-API-Key: <key>` header for new API instead of `Authorization: apikey <key>` (matching [this doc](https://swagger.io/docs/specification/authentication/api-keys/)). Possibly support both.
* [x] Update auth schema in api.swagger.proto to use `X-API-Key`


https://user-images.githubusercontent.com/1196565/224783497-ccd34ae0-4a61-4218-9325-afa47500430a.mov


