### PR TITLE
Option to skip client token signature verification 

### DIFF
--- a/internal/cli/token.go
+++ b/internal/cli/token.go
@@ -73,7 +73,7 @@ func verify(config jwtverify.VerifierConfig, ruleConfig rule.Config, token strin
 	if err != nil {
 		return jwtverify.ConnectToken{}, err
 	}
-	return verifier.VerifyConnectToken(token)
+	return verifier.VerifyConnectToken(token, false)
 }
 
 func verifySub(config jwtverify.VerifierConfig, ruleConfig rule.Config, token string) (jwtverify.SubscribeToken, error) {
@@ -85,7 +85,7 @@ func verifySub(config jwtverify.VerifierConfig, ruleConfig rule.Config, token st
 	if err != nil {
 		return jwtverify.SubscribeToken{}, err
 	}
-	return verifier.VerifySubscribeToken(token)
+	return verifier.VerifySubscribeToken(token, false)
 }
 
 // CheckToken checks JWT for user.

--- a/internal/client/handler.go
+++ b/internal/client/handler.go
@@ -286,7 +286,7 @@ func (h *Handler) OnClientConnecting(
 	storage := map[string]any{}
 
 	if e.Token != "" {
-		token, err := h.tokenVerifier.VerifyConnectToken(e.Token, h.ruleContainer.Config().ClientInsecureSkipTokenVerify)
+		token, err := h.tokenVerifier.VerifyConnectToken(e.Token, h.ruleContainer.Config().ClientInsecureSkipTokenSignatureVerify)
 		if err != nil {
 			if err == jwtverify.ErrTokenExpired {
 				return centrifuge.ConnectReply{}, centrifuge.ErrorTokenExpired
@@ -473,7 +473,7 @@ func (h *Handler) OnRefresh(c Client, e centrifuge.RefreshEvent, refreshProxyHan
 		}
 		return r, RefreshExtra{}, err
 	}
-	token, err := h.tokenVerifier.VerifyConnectToken(e.Token, h.ruleContainer.Config().ClientInsecureSkipTokenVerify)
+	token, err := h.tokenVerifier.VerifyConnectToken(e.Token, h.ruleContainer.Config().ClientInsecureSkipTokenSignatureVerify)
 	if err != nil {
 		if err == jwtverify.ErrTokenExpired {
 			return centrifuge.RefreshReply{Expired: true}, RefreshExtra{}, nil
@@ -531,7 +531,7 @@ func (h *Handler) OnSubRefresh(c Client, subRefreshProxyHandler proxy.SubRefresh
 	if h.subTokenVerifier != nil {
 		tokenVerifier = h.subTokenVerifier
 	}
-	token, err := tokenVerifier.VerifySubscribeToken(e.Token, h.ruleContainer.Config().ClientInsecureSkipTokenVerify)
+	token, err := tokenVerifier.VerifySubscribeToken(e.Token, h.ruleContainer.Config().ClientInsecureSkipTokenSignatureVerify)
 	if err != nil {
 		if err == jwtverify.ErrTokenExpired {
 			return centrifuge.SubRefreshReply{Expired: true}, SubRefreshExtra{}, nil
@@ -648,7 +648,7 @@ func (h *Handler) OnSubscribe(c Client, e centrifuge.SubscribeEvent, subscribePr
 		if h.subTokenVerifier != nil {
 			tokenVerifier = h.subTokenVerifier
 		}
-		token, err := tokenVerifier.VerifySubscribeToken(e.Token, h.ruleContainer.Config().ClientInsecureSkipTokenVerify)
+		token, err := tokenVerifier.VerifySubscribeToken(e.Token, h.ruleContainer.Config().ClientInsecureSkipTokenSignatureVerify)
 		if err != nil {
 			if err == jwtverify.ErrTokenExpired {
 				return centrifuge.SubscribeReply{}, SubscribeExtra{}, centrifuge.ErrorTokenExpired

--- a/internal/client/handler.go
+++ b/internal/client/handler.go
@@ -286,7 +286,7 @@ func (h *Handler) OnClientConnecting(
 	storage := map[string]any{}
 
 	if e.Token != "" {
-		token, err := h.tokenVerifier.VerifyConnectToken(e.Token)
+		token, err := h.tokenVerifier.VerifyConnectToken(e.Token, h.ruleContainer.Config().ClientInsecureSkipTokenVerify)
 		if err != nil {
 			if err == jwtverify.ErrTokenExpired {
 				return centrifuge.ConnectReply{}, centrifuge.ErrorTokenExpired
@@ -473,7 +473,7 @@ func (h *Handler) OnRefresh(c Client, e centrifuge.RefreshEvent, refreshProxyHan
 		}
 		return r, RefreshExtra{}, err
 	}
-	token, err := h.tokenVerifier.VerifyConnectToken(e.Token)
+	token, err := h.tokenVerifier.VerifyConnectToken(e.Token, h.ruleContainer.Config().ClientInsecureSkipTokenVerify)
 	if err != nil {
 		if err == jwtverify.ErrTokenExpired {
 			return centrifuge.RefreshReply{Expired: true}, RefreshExtra{}, nil
@@ -531,7 +531,7 @@ func (h *Handler) OnSubRefresh(c Client, subRefreshProxyHandler proxy.SubRefresh
 	if h.subTokenVerifier != nil {
 		tokenVerifier = h.subTokenVerifier
 	}
-	token, err := tokenVerifier.VerifySubscribeToken(e.Token)
+	token, err := tokenVerifier.VerifySubscribeToken(e.Token, h.ruleContainer.Config().ClientInsecureSkipTokenVerify)
 	if err != nil {
 		if err == jwtverify.ErrTokenExpired {
 			return centrifuge.SubRefreshReply{Expired: true}, SubRefreshExtra{}, nil
@@ -648,7 +648,7 @@ func (h *Handler) OnSubscribe(c Client, e centrifuge.SubscribeEvent, subscribePr
 		if h.subTokenVerifier != nil {
 			tokenVerifier = h.subTokenVerifier
 		}
-		token, err := tokenVerifier.VerifySubscribeToken(e.Token)
+		token, err := tokenVerifier.VerifySubscribeToken(e.Token, h.ruleContainer.Config().ClientInsecureSkipTokenVerify)
 		if err != nil {
 			if err == jwtverify.ErrTokenExpired {
 				return centrifuge.SubscribeReply{}, SubscribeExtra{}, centrifuge.ErrorTokenExpired

--- a/internal/jwtverify/token_verifier.go
+++ b/internal/jwtverify/token_verifier.go
@@ -7,8 +7,8 @@ import (
 )
 
 type Verifier interface {
-	VerifyConnectToken(token string) (ConnectToken, error)
-	VerifySubscribeToken(token string) (SubscribeToken, error)
+	VerifyConnectToken(token string, skipVerify bool) (ConnectToken, error)
+	VerifySubscribeToken(token string, skipVerify bool) (SubscribeToken, error)
 }
 
 type ConnectToken struct {

--- a/internal/jwtverify/token_verifier_jwt.go
+++ b/internal/jwtverify/token_verifier_jwt.go
@@ -436,11 +436,9 @@ func (verifier *VerifierJWT) VerifyConnectToken(t string, skipVerify bool) (Conn
 		return ConnectToken{}, ErrInvalidToken
 	}
 
-	if !skipVerify {
-		now := time.Now()
-		if !claims.IsValidExpiresAt(now) || !claims.IsValidNotBefore(now) {
-			return ConnectToken{}, ErrTokenExpired
-		}
+	now := time.Now()
+	if !claims.IsValidExpiresAt(now) || !claims.IsValidNotBefore(now) {
+		return ConnectToken{}, ErrTokenExpired
 	}
 
 	subs := map[string]centrifuge.SubscribeOptions{}
@@ -624,11 +622,9 @@ func (verifier *VerifierJWT) VerifySubscribeToken(t string, skipVerify bool) (Su
 		}
 	}
 
-	if !skipVerify {
-		now := time.Now()
-		if !claims.IsValidExpiresAt(now) || !claims.IsValidNotBefore(now) {
-			return SubscribeToken{}, ErrTokenExpired
-		}
+	now := time.Now()
+	if !claims.IsValidExpiresAt(now) || !claims.IsValidNotBefore(now) {
+		return SubscribeToken{}, ErrTokenExpired
 	}
 
 	if claims.Channel == "" {

--- a/internal/jwtverify/token_verifier_jwt_test.go
+++ b/internal/jwtverify/token_verifier_jwt_test.go
@@ -204,7 +204,7 @@ func Test_tokenVerifierJWT_Valid(t *testing.T) {
 	require.NoError(t, err)
 	verifier, err := NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, "", "", "", "", ""}, ruleContainer)
 	require.NoError(t, err)
-	ct, err := verifier.VerifyConnectToken(jwtValid)
+	ct, err := verifier.VerifyConnectToken(jwtValid, false)
 	require.NoError(t, err)
 	require.Equal(t, "2694", ct.UserID)
 	require.NotNil(t, ct.Info)
@@ -219,7 +219,7 @@ func Test_tokenVerifierJWT_Audience(t *testing.T) {
 	require.NoError(t, err)
 
 	// Token without aud.
-	_, err = verifier.VerifyConnectToken(jwtValid)
+	_, err = verifier.VerifyConnectToken(jwtValid, false)
 	require.ErrorIs(t, err, ErrInvalidToken)
 
 	// Generate token with aud.
@@ -229,25 +229,25 @@ func Test_tokenVerifierJWT_Audience(t *testing.T) {
 	verifier, err = NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, "", "test2", "", "", ""}, ruleContainer)
 	require.NoError(t, err)
 
-	_, err = verifier.VerifyConnectToken(token)
+	_, err = verifier.VerifyConnectToken(token, false)
 	require.ErrorIs(t, err, ErrInvalidToken)
 
 	// Verifier with token audience.
 	verifier, err = NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, "", "test", "", "", ""}, ruleContainer)
 	require.NoError(t, err)
-	_, err = verifier.VerifyConnectToken(token)
+	_, err = verifier.VerifyConnectToken(token, false)
 	require.NoError(t, err)
 
 	// Verifier with token audience - valid.
 	verifier, err = NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, "", "", "test", "", ""}, ruleContainer)
 	require.NoError(t, err)
-	_, err = verifier.VerifyConnectToken(token)
+	_, err = verifier.VerifyConnectToken(token, false)
 	require.NoError(t, err)
 
 	// Verifier with token audience - invalid.
 	verifier, err = NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, "", "", "test2", "", ""}, ruleContainer)
 	require.NoError(t, err)
-	_, err = verifier.VerifyConnectToken(token)
+	_, err = verifier.VerifyConnectToken(token, false)
 	require.Error(t, err)
 }
 
@@ -259,7 +259,7 @@ func Test_tokenVerifierJWT_Issuer(t *testing.T) {
 	require.NoError(t, err)
 
 	// Token without iss.
-	_, err = verifier.VerifyConnectToken(jwtValid)
+	_, err = verifier.VerifyConnectToken(jwtValid, false)
 	require.ErrorIs(t, err, ErrInvalidToken)
 
 	// Generate token with iss.
@@ -268,25 +268,25 @@ func Test_tokenVerifierJWT_Issuer(t *testing.T) {
 	// Verifier with issuer which does not match token iss.
 	verifier, err = NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, "", "", "", "test2", ""}, ruleContainer)
 	require.NoError(t, err)
-	_, err = verifier.VerifyConnectToken(token)
+	_, err = verifier.VerifyConnectToken(token, false)
 	require.ErrorIs(t, err, ErrInvalidToken)
 
 	// Verifier with token issuer.
 	verifier, err = NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, "", "", "", "test", ""}, ruleContainer)
 	require.NoError(t, err)
-	_, err = verifier.VerifyConnectToken(token)
+	_, err = verifier.VerifyConnectToken(token, false)
 	require.NoError(t, err)
 
 	// Verifier with token issuer regex - valid.
 	verifier, err = NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, "", "", "", "", "test"}, ruleContainer)
 	require.NoError(t, err)
-	_, err = verifier.VerifyConnectToken(token)
+	_, err = verifier.VerifyConnectToken(token, false)
 	require.NoError(t, err)
 
 	// Verifier with token issuer regex - invalid.
 	verifier, err = NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, "", "", "", "", "test2"}, ruleContainer)
 	require.NoError(t, err)
-	_, err = verifier.VerifyConnectToken(token)
+	_, err = verifier.VerifyConnectToken(token, false)
 	require.Error(t, err)
 }
 
@@ -296,7 +296,7 @@ func Test_tokenVerifierJWT_Expired(t *testing.T) {
 	require.NoError(t, err)
 	verifier, err := NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, "", "", "", "", ""}, ruleContainer)
 	require.NoError(t, err)
-	_, err = verifier.VerifyConnectToken(jwtExpired)
+	_, err = verifier.VerifyConnectToken(jwtExpired, false)
 	require.Error(t, err)
 	require.Equal(t, ErrTokenExpired, err)
 }
@@ -307,7 +307,7 @@ func Test_tokenVerifierJWT_DisabledAlgorithm(t *testing.T) {
 	require.NoError(t, err)
 	verifier, err := NewTokenVerifierJWT(VerifierConfig{"", nil, nil, "", "", "", "", ""}, ruleContainer)
 	require.NoError(t, err)
-	_, err = verifier.VerifyConnectToken(jwtExpired)
+	_, err = verifier.VerifyConnectToken(jwtExpired, false)
 	require.Error(t, err)
 	require.True(t, errors.Is(err, ErrInvalidToken), err.Error())
 }
@@ -318,7 +318,7 @@ func Test_tokenVerifierJWT_InvalidSignature(t *testing.T) {
 	require.NoError(t, err)
 	verifier, err := NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, "", "", "", "", ""}, ruleContainer)
 	require.NoError(t, err)
-	_, err = verifier.VerifyConnectToken(jwtInvalidSignature)
+	_, err = verifier.VerifyConnectToken(jwtInvalidSignature, false)
 	require.Error(t, err)
 }
 
@@ -328,7 +328,7 @@ func Test_tokenVerifierJWT_WithNotBefore(t *testing.T) {
 	require.NoError(t, err)
 	verifier, err := NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, "", "", "", "", ""}, ruleContainer)
 	require.NoError(t, err)
-	_, err = verifier.VerifyConnectToken(jwtNotBefore)
+	_, err = verifier.VerifyConnectToken(jwtNotBefore, false)
 	require.Error(t, err)
 }
 
@@ -338,7 +338,7 @@ func Test_tokenVerifierJWT_StringAudience(t *testing.T) {
 	require.NoError(t, err)
 	verifier, err := NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, "", "", "", "", ""}, ruleContainer)
 	require.NoError(t, err)
-	ct, err := verifier.VerifyConnectToken(jwtStringAud)
+	ct, err := verifier.VerifyConnectToken(jwtStringAud, false)
 	require.NoError(t, err)
 	require.Equal(t, "2694", ct.UserID)
 }
@@ -349,7 +349,7 @@ func Test_tokenVerifierJWT_ArrayAudience(t *testing.T) {
 	require.NoError(t, err)
 	verifier, err := NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, "", "", "", "", ""}, ruleContainer)
 	require.NoError(t, err)
-	ct, err := verifier.VerifyConnectToken(jwtArrayAud)
+	ct, err := verifier.VerifyConnectToken(jwtArrayAud, false)
 	require.NoError(t, err)
 	require.Equal(t, "2694", ct.UserID)
 }
@@ -441,7 +441,7 @@ func Test_tokenVerifierJWT_VerifyConnectToken(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := tt.verifier.VerifyConnectToken(tt.args.token)
+			got, err := tt.verifier.VerifyConnectToken(tt.args.token, false)
 			if tt.wantErr && err == nil {
 				t.Errorf("VerifyConnectToken() should return error")
 			}
@@ -533,7 +533,7 @@ func Test_tokenVerifierJWT_VerifyConnectTokenWithJWK(t *testing.T) {
 
 			token := getRSAConnToken(tt.token.user, tt.token.exp, privKey, jwt.WithKeyID(tt.jwk.kid))
 
-			got, err := verifier.VerifyConnectToken(token)
+			got, err := verifier.VerifyConnectToken(token, false)
 			if tt.wantErr {
 				r.Error(err)
 				return
@@ -649,7 +649,7 @@ func Test_tokenVerifierJWT_VerifySubscribeToken(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := tt.verifier.VerifySubscribeToken(tt.args.token)
+			got, err := tt.verifier.VerifySubscribeToken(tt.args.token, false)
 			if tt.wantErr && err == nil {
 				t.Errorf("VerifySubscribeToken() should return error")
 			}
@@ -674,7 +674,7 @@ func BenchmarkConnectTokenVerify_Valid(b *testing.B) {
 	require.NoError(b, err)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, err := verifierJWT.VerifyConnectToken(jwtValid)
+		_, err := verifierJWT.VerifyConnectToken(jwtValid, false)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -690,7 +690,7 @@ func BenchmarkConnectTokenVerify_Expired(b *testing.B) {
 	verifier, err := NewTokenVerifierJWT(VerifierConfig{"secret", nil, nil, "", "", "", "", ""}, ruleContainer)
 	require.NoError(b, err)
 	for i := 0; i < b.N; i++ {
-		_, err := verifier.VerifyConnectToken(jwtExpired)
+		_, err := verifier.VerifyConnectToken(jwtExpired, false)
 		if err != ErrTokenExpired {
 			panic(err)
 		}

--- a/internal/rule/rule.go
+++ b/internal/rule/rule.go
@@ -55,10 +55,10 @@ type Config struct {
 	// anonymous access and publish allowed for all channels, no connection expire
 	// performed. This can be suitable for demonstration or personal usage.
 	ClientInsecure bool
-	// ClientInsecureSkipTokenVerify if on tells Centrifugo to ignore token verification
-	// errors - for both connection and subscription tokens. This is insecure and should
-	// only be used for development and testing purposes.
-	ClientInsecureSkipTokenVerify bool
+	// ClientInsecureSkipTokenSignatureVerify if on tells Centrifugo to ignore token
+	// signature verification errors - for both connection and subscription tokens.
+	// This is insecure and should only be used for development and testing purposes.
+	ClientInsecureSkipTokenSignatureVerify bool
 
 	// AnonymousConnectWithoutToken when set to true, allows connecting without specifying
 	// a connection token or setting Credentials in authentication middleware. The resulting

--- a/internal/rule/rule.go
+++ b/internal/rule/rule.go
@@ -55,6 +55,11 @@ type Config struct {
 	// anonymous access and publish allowed for all channels, no connection expire
 	// performed. This can be suitable for demonstration or personal usage.
 	ClientInsecure bool
+	// ClientInsecureSkipTokenVerify if on tells Centrifugo to ignore token verification
+	// errors - for both connection and subscription tokens. This is insecure and should
+	// only be used for development and testing purposes.
+	ClientInsecureSkipTokenVerify bool
+
 	// AnonymousConnectWithoutToken when set to true, allows connecting without specifying
 	// a connection token or setting Credentials in authentication middleware. The resulting
 	// user will have empty string for user ID (i.e. user is treated as anonymous).

--- a/main.go
+++ b/main.go
@@ -100,8 +100,9 @@ var defaults = map[string]any{
 	"opentelemetry":     false,
 	"opentelemetry_api": false,
 
-	"client_insecure": false,
-	"api_insecure":    false,
+	"client_insecure":                   false,
+	"client_insecure_skip_token_verify": false,
+	"api_insecure":                      false,
 
 	"token_hmac_secret_key":      "",
 	"token_rsa_public_key":       "",
@@ -1623,6 +1624,7 @@ func ruleConfig() rule.Config {
 	cfg.UserPersonalSingleConnection = v.GetBool("user_personal_single_connection")
 	cfg.UserPersonalChannelNamespace = v.GetString("user_personal_channel_namespace")
 	cfg.ClientInsecure = v.GetBool("client_insecure")
+	cfg.ClientInsecureSkipTokenVerify = v.GetBool("client_insecure_skip_token_verify")
 	cfg.AnonymousConnectWithoutToken = v.GetBool("allow_anonymous_connect_without_token")
 	cfg.DisallowAnonymousConnectionTokens = v.GetBool("disallow_anonymous_connection_tokens")
 	cfg.ClientConcurrency = v.GetInt("client_concurrency")

--- a/main.go
+++ b/main.go
@@ -100,9 +100,9 @@ var defaults = map[string]any{
 	"opentelemetry":     false,
 	"opentelemetry_api": false,
 
-	"client_insecure":                   false,
-	"client_insecure_skip_token_verify": false,
-	"api_insecure":                      false,
+	"client_insecure": false,
+	"client_insecure_skip_token_signature_verify": false,
+	"api_insecure": false,
 
 	"token_hmac_secret_key":      "",
 	"token_rsa_public_key":       "",
@@ -1624,7 +1624,7 @@ func ruleConfig() rule.Config {
 	cfg.UserPersonalSingleConnection = v.GetBool("user_personal_single_connection")
 	cfg.UserPersonalChannelNamespace = v.GetString("user_personal_channel_namespace")
 	cfg.ClientInsecure = v.GetBool("client_insecure")
-	cfg.ClientInsecureSkipTokenVerify = v.GetBool("client_insecure_skip_token_verify")
+	cfg.ClientInsecureSkipTokenSignatureVerify = v.GetBool("client_insecure_skip_token_signature_verify")
 	cfg.AnonymousConnectWithoutToken = v.GetBool("allow_anonymous_connect_without_token")
 	cfg.DisallowAnonymousConnectionTokens = v.GetBool("disallow_anonymous_connection_tokens")
 	cfg.ClientConcurrency = v.GetInt("client_concurrency")


### PR DESCRIPTION
## Proposed changes

Adding boolean option `client_insecure_skip_token_signature_verify`

If enabled tells Centrifugo to skip JWT signature verification - for both connection and subscription tokens. **This is insecure and should only be used for development and testing purposes.** Token claims are parsed as usual - so token should still follow JWT format.



