### PR TITLE
Support expire_at of SubscribeResult

### DIFF
--- a/internal/proxy/subscribe_handler.go
+++ b/internal/proxy/subscribe_handler.go
@@ -142,6 +142,7 @@ func (h *SubscribeHandler) Handle(node *centrifuge.Node) SubscribeHandlerFunc {
 
 		var info []byte
 		var data []byte
+		var expireAt int64
 		var extra SubscribeExtra
 		if subscribeRep.Result != nil {
 			if subscribeRep.Result.B64Info != "" {
@@ -182,10 +183,13 @@ func (h *SubscribeHandler) Handle(node *centrifuge.Node) SubscribeHandlerFunc {
 			if result.Override != nil && result.Override.ForcePositioning != nil {
 				positioning = result.Override.ForcePositioning.Value
 			}
+
+			expireAt = result.ExpireAt
 		}
 
 		return centrifuge.SubscribeReply{
 			Options: centrifuge.SubscribeOptions{
+				ExpireAt:          expireAt,
 				ChannelInfo:       info,
 				EmitPresence:      presence,
 				EmitJoinLeave:     joinLeave,


### PR DESCRIPTION
## Proposed changes

Adds missing support for `expire_at` field from subscribe proxy result.

Addresses this comment: https://github.com/centrifugal/centrifugo/issues/706#issuecomment-1722196878
