### PR TITLE
Up golangci-lint to v1.54.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,11 +10,11 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.20.x'
+          go-version: '1.21.x'
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.53.3
+          version: v1.54.2
           args: --timeout 3m0s
   test:
     name: Test with Go ${{ matrix.go-version }}


### PR DESCRIPTION
## Proposed changes

Use go 1.21.x and up golangci-lint to the latest version
