### PR TITLE
Disable CGO in rpm/deb Centrifugo build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,9 +20,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Install gox
-        run: go install github.com/mitchellh/gox@latest
-
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
         with:

--- a/Makefile
+++ b/Makefile
@@ -11,9 +11,6 @@ DOCKER_RUN_DOC_OPTS := --rm $(DOCKER_RUN_DOC_MOUNT) -p $(DOCKER_RUN_DOC_PORT):80
 
 all: test
 
-prepare:
-	go install github.com/mitchellh/gox@latest
-
 test:
 	go test -count=1 -v $(TESTFOLDERS) -cover -race
 

--- a/misc/scripts/package.sh
+++ b/misc/scripts/package.sh
@@ -106,7 +106,7 @@ do_build() {
         echo "STATS_TOKEN found"
     fi
 
-    gox -os="linux" -ldflags="-X github.com/centrifugal/centrifugo/v4/internal/build.Version=$VERSION -X github.com/centrifugal/centrifugo/v4/internal/build.UsageStatsEndpoint=$STATS_ENDPOINT -X github.com/centrifugal/centrifugo/v4/internal/build.UsageStatsToken=$STATS_TOKEN" -arch="amd64" -output="$TMP_BINARIES_DIR/{{.OS}}-{{.Arch}}/centrifugo"
+    CGO_ENABLED=0 GOOS="linux" GOARCH="amd64" go build -ldflags="-X github.com/centrifugal/centrifugo/v4/internal/build.Version=$VERSION -X github.com/centrifugal/centrifugo/v4/internal/build.UsageStatsEndpoint=$STATS_ENDPOINT -X github.com/centrifugal/centrifugo/v4/internal/build.UsageStatsToken=$STATS_TOKEN" -o "$TMP_BINARIES_DIR/centrifugo"
     echo "Binary build completed successfully"
 }
 
@@ -114,7 +114,7 @@ do_build $VERSION
 
 make_dir_tree $TMP_WORK_DIR
 
-cp $TMP_BINARIES_DIR/linux-amd64/centrifugo $TMP_WORK_DIR/$INSTALL_DIR/
+cp $TMP_BINARIES_DIR/centrifugo $TMP_WORK_DIR/$INSTALL_DIR/
 if [ $? -ne 0 ]; then
     echo "Failed to copy binaries to packaging directory ($TMP_WORK_DIR/$INSTALL_DIR/) -- aborting."
     cleanup_exit 1


### PR DESCRIPTION
## Proposed changes

Relates #644 

Also do not use `gox` for the build - just use `go`.
