### PR TITLE
Dynamic jwks based on iss and aud

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/rs/zerolog v1.29.0
 	github.com/spf13/cobra v0.0.7
 	github.com/stretchr/testify v1.8.2
+	github.com/valyala/fasttemplate v1.2.2
 	github.com/vmihailenco/msgpack/v5 v5.3.5
 	go.uber.org/automaxprocs v1.5.2
 	golang.org/x/crypto v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -241,6 +241,8 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
+github.com/valyala/fasttemplate v1.2.2 h1:lxLXG0uE3Qnshl9QyaK6XJxMXlQZELvChBOCmQD0Loo=
+github.com/valyala/fasttemplate v1.2.2/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+qRAEEKiv+SiQ=
 github.com/vmihailenco/msgpack/v5 v5.3.5 h1:5gO0H1iULLWGhs2H5tbAHIZTV8/cYafcFOr9znI5mJU=
 github.com/vmihailenco/msgpack/v5 v5.3.5/go.mod h1:7xyJ9e+0+9SaZT0Wt1RGleJXzli6Q/V5KbhBonMG9jc=
 github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=

--- a/internal/cli/token.go
+++ b/internal/cli/token.go
@@ -63,7 +63,10 @@ func verify(config jwtverify.VerifierConfig, ruleConfig rule.Config, token strin
 	if err != nil {
 		return jwtverify.ConnectToken{}, err
 	}
-	verifier := jwtverify.NewTokenVerifierJWT(config, ruleContainer)
+	verifier, err := jwtverify.NewTokenVerifierJWT(config, ruleContainer)
+	if err != nil {
+		return jwtverify.ConnectToken{}, err
+	}
 	return verifier.VerifyConnectToken(token)
 }
 
@@ -72,7 +75,10 @@ func verifySub(config jwtverify.VerifierConfig, ruleConfig rule.Config, token st
 	if err != nil {
 		return jwtverify.SubscribeToken{}, err
 	}
-	verifier := jwtverify.NewTokenVerifierJWT(config, ruleContainer)
+	verifier, err := jwtverify.NewTokenVerifierJWT(config, ruleContainer)
+	if err != nil {
+		return jwtverify.SubscribeToken{}, err
+	}
 	return verifier.VerifySubscribeToken(token)
 }
 

--- a/internal/jwks/manager_test.go
+++ b/internal/jwks/manager_test.go
@@ -61,7 +61,7 @@ func TestManagerFetchKey_UnmarshalError(t *testing.T) {
 	manager, err := NewManager(server.URL + path)
 	require.NoError(t, err)
 
-	_, err = manager.FetchKey(context.Background(), "202101")
+	_, err = manager.FetchKey(context.Background(), "202101", nil)
 	require.ErrorIs(t, err, errUnmarshal)
 }
 
@@ -78,7 +78,7 @@ func TestManagerFetchKey_KeyNotFound(t *testing.T) {
 	manager, err := NewManager(server.URL + path)
 	require.NoError(t, err)
 
-	_, err = manager.FetchKey(context.Background(), "202101")
+	_, err = manager.FetchKey(context.Background(), "202101", nil)
 	require.ErrorIs(t, err, ErrPublicKeyNotFound)
 }
 
@@ -94,7 +94,7 @@ func TestManagerFetchKey_WrongStatusCode(t *testing.T) {
 	manager, err := NewManager(server.URL + path)
 	require.NoError(t, err)
 
-	_, err = manager.FetchKey(context.Background(), "202101")
+	_, err = manager.FetchKey(context.Background(), "202101", nil)
 	require.ErrorIs(t, err, errUnexpectedStatusCode)
 }
 
@@ -131,7 +131,7 @@ func TestManagerInitialFetchKey(t *testing.T) {
 			manager, err := NewManager(ts.URL)
 			r.NoError(err)
 
-			key, err := manager.FetchKey(context.Background(), tc.Kid)
+			key, err := manager.FetchKey(context.Background(), tc.Kid, nil)
 			if tc.Error != nil {
 				r.Error(err)
 				r.ErrorIs(err, tc.Error)
@@ -176,7 +176,7 @@ func TestManagerCachedFetchKey(t *testing.T) {
 			manager, err := NewManager(ts.URL, tc.Options...)
 			r.NoError(err)
 
-			key, err := manager.FetchKey(ctx, kid)
+			key, err := manager.FetchKey(ctx, kid, nil)
 			r.NoError(err)
 			r.Equal(kid, key.Kid)
 

--- a/internal/jwtverify/token_verifier_jwt_test.go
+++ b/internal/jwtverify/token_verifier_jwt_test.go
@@ -348,6 +348,7 @@ func Test_tokenVerifierJWT_ArrayAudience(t *testing.T) {
 	ruleContainer, err := rule.NewContainer(ruleConfig)
 	require.NoError(t, err)
 	verifier, err := NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, "", "", "", "", ""}, ruleContainer)
+	require.NoError(t, err)
 	ct, err := verifier.VerifyConnectToken(jwtArrayAud)
 	require.NoError(t, err)
 	require.Equal(t, "2694", ct.UserID)

--- a/internal/jwtverify/token_verifier_jwt_test.go
+++ b/internal/jwtverify/token_verifier_jwt_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 // Use https://jwt.io to look at token contents.
-//noinspection ALL
+// noinspection ALL
 const (
 	jwtValid            = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIyNjk0IiwiaW5mbyI6eyJmaXJzdF9uYW1lIjoiQWxleGFuZGVyIiwibGFzdF9uYW1lIjoiRW1lbGluIn19.m-TaS80RxkAiP9jH_s_h2NrKS_TDuPxJ8-z6gI7UewI"
 	jwtExpired          = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIyNjk0IiwiaW5mbyI6eyJmaXJzdF9uYW1lIjoiQWxleGFuZGVyIiwibGFzdF9uYW1lIjoiRW1lbGluIn0sImV4cCI6MTU4ODM1MTcwNH0.LTc0p5YlrwJcxXPETrjhm9qyYUBKCR5fSROmfCE4TD8"
@@ -202,7 +202,8 @@ func Test_tokenVerifierJWT_Valid(t *testing.T) {
 	ruleConfig := rule.DefaultConfig
 	ruleContainer, err := rule.NewContainer(ruleConfig)
 	require.NoError(t, err)
-	verifier := NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, "", "", ""}, ruleContainer)
+	verifier, err := NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, "", "", "", "", ""}, ruleContainer)
+	require.NoError(t, err)
 	ct, err := verifier.VerifyConnectToken(jwtValid)
 	require.NoError(t, err)
 	require.Equal(t, "2694", ct.UserID)
@@ -214,7 +215,8 @@ func Test_tokenVerifierJWT_Audience(t *testing.T) {
 	ruleConfig := rule.DefaultConfig
 	ruleContainer, err := rule.NewContainer(ruleConfig)
 	require.NoError(t, err)
-	verifier := NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, "", "test2", ""}, ruleContainer)
+	verifier, err := NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, "", "test2", "", "", ""}, ruleContainer)
+	require.NoError(t, err)
 
 	// Token without aud.
 	_, err = verifier.VerifyConnectToken(jwtValid)
@@ -224,21 +226,37 @@ func Test_tokenVerifierJWT_Audience(t *testing.T) {
 	token := getRSAConnToken("user", time.Now().Add(time.Hour).Unix(), nil)
 
 	// Verifier with audience which does not match aud in token.
-	verifier = NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, "", "test2", ""}, ruleContainer)
+	verifier, err = NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, "", "test2", "", "", ""}, ruleContainer)
+	require.NoError(t, err)
+
 	_, err = verifier.VerifyConnectToken(token)
 	require.ErrorIs(t, err, ErrInvalidToken)
 
 	// Verifier with token audience.
-	verifier = NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, "", "test", ""}, ruleContainer)
+	verifier, err = NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, "", "test", "", "", ""}, ruleContainer)
+	require.NoError(t, err)
 	_, err = verifier.VerifyConnectToken(token)
 	require.NoError(t, err)
+
+	// Verifier with token audience - valid.
+	verifier, err = NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, "", "", "test", "", ""}, ruleContainer)
+	require.NoError(t, err)
+	_, err = verifier.VerifyConnectToken(token)
+	require.NoError(t, err)
+
+	// Verifier with token audience - invalid.
+	verifier, err = NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, "", "", "test2", "", ""}, ruleContainer)
+	require.NoError(t, err)
+	_, err = verifier.VerifyConnectToken(token)
+	require.Error(t, err)
 }
 
 func Test_tokenVerifierJWT_Issuer(t *testing.T) {
 	ruleConfig := rule.DefaultConfig
 	ruleContainer, err := rule.NewContainer(ruleConfig)
 	require.NoError(t, err)
-	verifier := NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, "", "", "test2"}, ruleContainer)
+	verifier, err := NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, "", "", "", "test2", ""}, ruleContainer)
+	require.NoError(t, err)
 
 	// Token without iss.
 	_, err = verifier.VerifyConnectToken(jwtValid)
@@ -248,21 +266,36 @@ func Test_tokenVerifierJWT_Issuer(t *testing.T) {
 	token := getRSAConnToken("user", time.Now().Add(time.Hour).Unix(), nil)
 
 	// Verifier with issuer which does not match token iss.
-	verifier = NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, "", "", "test2"}, ruleContainer)
+	verifier, err = NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, "", "", "", "test2", ""}, ruleContainer)
+	require.NoError(t, err)
 	_, err = verifier.VerifyConnectToken(token)
 	require.ErrorIs(t, err, ErrInvalidToken)
 
 	// Verifier with token issuer.
-	verifier = NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, "", "", "test"}, ruleContainer)
+	verifier, err = NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, "", "", "", "test", ""}, ruleContainer)
+	require.NoError(t, err)
 	_, err = verifier.VerifyConnectToken(token)
 	require.NoError(t, err)
+
+	// Verifier with token issuer regex - valid.
+	verifier, err = NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, "", "", "", "", "test"}, ruleContainer)
+	require.NoError(t, err)
+	_, err = verifier.VerifyConnectToken(token)
+	require.NoError(t, err)
+
+	// Verifier with token issuer regex - invalid.
+	verifier, err = NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, "", "", "", "", "test2"}, ruleContainer)
+	require.NoError(t, err)
+	_, err = verifier.VerifyConnectToken(token)
+	require.Error(t, err)
 }
 
 func Test_tokenVerifierJWT_Expired(t *testing.T) {
 	ruleConfig := rule.DefaultConfig
 	ruleContainer, err := rule.NewContainer(ruleConfig)
 	require.NoError(t, err)
-	verifier := NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, "", "", ""}, ruleContainer)
+	verifier, err := NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, "", "", "", "", ""}, ruleContainer)
+	require.NoError(t, err)
 	_, err = verifier.VerifyConnectToken(jwtExpired)
 	require.Error(t, err)
 	require.Equal(t, ErrTokenExpired, err)
@@ -272,7 +305,8 @@ func Test_tokenVerifierJWT_DisabledAlgorithm(t *testing.T) {
 	ruleConfig := rule.DefaultConfig
 	ruleContainer, err := rule.NewContainer(ruleConfig)
 	require.NoError(t, err)
-	verifier := NewTokenVerifierJWT(VerifierConfig{"", nil, nil, "", "", ""}, ruleContainer)
+	verifier, err := NewTokenVerifierJWT(VerifierConfig{"", nil, nil, "", "", "", "", ""}, ruleContainer)
+	require.NoError(t, err)
 	_, err = verifier.VerifyConnectToken(jwtExpired)
 	require.Error(t, err)
 	require.True(t, errors.Is(err, ErrInvalidToken), err.Error())
@@ -282,7 +316,8 @@ func Test_tokenVerifierJWT_InvalidSignature(t *testing.T) {
 	ruleConfig := rule.DefaultConfig
 	ruleContainer, err := rule.NewContainer(ruleConfig)
 	require.NoError(t, err)
-	verifier := NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, "", "", ""}, ruleContainer)
+	verifier, err := NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, "", "", "", "", ""}, ruleContainer)
+	require.NoError(t, err)
 	_, err = verifier.VerifyConnectToken(jwtInvalidSignature)
 	require.Error(t, err)
 }
@@ -291,7 +326,8 @@ func Test_tokenVerifierJWT_WithNotBefore(t *testing.T) {
 	ruleConfig := rule.DefaultConfig
 	ruleContainer, err := rule.NewContainer(ruleConfig)
 	require.NoError(t, err)
-	verifier := NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, "", "", ""}, ruleContainer)
+	verifier, err := NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, "", "", "", "", ""}, ruleContainer)
+	require.NoError(t, err)
 	_, err = verifier.VerifyConnectToken(jwtNotBefore)
 	require.Error(t, err)
 }
@@ -300,7 +336,8 @@ func Test_tokenVerifierJWT_StringAudience(t *testing.T) {
 	ruleConfig := rule.DefaultConfig
 	ruleContainer, err := rule.NewContainer(ruleConfig)
 	require.NoError(t, err)
-	verifier := NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, "", "", ""}, ruleContainer)
+	verifier, err := NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, "", "", "", "", ""}, ruleContainer)
+	require.NoError(t, err)
 	ct, err := verifier.VerifyConnectToken(jwtStringAud)
 	require.NoError(t, err)
 	require.Equal(t, "2694", ct.UserID)
@@ -310,7 +347,7 @@ func Test_tokenVerifierJWT_ArrayAudience(t *testing.T) {
 	ruleConfig := rule.DefaultConfig
 	ruleContainer, err := rule.NewContainer(ruleConfig)
 	require.NoError(t, err)
-	verifier := NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, "", "", ""}, ruleContainer)
+	verifier, err := NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, "", "", "", "", ""}, ruleContainer)
 	ct, err := verifier.VerifyConnectToken(jwtArrayAud)
 	require.NoError(t, err)
 	require.Equal(t, "2694", ct.UserID)
@@ -328,7 +365,9 @@ func Test_tokenVerifierJWT_VerifyConnectToken(t *testing.T) {
 	ruleContainer, err := rule.NewContainer(ruleConfig)
 	require.NoError(t, err)
 
-	verifierJWT := NewTokenVerifierJWT(VerifierConfig{"secret", rsaPubKey, ecdsaPubKey, "", "", ""}, ruleContainer)
+	verifierJWT, err := NewTokenVerifierJWT(VerifierConfig{"secret", rsaPubKey, ecdsaPubKey, "", "", "", "", ""}, ruleContainer)
+	require.NoError(t, err)
+
 	_time := time.Now()
 	tests := []struct {
 		name     string
@@ -488,7 +527,9 @@ func Test_tokenVerifierJWT_VerifyConnectTokenWithJWK(t *testing.T) {
 			ruleContainer, err := rule.NewContainer(ruleConfig)
 			require.NoError(t, err)
 
-			verifier := NewTokenVerifierJWT(VerifierConfig{"", nil, nil, ts.URL, "", ""}, ruleContainer)
+			verifier, err := NewTokenVerifierJWT(VerifierConfig{"", nil, nil, ts.URL, "", "", "", ""}, ruleContainer)
+			require.NoError(t, err)
+
 			token := getRSAConnToken(tt.token.user, tt.token.exp, privKey, jwt.WithKeyID(tt.jwk.kid))
 
 			got, err := verifier.VerifyConnectToken(token)
@@ -520,7 +561,9 @@ func Test_tokenVerifierJWT_VerifySubscribeToken(t *testing.T) {
 	ruleContainer, err := rule.NewContainer(ruleConfig)
 	require.NoError(t, err)
 
-	verifierJWT := NewTokenVerifierJWT(VerifierConfig{"secret", rsaPubKey, ecdsaPubKey, "", "", ""}, ruleContainer)
+	verifierJWT, err := NewTokenVerifierJWT(VerifierConfig{"secret", rsaPubKey, ecdsaPubKey, "", "", "", "", ""}, ruleContainer)
+	require.NoError(t, err)
+
 	_time := time.Now()
 	tests := []struct {
 		name     string
@@ -626,7 +669,8 @@ func BenchmarkConnectTokenVerify_Valid(b *testing.B) {
 	ruleConfig := rule.DefaultConfig
 	ruleContainer, err := rule.NewContainer(ruleConfig)
 	require.NoError(b, err)
-	verifierJWT := NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, "", "", ""}, ruleContainer)
+	verifierJWT, err := NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, "", "", "", "", ""}, ruleContainer)
+	require.NoError(b, err)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_, err := verifierJWT.VerifyConnectToken(jwtValid)
@@ -642,7 +686,8 @@ func BenchmarkConnectTokenVerify_Expired(b *testing.B) {
 	ruleConfig := rule.DefaultConfig
 	ruleContainer, err := rule.NewContainer(ruleConfig)
 	require.NoError(b, err)
-	verifier := NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, "", "", ""}, ruleContainer)
+	verifier, err := NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, "", "", "", "", ""}, ruleContainer)
+	require.NoError(b, err)
 	for i := 0; i < b.N; i++ {
 		_, err := verifier.VerifyConnectToken(jwtExpired)
 		if err != ErrTokenExpired {

--- a/main.go
+++ b/main.go
@@ -407,7 +407,10 @@ func main() {
 				log.Fatal().Msgf("error creating engine: %v", err)
 			}
 
-			tokenVerifier := jwtverify.NewTokenVerifierJWT(jwtVerifierConfig(), ruleContainer)
+			tokenVerifier, err := jwtverify.NewTokenVerifierJWT(jwtVerifierConfig(), ruleContainer)
+			if err != nil {
+				log.Fatal().Msgf("error creating token verifier: %v", err)
+			}
 
 			if viper.GetBool("skip_user_check_in_subscription_token") {
 				// See detailed comment about this by falling through to
@@ -1445,8 +1448,9 @@ func jwtVerifierConfig() jwtverify.VerifierConfig {
 
 	cfg.JWKSPublicEndpoint = v.GetString("token_jwks_public_endpoint")
 	cfg.Audience = v.GetString("token_audience")
+	cfg.AudienceRegex = v.GetString("token_audience_regex")
 	cfg.Issuer = v.GetString("token_issuer")
-
+	cfg.IssuerRegex = v.GetString("token_issuer_regex")
 	return cfg
 }
 


### PR DESCRIPTION
## Proposed changes

More generic version of #618 

It's possible to extract vars from issuer and aud JWT claims using Go regexp named groups, then use these vars to construct JWKS endpoint dynamically. In this case JWKS endpoint may be set in config as template. Let's look how this may help in case of using different realms of Keycloak:

```json
{
  "token_issuer_regex": "https://example.com/auth/realms/(?P<realm>[A-z]+)",
  "token_jwks_public_endpoint": "https://keycloak:443/{{realm}}/protocol/openid-connect/certs"
}
```

Two new options introduced:

* `token_issuer_regex` - match JWT issuer against this regex, extract named groups to variables for jwks endpoint construction.
* `token_audience_regex` - match JWT audience against this regex, extract named groups to variables for jwks endpoint construction.

TODO:

* [x] when using `token_issuer_regex` and `token_audience_regex` make sure `token_issuer` and `token_audience` not used in the config - return an error on start in this case.
