### PR TITLE
Add proxy_static_http_headers option and static_http_headers key for granular proxy

### DIFF
--- a/internal/proxy/connect_handler_test.go
+++ b/internal/proxy/connect_handler_test.go
@@ -36,6 +36,9 @@ func getTestHttpProxy(commonProxyTestCase *tools.CommonHTTPProxyTestCase, endpoi
 	return Proxy{
 		Endpoint: commonProxyTestCase.Server.URL + endpoint,
 		Timeout:  tools.Duration(5 * time.Second),
+		StaticHttpHeaders: map[string]string{
+			"X-Test": "test",
+		},
 	}
 }
 
@@ -122,6 +125,7 @@ func TestHandleConnectWithEmptyReply(t *testing.T) {
 
 	httpTestCase := newConnHandleHTTPTestCase(context.Background(), "/proxy")
 	httpTestCase.Mux.HandleFunc("/proxy", func(w http.ResponseWriter, req *http.Request) {
+		require.Equal(t, "test", req.Header.Get("X-Test"))
 		_, _ = w.Write([]byte(`{}`))
 	})
 	defer httpTestCase.Teardown()

--- a/internal/proxy/grpc.go
+++ b/internal/proxy/grpc.go
@@ -79,7 +79,7 @@ func grpcRequestContext(ctx context.Context, proxy Proxy) context.Context {
 }
 
 func httpRequestHeaders(ctx context.Context, proxy Proxy) http.Header {
-	return requestHeaders(ctx, proxy.HttpHeaders, proxy.GrpcMetadata)
+	return requestHeaders(ctx, proxy.HttpHeaders, proxy.GrpcMetadata, proxy.StaticHttpHeaders)
 }
 
 func requestMetadata(ctx context.Context, allowedHeaders []string, allowedMetaKeys []string) metadata.MD {
@@ -101,10 +101,13 @@ func requestMetadata(ctx context.Context, allowedHeaders []string, allowedMetaKe
 	return requestMD
 }
 
-func requestHeaders(ctx context.Context, allowedHeaders []string, allowedMetaKeys []string) http.Header {
-	headers := http.Header{}
+func requestHeaders(ctx context.Context, allowedHeaders []string, allowedMetaKeys []string, staticHeaders map[string]string) http.Header {
 	if headers, ok := middleware.GetHeadersFromContext(ctx); ok {
-		return getProxyHeader(headers, allowedHeaders)
+		return getProxyHeader(headers, allowedHeaders, staticHeaders)
+	}
+	headers := http.Header{}
+	for k, v := range staticHeaders {
+		headers.Set(k, v)
 	}
 	headers.Set("Content-Type", "application/json")
 	md, _ := metadata.FromIncomingContext(ctx)

--- a/internal/proxy/http.go
+++ b/internal/proxy/http.go
@@ -80,9 +80,12 @@ func (c *httpCaller) CallHTTP(ctx context.Context, endpoint string, header http.
 	return respData, nil
 }
 
-func getProxyHeader(allHeader http.Header, extraHeaders []string) http.Header {
+func getProxyHeader(allHeader http.Header, allowedHeaders []string, staticHeaders map[string]string) http.Header {
 	proxyHeader := http.Header{}
-	copyHeader(proxyHeader, allHeader, extraHeaders)
+	for k, v := range staticHeaders {
+		proxyHeader.Set(k, v)
+	}
+	copyHeader(proxyHeader, allHeader, allowedHeaders)
 	proxyHeader.Set("Content-Type", "application/json")
 	return proxyHeader
 }

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -18,12 +18,17 @@ type Proxy struct {
 	// Timeout for proxy request.
 	Timeout tools.Duration `mapstructure:"timeout" json:"timeout,omitempty"`
 
-	// HTTPHeaders is a list of HTTP headers to proxy.  No headers used by proxy by default.
+	// HTTPHeaders is a list of HTTP headers to proxy. No headers used by proxy by default.
 	// If GRPC proxy is used then request HTTP headers set to outgoing request metadata.
 	HttpHeaders []string `mapstructure:"http_headers" json:"http_headers,omitempty"`
 	// GRPCMetadata is a list of GRPC metadata keys to proxy. No meta keys used by proxy by
 	// default. If HTTP proxy is used then these keys become outgoing request HTTP headers.
 	GrpcMetadata []string `mapstructure:"grpc_metadata" json:"grpc_metadata,omitempty"`
+
+	// StaticHttpHeaders is a static set of key/value pairs to attach to HTTP proxy request as
+	// headers. Headers received from HTTP client request or metadata from GRPC client request
+	// both have priority over values set in StaticHttpHeaders map.
+	StaticHttpHeaders map[string]string `mapstructure:"static_http_headers" json:"static_http_headers,omitempty"`
 
 	// BinaryEncoding makes proxy send data as base64 string (assuming it contains custom
 	// non-JSON payload).

--- a/internal/tools/config.go
+++ b/internal/tools/config.go
@@ -121,3 +121,29 @@ func ErrorMessageFromConfigError(err error, configPath string) string {
 	// Fallback if we can't construct a better one.
 	return fmt.Sprintf("configuration error: %v", err)
 }
+
+func MapStringString(v *viper.Viper, key string) (map[string]string, error) {
+	if !v.IsSet(key) {
+		return map[string]string{}, nil
+	}
+	var m map[string]string
+	var err error
+	switch val := v.Get(key).(type) {
+	case string:
+		err = json.Unmarshal([]byte(val), &m)
+	case map[string]string:
+		m = val
+	case map[string]any:
+		var jsonData []byte
+		jsonData, err = json.Marshal(val)
+		if err == nil {
+			err = json.Unmarshal(jsonData, &m)
+		}
+	default:
+		err = fmt.Errorf("unknown type: %T", val)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return m, nil
+}

--- a/internal/tools/unknown_keys.go
+++ b/internal/tools/unknown_keys.go
@@ -45,8 +45,27 @@ func CheckPlainConfigKeys(defaults map[string]any, allKeys []string) {
 	checkEnvironmentConfigKeys(defaults)
 }
 
+// Map[string]string keys require a special care because viper will return all the keys found
+// in map from allKeys method in a format like "proxy_static_http_headers.some_key". Since we
+// allow arbitrary keys for maps we have this slice of such configuration options here.
+var mapStringStringKeys = []string{
+	"proxy_static_http_headers",
+}
+
+func isMapStringStringKey(key string) bool {
+	for _, mapKey := range mapStringStringKeys {
+		if strings.HasPrefix(key, mapKey+".") {
+			return true
+		}
+	}
+	return false
+}
+
 func checkFileConfigKeys(defaults map[string]any, allKeys []string) {
 	for _, key := range allKeys {
+		if isMapStringStringKey(key) {
+			continue
+		}
 		if _, ok := defaults[key]; !ok {
 			log.Warn().Str("key", key).Msg("unknown key found in the configuration file")
 		}

--- a/main.go
+++ b/main.go
@@ -266,6 +266,7 @@ var defaults = map[string]any{
 	"proxy_sub_refresh_timeout":     time.Second,
 	"proxy_grpc_metadata":           []string{},
 	"proxy_http_headers":            []string{},
+	"proxy_static_http_headers":     map[string]string{},
 	"proxy_binary_encoding":         false,
 	"proxy_include_connection_meta": false,
 	"proxy_grpc_cert_file":          "",
@@ -1731,6 +1732,12 @@ func proxyMapConfig() (*client.ProxyMap, bool) {
 	for i, header := range p.HttpHeaders {
 		p.HttpHeaders[i] = strings.ToLower(header)
 	}
+
+	staticHttpHeaders, err := tools.MapStringString(v, "proxy_static_http_headers")
+	if err != nil {
+		log.Fatal().Err(err).Msg("malformed configuration for proxy_static_http_headers")
+	}
+	p.StaticHttpHeaders = staticHttpHeaders
 
 	p.BinaryEncoding = v.GetBool("proxy_binary_encoding")
 	p.IncludeConnectionMeta = v.GetBool("proxy_include_connection_meta")


### PR DESCRIPTION
## Proposed changes

Relates #684

`proxy_static_http_headers` is a set of key/value pairs to attach to HTTP proxy requests as headers. Headers received from HTTP client request or metadata from GRPC client request both have priority over values set in this map.

```json
{
  ...
  "proxy_static_http_headers": {
    "X-Custom-Header": "custom value"
  }
}
```

Also added `static_http_headers` key for granular proxy configuration.
