### PR TITLE
Option to extract client connection user id from http header

### DIFF
--- a/internal/middleware/user_header_auth.go
+++ b/internal/middleware/user_header_auth.go
@@ -1,0 +1,25 @@
+package middleware
+
+import (
+	"net/http"
+
+	"github.com/centrifugal/centrifuge"
+)
+
+// UserHeaderAuth is a middleware that extracts the value of user ID from the specific header
+// and sets connection credentials.
+func UserHeaderAuth(userHeaderName string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			userID := r.Header.Get(userHeaderName)
+			if userID != "" {
+				ctx := centrifuge.SetCredentials(r.Context(), &centrifuge.Credentials{
+					UserID: userID,
+				})
+				r = r.WithContext(ctx)
+			}
+			// Call the next handler
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/internal/middleware/user_header_auth_test.go
+++ b/internal/middleware/user_header_auth_test.go
@@ -1,0 +1,46 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/centrifugal/centrifuge"
+	"github.com/stretchr/testify/require"
+)
+
+func userHeaderAuthTestHandler(t *testing.T, userMustBeSet bool) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		cred, ok := centrifuge.GetCredentials(r.Context())
+		if userMustBeSet {
+			require.True(t, ok, "credentials should be set")
+			require.Equal(t, "123", cred.UserID, "user ID should be set correctly")
+		} else {
+			require.False(t, ok)
+		}
+		_, _ = w.Write([]byte("OK"))
+	})
+}
+
+func TestUserHeaderAuthWithUserID(t *testing.T) {
+	middleware := UserHeaderAuth("X-User-ID")
+	req := httptest.NewRequest("GET", "/test", nil)
+	req.Header.Set("X-User-ID", "123")
+	rr := httptest.NewRecorder()
+
+	handler := middleware(userHeaderAuthTestHandler(t, true))
+	handler.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code, "status code should be 200 OK")
+}
+
+func TestUserHeaderAuthWithoutUserID(t *testing.T) {
+	middleware := UserHeaderAuth("X-User-ID")
+	req := httptest.NewRequest("GET", "/test", nil)
+	rr := httptest.NewRecorder()
+
+	handler := middleware(userHeaderAuthTestHandler(t, false))
+	handler.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code, "status code should be 200 OK")
+}

--- a/main.go
+++ b/main.go
@@ -105,7 +105,7 @@ var defaults = map[string]any{
 	"client_insecure_skip_token_signature_verify": false,
 	"api_insecure": false,
 
-	"user_id_http_header": "",
+	"client_auth_user_id_http_header": "",
 
 	"token_hmac_secret_key":      "",
 	"token_rsa_public_key":       "",
@@ -2808,7 +2808,7 @@ func Mux(n *centrifuge.Node, ruleContainer *rule.Container, apiExecutor *api.Exe
 		connLimitMW := middleware.NewConnLimit(n, ruleContainer)
 		connMiddlewares = append(connMiddlewares, connLimitMW.Middleware)
 	}
-	userIDHTTPHeader := v.GetString("user_id_http_header")
+	userIDHTTPHeader := v.GetString("client_auth_user_id_http_header")
 	if userIDHTTPHeader != "" {
 		connMiddlewares = append(connMiddlewares, middleware.UserHeaderAuth(userIDHTTPHeader))
 	}

--- a/main.go
+++ b/main.go
@@ -105,7 +105,7 @@ var defaults = map[string]any{
 	"client_insecure_skip_token_signature_verify": false,
 	"api_insecure": false,
 
-	"client_auth_user_id_http_header": "",
+	"client_user_id_http_header": "",
 
 	"token_hmac_secret_key":      "",
 	"token_rsa_public_key":       "",
@@ -2808,7 +2808,7 @@ func Mux(n *centrifuge.Node, ruleContainer *rule.Container, apiExecutor *api.Exe
 		connLimitMW := middleware.NewConnLimit(n, ruleContainer)
 		connMiddlewares = append(connMiddlewares, connLimitMW.Middleware)
 	}
-	userIDHTTPHeader := v.GetString("client_auth_user_id_http_header")
+	userIDHTTPHeader := v.GetString("client_user_id_http_header")
 	if userIDHTTPHeader != "" {
 		connMiddlewares = append(connMiddlewares, middleware.UserHeaderAuth(userIDHTTPHeader))
 	}

--- a/main.go
+++ b/main.go
@@ -105,6 +105,8 @@ var defaults = map[string]any{
 	"client_insecure_skip_token_signature_verify": false,
 	"api_insecure": false,
 
+	"user_id_http_header": "",
+
 	"token_hmac_secret_key":      "",
 	"token_rsa_public_key":       "",
 	"token_ecdsa_public_key":     "",
@@ -2805,6 +2807,10 @@ func Mux(n *centrifuge.Node, ruleContainer *rule.Container, apiExecutor *api.Exe
 	if connLimit > 0 {
 		connLimitMW := middleware.NewConnLimit(n, ruleContainer)
 		connMiddlewares = append(connMiddlewares, connLimitMW.Middleware)
+	}
+	userIDHTTPHeader := v.GetString("user_id_http_header")
+	if userIDHTTPHeader != "" {
+		connMiddlewares = append(connMiddlewares, middleware.UserHeaderAuth(userIDHTTPHeader))
 	}
 	if keepHeadersInContext {
 		connMiddlewares = append(connMiddlewares, middleware.HeadersToContext)


### PR DESCRIPTION
## Proposed changes

Possibility to set `client_user_id_http_header` option which contains a header name from which Centrifugo will try to extract authenticated user ID for client connections based on HTTP transports (all except unidirectional GRPC). This allows using proxies before Centrifugo which can authenticate requests and set user ID as a header.

In this case applications **must ensure that they strip such headers coming from clients on proxy level before authenticating request to avoid malicious usage**.

Ex.

```json
{
  ..
  "client_user_id_http_header": "X-User-Id"
}
```

In this case we do not support setting  connection expiration and info.

TODO: possibly think a bit on a better option name.