### PR TITLE
Quiet mode and no expiration for gentoken/gensubtoken cli commands

### DIFF
--- a/internal/cli/token.go
+++ b/internal/cli/token.go
@@ -21,11 +21,14 @@ func GenerateToken(config jwtverify.VerifierConfig, user string, ttlSeconds int6
 		return "", fmt.Errorf("error creating HMAC signer: %w", err)
 	}
 	builder := jwt.NewBuilder(signer)
-	token, err := builder.Build(jwt.RegisteredClaims{
-		Subject:   user,
-		ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Duration(ttlSeconds) * time.Second)),
-		IssuedAt:  jwt.NewNumericDate(time.Now()),
-	})
+	claims := jwt.RegisteredClaims{
+		Subject:  user,
+		IssuedAt: jwt.NewNumericDate(time.Now()),
+	}
+	if ttlSeconds > 0 {
+		claims.ExpiresAt = jwt.NewNumericDate(time.Now().Add(time.Duration(ttlSeconds) * time.Second))
+	}
+	token, err := builder.Build(claims)
 	if err != nil {
 		return "", err
 	}
@@ -42,14 +45,17 @@ func GenerateSubToken(config jwtverify.VerifierConfig, user string, channel stri
 		return "", fmt.Errorf("error creating HMAC signer: %w", err)
 	}
 	builder := jwt.NewBuilder(signer)
+	claims := jwt.RegisteredClaims{
+		Subject:  user,
+		IssuedAt: jwt.NewNumericDate(time.Now()),
+	}
+	if ttlSeconds > 0 {
+		claims.ExpiresAt = jwt.NewNumericDate(time.Now().Add(time.Duration(ttlSeconds) * time.Second))
+	}
 	token, err := builder.Build(
 		jwtverify.SubscribeTokenClaims{
-			RegisteredClaims: jwt.RegisteredClaims{
-				Subject:   user,
-				ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Duration(ttlSeconds) * time.Second)),
-				IssuedAt:  jwt.NewNumericDate(time.Now()),
-			},
-			Channel: channel,
+			RegisteredClaims: claims,
+			Channel:          channel,
 		},
 	)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -898,6 +898,7 @@ func main() {
 	var genTokenConfigFile string
 	var genTokenUser string
 	var genTokenTTL int64
+	var genTokenQuiet bool
 
 	var genTokenCmd = &cobra.Command{
 		Use:   "gentoken",
@@ -920,17 +921,27 @@ func main() {
 			if genTokenUser == "" {
 				user = "anonymous user"
 			}
-			fmt.Printf("HMAC SHA-256 JWT for %s with expiration TTL %s:\n%s\n", user, time.Duration(genTokenTTL)*time.Second, token)
+			exp := "without expiration"
+			if genTokenTTL >= 0 {
+				exp = fmt.Sprintf("with expiration TTL %s", time.Duration(genTokenTTL)*time.Second)
+			}
+			if genTokenQuiet {
+				fmt.Print(token)
+				return
+			}
+			fmt.Printf("HMAC SHA-256 JWT for %s %s:\n%s\n", user, exp, token)
 		},
 	}
 	genTokenCmd.Flags().StringVarP(&genTokenConfigFile, "config", "c", "config.json", "path to config file")
-	genTokenCmd.Flags().StringVarP(&genTokenUser, "user", "u", "", "user ID")
-	genTokenCmd.Flags().Int64VarP(&genTokenTTL, "ttl", "t", 3600*24*7, "token TTL in seconds")
+	genTokenCmd.Flags().StringVarP(&genTokenUser, "user", "u", "", "user ID, by default anonymous")
+	genTokenCmd.Flags().Int64VarP(&genTokenTTL, "ttl", "t", 3600*24*7, "token TTL in seconds, use -1 for token without expiration")
+	genTokenCmd.Flags().BoolVarP(&genTokenQuiet, "quiet", "q", false, "only output the token without anything else")
 
 	var genSubTokenConfigFile string
 	var genSubTokenUser string
 	var genSubTokenChannel string
 	var genSubTokenTTL int64
+	var genSubTokenQuiet bool
 
 	var genSubTokenCmd = &cobra.Command{
 		Use:   "gensubtoken",
@@ -960,13 +971,22 @@ func main() {
 			if genSubTokenUser == "" {
 				user = "anonymous user"
 			}
-			fmt.Printf("HMAC SHA-256 JWT for %s and channel \"%s\" with expiration TTL %s:\n%s\n", user, genSubTokenChannel, time.Duration(genSubTokenTTL)*time.Second, token)
+			exp := "without expiration"
+			if genTokenTTL >= 0 {
+				exp = fmt.Sprintf("with expiration TTL %s", time.Duration(genTokenTTL)*time.Second)
+			}
+			if genSubTokenQuiet {
+				fmt.Print(token)
+				return
+			}
+			fmt.Printf("HMAC SHA-256 JWT for %s and channel \"%s\" %s:\n%s\n", user, genSubTokenChannel, exp, token)
 		},
 	}
 	genSubTokenCmd.Flags().StringVarP(&genSubTokenConfigFile, "config", "c", "config.json", "path to config file")
 	genSubTokenCmd.Flags().StringVarP(&genSubTokenUser, "user", "u", "", "user ID")
 	genSubTokenCmd.Flags().StringVarP(&genSubTokenChannel, "channel", "s", "", "channel")
-	genSubTokenCmd.Flags().Int64VarP(&genSubTokenTTL, "ttl", "t", 3600*24*7, "token TTL in seconds")
+	genSubTokenCmd.Flags().Int64VarP(&genSubTokenTTL, "ttl", "t", 3600*24*7, "token TTL in seconds, use -1 for token without expiration")
+	genSubTokenCmd.Flags().BoolVarP(&genSubTokenQuiet, "quiet", "q", false, "only output the token without anything else")
 
 	var checkTokenConfigFile string
 


### PR DESCRIPTION
## Proposed changes

Adding possibility to create non-expiring tokens:

```
./centrifugo gentoken -t -1
```

And suppress all the output except token itself (may be useful for development automation):

```
./centrifugo gentoken -q
```