### PR TITLE
Speed up channel config operations 

### DIFF
--- a/internal/rule/cache.go
+++ b/internal/rule/cache.go
@@ -1,0 +1,68 @@
+package rule
+
+import (
+	"hash/fnv"
+	"sync/atomic"
+	"time"
+)
+
+type CacheItem struct {
+	channel string
+	value   channelOptionsResult
+	expires int64
+}
+
+type CacheShard struct {
+	size   int
+	buffer []CacheItem
+	index  int32
+}
+
+type rollingCache struct {
+	shards []*CacheShard
+}
+
+func newRollingCache(size int, shardCount int) *rollingCache {
+	shardSize := size / shardCount
+	rc := &rollingCache{
+		shards: make([]*CacheShard, shardCount),
+	}
+
+	for i := range rc.shards {
+		rc.shards[i] = &CacheShard{
+			size:   shardSize,
+			buffer: make([]CacheItem, shardSize),
+		}
+	}
+
+	return rc
+}
+
+func (c *rollingCache) shardForKey(key string) *CacheShard {
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(key))
+	shardIndex := h.Sum64() % uint64(len(c.shards))
+	return c.shards[shardIndex]
+}
+
+func (c *rollingCache) Get(channel string) (channelOptionsResult, bool) {
+	shard := c.shardForKey(channel)
+	for _, item := range shard.buffer {
+		if item.channel == channel && time.Now().Before(time.Unix(0, item.expires)) {
+			return item.value, true
+		}
+	}
+	return channelOptionsResult{}, false
+}
+
+func (c *rollingCache) Set(channel string, value channelOptionsResult, ttl time.Duration) {
+	shard := c.shardForKey(channel)
+
+	index := int(atomic.AddInt32(&shard.index, 1) % int32(shard.size))
+	item := CacheItem{
+		channel: channel,
+		value:   value,
+		expires: time.Now().Add(ttl).UnixNano(),
+	}
+	shard.buffer[index] = item
+}

--- a/internal/rule/cache_test.go
+++ b/internal/rule/cache_test.go
@@ -1,0 +1,55 @@
+package rule
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRollingCache(t *testing.T) {
+	size := 30
+	shardCount := 1
+	cache := newRollingCache(size, shardCount)
+
+	// Testing Set.
+	channel := "channel1"
+	value := channelOptionsResult{nsName: "value1"}
+	ttl := 200 * time.Millisecond
+	cache.Set(channel, value, ttl)
+
+	// Testing Get after Set.
+	gotValue, ok := cache.Get(channel)
+	require.True(t, ok)
+	require.Equal(t, value, gotValue)
+
+	// Testing Get after expiry.
+	time.Sleep(400 * time.Millisecond)
+	_, ok = cache.Get(channel)
+	require.False(t, ok)
+
+	// Testing if data rolls over.
+	// Setting more data than cache size, to see if rolling over works without errors.
+	for i := 0; i < size+10; i++ {
+		channel := "channel" + strconv.Itoa(i)
+		value := channelOptionsResult{nsName: "value" + strconv.Itoa(i)}
+		cache.Set(channel, value, ttl)
+	}
+
+	// The first 10 items should have been rolled over and replaced.
+	// So, channel0, channel1, ... channel9 should no longer be in the cache.
+	for i := 0; i < 10; i++ {
+		channel := "channel" + strconv.Itoa(i)
+		_, ok = cache.Get(channel)
+		require.False(t, ok, channel)
+	}
+
+	// Whereas, the items from channel10 onwards should still be there.
+	for i := 10; i < size+10; i++ {
+		channel := "channel" + strconv.Itoa(i)
+		gotValue, ok := cache.Get(channel)
+		require.True(t, ok)
+		require.Equal(t, channelOptionsResult{nsName: "value" + strconv.Itoa(i)}, gotValue)
+	}
+}

--- a/internal/rule/rule.go
+++ b/internal/rule/rule.go
@@ -212,6 +212,11 @@ type Container struct {
 	ChannelOptionsCacheTTL time.Duration
 }
 
+const (
+	channelOptionsCacheSize   = 100
+	channelOptionsCacheShards = 16
+)
+
 // NewContainer ...
 func NewContainer(config Config) (*Container, error) {
 	preparedConfig, err := getPreparedConfig(config)
@@ -219,7 +224,7 @@ func NewContainer(config Config) (*Container, error) {
 		return nil, err
 	}
 	c := &Container{
-		channelOptionsCache: newRollingCache(100, 16),
+		channelOptionsCache: newRollingCache(channelOptionsCacheSize, channelOptionsCacheShards),
 	}
 	c.configValue.Store(*preparedConfig)
 	return c, nil

--- a/internal/rule/rule_test.go
+++ b/internal/rule/rule_test.go
@@ -137,6 +137,59 @@ func TestIsUserLimited(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, rules.IsUserLimited("#12"))
 	require.True(t, rules.IsUserLimited("test#12"))
-	rules.config.ChannelUserBoundary = ""
+	config := rules.Config()
+	config.ChannelUserBoundary = ""
+	err = rules.Reload(config)
+	require.NoError(t, err)
 	require.False(t, rules.IsUserLimited("#12"))
+}
+
+func BenchmarkContainer_ChannelOptions(b *testing.B) {
+	cfg := DefaultConfig
+	cfg.Namespaces = []ChannelNamespace{
+		{
+			Name: "test0",
+		},
+		{
+			Name: "test1",
+		},
+		{
+			Name: "test2",
+		},
+		{
+			Name: "test3",
+		},
+		{
+			Name: "test4",
+		},
+		{
+			Name: "test5",
+		},
+		{
+			Name: "test6",
+		},
+		{
+			Name: "test7",
+		},
+		{
+			Name: "test8",
+		},
+		{
+			Name: "test9",
+		},
+	}
+	c, _ := NewContainer(cfg)
+
+	b.ReportAllocs()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			nsName, _, _, ok, _ := c.ChannelOptions("test9:123")
+			if !ok {
+				b.Fatal("ns not found")
+			}
+			if nsName != "test9" {
+				b.Fatal("wrong ns name: " + nsName)
+			}
+		}
+	})
 }

--- a/internal/rule/rule_test.go
+++ b/internal/rule/rule_test.go
@@ -2,6 +2,7 @@ package rule
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -179,6 +180,7 @@ func BenchmarkContainer_ChannelOptions(b *testing.B) {
 		},
 	}
 	c, _ := NewContainer(cfg)
+	c.ChannelOptionsCacheTTL = 200 * time.Millisecond
 
 	b.ReportAllocs()
 	b.RunParallel(func(pb *testing.PB) {

--- a/internal/rule/rule_test.go
+++ b/internal/rule/rule_test.go
@@ -1,6 +1,7 @@
 package rule
 
 import (
+	"strconv"
 	"testing"
 	"time"
 
@@ -147,50 +148,53 @@ func TestIsUserLimited(t *testing.T) {
 
 func BenchmarkContainer_ChannelOptions(b *testing.B) {
 	cfg := DefaultConfig
-	cfg.Namespaces = []ChannelNamespace{
-		{
-			Name: "test0",
-		},
-		{
-			Name: "test1",
-		},
-		{
-			Name: "test2",
-		},
-		{
-			Name: "test3",
-		},
-		{
-			Name: "test4",
-		},
-		{
-			Name: "test5",
-		},
-		{
-			Name: "test6",
-		},
-		{
-			Name: "test7",
-		},
-		{
-			Name: "test8",
-		},
-		{
-			Name: "test9",
-		},
+
+	var namespaces []ChannelNamespace
+
+	for i := 0; i < 100; i++ {
+		namespaces = append(namespaces, ChannelNamespace{
+			Name: "test" + strconv.Itoa(i),
+		})
 	}
+	cfg.Namespaces = namespaces
+
 	c, _ := NewContainer(cfg)
 	c.ChannelOptionsCacheTTL = 200 * time.Millisecond
 
 	b.ReportAllocs()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			nsName, _, _, ok, _ := c.ChannelOptions("test9:123")
+			nsName, _, _, ok, _ := c.ChannelOptions("test99:123")
 			if !ok {
 				b.Fatal("ns not found")
 			}
-			if nsName != "test9" {
+			if nsName != "test99" {
 				b.Fatal("wrong ns name: " + nsName)
+			}
+		}
+	})
+}
+
+var testConfig Config
+
+func BenchmarkContainer_Config(b *testing.B) {
+	cfg := DefaultConfig
+	var namespaces []ChannelNamespace
+	for i := 0; i < 100; i++ {
+		namespaces = append(namespaces, ChannelNamespace{
+			Name: "test" + strconv.Itoa(i),
+		})
+	}
+	cfg.Namespaces = namespaces
+	c, _ := NewContainer(cfg)
+	c.ChannelOptionsCacheTTL = 200 * time.Millisecond
+
+	b.ReportAllocs()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			testConfig = c.Config()
+			if len(testConfig.Namespaces) != 100 {
+				b.Fatal("wrong config")
 			}
 		}
 	})

--- a/main.go
+++ b/main.go
@@ -529,6 +529,7 @@ func main() {
 			if err != nil {
 				log.Fatal().Msgf("error creating config: %v", err)
 			}
+			ruleContainer.ChannelOptionsCacheTTL = 200 * time.Millisecond
 
 			granularProxyMode := viper.GetBool("granular_proxy_mode")
 			var proxyMap *client.ProxyMap


### PR DESCRIPTION
## Proposed changes

Using `atomic.Value` to avoid config locks, adding rolling cache with item expiration for retrieving `ChannelOptions`.

Before:

```
BenchmarkContainer_ChannelOptions-12    	 8343092	       140.7 ns/op	      32 B/op	       1 allocs/op
BenchmarkContainer_Config-12            	23106529	        50.98 ns/op	       0 B/op	       0 allocs/op
```

After:

```
BenchmarkContainer_ChannelOptions-12    	22248208	        46.87 ns/op	       0 B/op	       0 allocs/op
BenchmarkContainer_Config-12            	54884310	        21.48 ns/op	       0 B/op	       0 allocs/op
```
