### PR TITLE
added channels router

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,7 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/dghubble/trie v0.0.0-20230228185955-dca8fa4fd7f8 // indirect
 	github.com/fsnotify/fsnotify v1.5.4 // indirect
 	github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0 // indirect
 	github.com/golang/mock v1.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -86,6 +86,8 @@ github.com/cristalhq/jwt/v4 v4.0.2/go.mod h1:HnYraSNKDRag1DZP92rYHyrjyQHnVEHPNqe
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dghubble/trie v0.0.0-20230228185955-dca8fa4fd7f8 h1:hyXHmCxADfwpski6P8WFoZg5ssJKWwrk34wS4wTar9g=
+github.com/dghubble/trie v0.0.0-20230228185955-dca8fa4fd7f8/go.mod h1:sOmnzfBNH7H92ow2292dDFWNsVQuh/izuD7otCYb1ak=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=

--- a/internal/router/config.go
+++ b/internal/router/config.go
@@ -1,0 +1,8 @@
+package router
+
+type Config struct {
+	Routes []struct {
+		Name      string   `mapstructure:"name" json:"name"`
+		Addresses []string `mapstructure:"addresses" json:"addresses"`
+	} `mapstructure:"routes" json:"routes"`
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -1,0 +1,60 @@
+package router
+
+import (
+	"github.com/centrifugal/centrifuge"
+
+	"github.com/dghubble/trie"
+)
+
+type Router struct {
+	node         *centrifuge.Node
+	exactRoutes  map[string]any
+	prefixRoutes *trie.RuneTrie
+}
+
+func New(n *centrifuge.Node) *Router {
+	return &Router{
+		node:         n,
+		exactRoutes:  make(map[string]any),
+		prefixRoutes: trie.NewRuneTrie(),
+	}
+}
+
+func (r *Router) AddExact(channel string, value any) {
+	r.exactRoutes[channel] = value
+}
+
+func (r *Router) AddPrefix(channelPrefix string, value any) {
+	_ = r.prefixRoutes.Put(channelPrefix, value)
+}
+
+func (r *Router) Find(channel string) any {
+	if value, ok := r.exactRoutes[channel]; ok {
+		if r.node.LogEnabled(centrifuge.LogLevelTrace) {
+			r.node.Log(centrifuge.NewLogEntry(centrifuge.LogLevelTrace, "exact route for channel", map[string]any{"channel": channel}))
+		}
+		return value
+	}
+
+	var value any
+	_ = r.prefixRoutes.WalkPath(channel, func(key string, val any) error {
+		if val != nil {
+			if r.node.LogEnabled(centrifuge.LogLevelTrace) {
+				r.node.Log(centrifuge.NewLogEntry(centrifuge.LogLevelTrace, "prefix route for channel", map[string]any{"channel": channel}))
+			}
+			value = val
+		}
+		return nil
+	})
+
+	if value == nil {
+		if value, ok := r.exactRoutes["__default"]; ok {
+			if r.node.LogEnabled(centrifuge.LogLevelTrace) {
+				r.node.Log(centrifuge.NewLogEntry(centrifuge.LogLevelTrace, "default route for channel", map[string]any{"channel": channel}))
+			}
+			return value
+		}
+	}
+
+	return value
+}

--- a/internal/tntengine/shard.go
+++ b/internal/tntengine/shard.go
@@ -77,6 +77,10 @@ func (s *Shard) ExecTyped(request *tarantool.Request, result interface{}) error 
 	return conn.ExecTyped(request, result)
 }
 
+func (s *Shard) GetAddresses() []string {
+	return s.config.Addresses
+}
+
 func (s *Shard) pubSubConn() (*tarantool.Connection, func(), error) {
 	conn, err := s.mc.NewLeaderConn(tarantool.Opts{
 		ConnectTimeout: defaultConnectTimeout,


### PR DESCRIPTION
channels pub/sub can be routed to concrete tarantool instances

## Proposed changes
added shards routing ability (for tarantool engine only)
clients can subscribe channels to subset of tarantool shards
each channel can be subscribed to multiple shards

at now all instances/shards are all the same and consistent hashing is used to select one of them
but we can have tarantool instances with different roles and each instance has its own set of channels

this patch adds flexible rules how to subscribe channels to shards

config example:
```
{
  "tarantool_address": ["shard1-addr1,shard1-addr2", "shard2-addr1,shard2-addr2"], // here we describe all avail instances
  "router": {
    "routes": [
      // here the rules to subscribe channels to exact tarantool shards
      {"name": "channel1", "addresses": ["shard2-addr1"]}, // (exact routing) any address of needed shard
      {"name": "channel2*", "addresses": ["shard1-addr1", "shard2-addr1"]}, // (the longest prefix routing) * means prefix, here we subscribe to two shards and will receive mesages from both shards
      {"name": "__default", ["shard2-addr1"]} // force to use default route if none was found
    ]
  }
}
```

presence/publish/history is not yet implemented

### limitations for multi-shards routes:
publish cannot do it atomically, so duplicates will be if client re-publishes on error (if some of shards will die)

history cannot return just one StreamPosition, so new history api is needed (and what to do with old one?)
