### PR TITLE
Refactor MakeTLSConfig and support mTLS on server

### DIFF
--- a/internal/tools/tls.go
+++ b/internal/tools/tls.go
@@ -23,51 +23,143 @@ type ReadFileFunc func(name string) ([]byte, error)
 // scoped under key prefix.
 func MakeTLSConfig(v ConfigGetter, keyPrefix string, readFile ReadFileFunc) (*tls.Config, error) {
 	tlsConfig := &tls.Config{}
-	if v.GetString(keyPrefix+"tls_cert") != "" && v.GetString(keyPrefix+"tls_key") != "" {
-		certPEMBlock, err := readFile(v.GetString(keyPrefix + "tls_cert"))
-		if err != nil {
+
+	loaders := []tlsConfigLoader{
+		chainTLSConfigLoaders(loadCertFromFile, loadCertFromPEM),
+		chainTLSConfigLoaders(loadRootCAFromFile, loadRootCAFromPEM),
+	}
+	for _, loadConfig := range loaders {
+		if _, err := loadConfig(tlsConfig, v, keyPrefix, readFile); err != nil {
 			return nil, err
 		}
-		keyPEMBlock, err := readFile(v.GetString(keyPrefix + "tls_key"))
-		if err != nil {
-			return nil, err
-		}
-		cert, err := tls.X509KeyPair(certPEMBlock, keyPEMBlock)
-		if err != nil {
-			return nil, fmt.Errorf("could not read the certificate/key: %s", err)
-		}
-		tlsConfig.Certificates = []tls.Certificate{cert}
-	} else if v.GetString(keyPrefix+"tls_cert_pem") != "" && v.GetString(keyPrefix+"tls_key_pem") != "" {
-		cert, err := tls.X509KeyPair([]byte(v.GetString(keyPrefix+"tls_cert_pem")), []byte(v.GetString(keyPrefix+"tls_key_pem")))
-		if err != nil {
-			return nil, fmt.Errorf("error creating X509 key pair: %s", err)
-		}
-		tlsConfig.Certificates = []tls.Certificate{cert}
 	}
-	if v.GetString(keyPrefix+"tls_root_ca") != "" {
-		caCert, err := readFile(v.GetString(keyPrefix + "tls_root_ca"))
-		if err != nil {
-			return nil, fmt.Errorf("can not read the CA certificate: %s", err)
-		}
-		caCertPool := x509.NewCertPool()
-		ok := caCertPool.AppendCertsFromPEM(caCert)
-		if !ok {
-			return nil, errors.New("can not parse CA certificate")
-		}
-		tlsConfig.RootCAs = caCertPool
-	} else if v.GetString(keyPrefix+"tls_root_ca_pem") != "" {
-		caCertPool := x509.NewCertPool()
-		ok := caCertPool.AppendCertsFromPEM([]byte(v.GetString(keyPrefix + "tls_root_ca_pem")))
-		if !ok {
-			return nil, errors.New("can not parse CA certificate")
-		}
-		tlsConfig.RootCAs = caCertPool
-	}
-	if v.GetString(keyPrefix+"tls_server_name") != "" {
-		tlsConfig.ServerName = v.GetString(keyPrefix + "tls_server_name")
-	}
-	if v.GetBool(keyPrefix + "tls_insecure_skip_verify") {
-		tlsConfig.InsecureSkipVerify = true
-	}
+
+	tlsConfig.ServerName = v.GetString(keyPrefix + "tls_server_name")
+	tlsConfig.InsecureSkipVerify = v.GetBool(keyPrefix + "tls_insecure_skip_verify")
+
 	return tlsConfig, nil
+}
+
+// tlsConfigLoader is a function that loads TLS from the given ConfigGetter.
+// It returns false, nil if configuration does not exist, true, nil on success,
+// or true, err ≠ nil if there was an error loading the configuration.
+type tlsConfigLoader func(c *tls.Config, v ConfigGetter, keyPrefix string, readFile ReadFileFunc) (bool, error)
+
+// chainTLSConfigLoaders returns tlsConfigLoader function that attempts to load
+// TLS configuration until either a configuration is found or an error occurs.
+func chainTLSConfigLoaders(loaders ...tlsConfigLoader) tlsConfigLoader {
+	return func(c *tls.Config, v ConfigGetter, keyPrefix string, readFile ReadFileFunc) (bool, error) {
+		for _, f := range loaders {
+			found, err := f(c, v, keyPrefix, readFile)
+			if found || err != nil {
+				return found, err
+			}
+		}
+		return false, nil
+	}
+}
+
+// loadCertFromFile loads the TLS configuration with certificate from key pair
+// files containing PEM-encoded TLS key and certificate.
+func loadCertFromFile(tlsConfig *tls.Config, v ConfigGetter, keyPrefix string, readFile ReadFileFunc) (bool, error) {
+	certFileKeyName, keyFileKeyName := keyPrefix+"tls_cert", keyPrefix+"tls_key"
+
+	certFile, keyFile := v.GetString(certFileKeyName), v.GetString(keyFileKeyName)
+	if certFile == "" || keyFile == "" {
+		return false, nil
+	}
+
+	certPEMBlock, err := readFile(certFile)
+	if err != nil {
+		return true, fmt.Errorf("read TLS certificate for %s: %w", certFileKeyName, err)
+	}
+	keyPEMBlock, err := readFile(keyFile)
+	if err != nil {
+		return true, fmt.Errorf("read TLS key for %s: %w", keyFileKeyName, err)
+	}
+
+	cert, err := tls.X509KeyPair(certPEMBlock, keyPEMBlock)
+	if err != nil {
+		return true, fmt.Errorf("parse certificate/key pair for %s/%s: %w", certFileKeyName, keyFileKeyName, err)
+	}
+
+	tlsConfig.Certificates = []tls.Certificate{cert}
+
+	return true, nil
+}
+
+// loadCertFromPEM loads the TLS configuration with certificate from key pair
+// strings containing PEM-encoded TLS key and certificate.
+func loadCertFromPEM(tlsConfig *tls.Config, v ConfigGetter, keyPrefix string, _ ReadFileFunc) (bool, error) {
+	certPEMKeyName, keyPEMKeyName := keyPrefix+"tls_cert_pem", keyPrefix+"tls_key_pem"
+
+	certPEM, keyPEM := v.GetString(certPEMKeyName), v.GetString(keyPEMKeyName)
+	if certPEM == "" || keyPEM == "" {
+		return false, nil
+	}
+
+	cert, err := tls.X509KeyPair([]byte(certPEM), []byte(keyPEM))
+	if err != nil {
+		return true, fmt.Errorf("parse certificate/key pair for %s/%s: %w", certPEMKeyName, keyPEMKeyName, err)
+	}
+
+	tlsConfig.Certificates = []tls.Certificate{cert}
+
+	return true, nil
+}
+
+// loadRootCAFromFile loads the TLS configuration with root CA bundle from file
+// containing PEM-encoded certificates.
+func loadRootCAFromFile(tlsConfig *tls.Config, v ConfigGetter, keyPrefix string, readFile ReadFileFunc) (bool, error) {
+	keyName := keyPrefix + "tls_root_ca"
+
+	rootCAFile := v.GetString(keyName)
+	if rootCAFile == "" {
+		return false, nil
+	}
+
+	caCert, err := readFile(rootCAFile)
+	if err != nil {
+		return true, fmt.Errorf("read the root CA certificate for %s: %w", keyName, err)
+	}
+
+	caCertPool, err := newCertPoolFromPEM(caCert)
+	if err != nil {
+		return true, fmt.Errorf("parse root CA certificate for %s: %w", keyName, err)
+	}
+
+	tlsConfig.RootCAs = caCertPool
+
+	return true, nil
+}
+
+// loadRootCAFromFile loads the TLS configuration with root CA bundle from
+// string containing PEM-encoded certificates.
+func loadRootCAFromPEM(tlsConfig *tls.Config, v ConfigGetter, keyPrefix string, _ ReadFileFunc) (bool, error) {
+	keyName := keyPrefix + "tls_root_ca_pem"
+
+	rootCAPEM := v.GetString(keyName)
+	if rootCAPEM == "" {
+		return false, nil
+	}
+
+	caCertPool, err := newCertPoolFromPEM([]byte(rootCAPEM))
+	if err != nil {
+		return true, fmt.Errorf("parse root CA certificate for %s: %w", keyName, err)
+	}
+
+	tlsConfig.RootCAs = caCertPool
+
+	return true, nil
+}
+
+// newCertPoolFromPEM returns certificate pool for the given PEM-encoded
+// certificate bundle. Note that it currently ignores invalid blocks.
+func newCertPoolFromPEM(pem []byte) (*x509.CertPool, error) {
+	certPool := x509.NewCertPool()
+	ok := certPool.AppendCertsFromPEM(pem)
+	if !ok {
+		return nil, errors.New("no valid certificates found")
+	}
+	return certPool, nil
 }

--- a/internal/tools/tls.go
+++ b/internal/tools/tls.go
@@ -5,7 +5,6 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"os"
 )
 
 type ConfigGetter interface {
@@ -13,10 +12,27 @@ type ConfigGetter interface {
 	GetString(name string) string
 }
 
-func MakeTLSConfig(v ConfigGetter, keyPrefix string) (*tls.Config, error) {
+// ReadFileFunc is an abstraction for os.ReadFile but also io/fs.ReadFile
+// wrapped with an io/fs.FS instance.
+//
+// Note that os.DirFS has slightly different semantics compared to the native
+// filesystem APIs, see https://go.dev/issue/44279
+type ReadFileFunc func(name string) ([]byte, error)
+
+// MakeTLSConfig constructs a tls.Config instance using the given configuration
+// scoped under key prefix.
+func MakeTLSConfig(v ConfigGetter, keyPrefix string, readFile ReadFileFunc) (*tls.Config, error) {
 	tlsConfig := &tls.Config{}
 	if v.GetString(keyPrefix+"tls_cert") != "" && v.GetString(keyPrefix+"tls_key") != "" {
-		cert, err := tls.LoadX509KeyPair(v.GetString(keyPrefix+"tls_cert"), v.GetString(keyPrefix+"tls_key"))
+		certPEMBlock, err := readFile(v.GetString(keyPrefix + "tls_cert"))
+		if err != nil {
+			return nil, err
+		}
+		keyPEMBlock, err := readFile(v.GetString(keyPrefix + "tls_key"))
+		if err != nil {
+			return nil, err
+		}
+		cert, err := tls.X509KeyPair(certPEMBlock, keyPEMBlock)
 		if err != nil {
 			return nil, fmt.Errorf("could not read the certificate/key: %s", err)
 		}
@@ -29,7 +45,7 @@ func MakeTLSConfig(v ConfigGetter, keyPrefix string) (*tls.Config, error) {
 		tlsConfig.Certificates = []tls.Certificate{cert}
 	}
 	if v.GetString(keyPrefix+"tls_root_ca") != "" {
-		caCert, err := os.ReadFile(v.GetString(keyPrefix + "tls_root_ca"))
+		caCert, err := readFile(v.GetString(keyPrefix + "tls_root_ca"))
 		if err != nil {
 			return nil, fmt.Errorf("can not read the CA certificate: %s", err)
 		}

--- a/internal/tools/tls_test.go
+++ b/internal/tools/tls_test.go
@@ -1,0 +1,300 @@
+package tools
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"strconv"
+	"testing"
+	"testing/fstest"
+)
+
+const testCertPEM = `-----BEGIN CERTIFICATE-----
+MIIBhTCCASugAwIBAgIQIRi6zePL6mKjOipn+dNuaTAKBggqhkjOPQQDAjASMRAw
+DgYDVQQKEwdBY21lIENvMB4XDTE3MTAyMDE5NDMwNloXDTE4MTAyMDE5NDMwNlow
+EjEQMA4GA1UEChMHQWNtZSBDbzBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABD0d
+7VNhbWvZLWPuj/RtHFjvtJBEwOkhbN/BnnE8rnZR8+sbwnc/KhCk3FhnpHZnQz7B
+5aETbbIgmuvewdjvSBSjYzBhMA4GA1UdDwEB/wQEAwICpDATBgNVHSUEDDAKBggr
+BgEFBQcDATAPBgNVHRMBAf8EBTADAQH/MCkGA1UdEQQiMCCCDmxvY2FsaG9zdDo1
+NDUzgg4xMjcuMC4wLjE6NTQ1MzAKBggqhkjOPQQDAgNIADBFAiEA2zpJEPQyz6/l
+Wf86aX6PepsntZv2GYlA5UpabfT2EZICICpJ5h/iI+i341gBmLiAFQOyTDT+/wQc
+6MF9+Yw1Yy0t
+-----END CERTIFICATE-----`
+
+const testKeyPEM = `-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEIIrYSSNQFaA2Hwf1duRSxKtLYX5CB04fSeQ6tF1aY/PuoAoGCCqGSM49
+AwEHoUQDQgAEPR3tU2Fta9ktY+6P9G0cWO+0kETA6SFs38GecTyudlHz6xvCdz8q 
+EKTcWGekdmdDPsHloRNtsiCa697B2O9IFA==
+-----END EC PRIVATE KEY-----`
+
+var testCertificate, _ = tls.X509KeyPair([]byte(testCertPEM), []byte(testKeyPEM))
+
+var testCertPool, _ = newCertPoolFromPEM([]byte(testCertPEM))
+
+type testConfigGetter map[string]string
+
+func (c testConfigGetter) GetBool(name string) bool {
+	v, _ := strconv.ParseBool(c[name])
+	return v
+}
+
+func (c testConfigGetter) GetString(name string) string {
+	return c[name]
+}
+
+func TestMakeTLSConfig(t *testing.T) {
+	testCases := []struct {
+		name   string
+		config testConfigGetter
+		prefix string
+		fsys   fstest.MapFS
+		expect tls.Config
+		errOK  bool
+	}{{
+		name: "empty",
+	}, {
+		name: "serverName",
+		config: testConfigGetter{
+			"tls_server_name": "example.com",
+		},
+		expect: tls.Config{
+			ServerName: "example.com",
+		},
+	}, {
+		name: "insecureSkipVerify",
+		config: testConfigGetter{
+			"tls_insecure_skip_verify": "true",
+		},
+		expect: tls.Config{
+			InsecureSkipVerify: true,
+		},
+	}, {
+		name: "certPEM",
+		config: testConfigGetter{
+			"tls_key_pem":  testKeyPEM,
+			"tls_cert_pem": testCertPEM,
+		},
+		expect: tls.Config{
+			Certificates: []tls.Certificate{testCertificate},
+		},
+	}, {
+		name: "certPEMWithoutKey",
+		config: testConfigGetter{
+			"tls_cert_pem": testCertPEM,
+		},
+	}, {
+		name: "keyPEMWithoutCert",
+		config: testConfigGetter{
+			"tls_key_pem": testKeyPEM,
+		},
+	}, {
+		name: "badKeyPairPEM",
+		config: testConfigGetter{
+			"tls_key_pem":  "garbage",
+			"tls_cert_pem": "garbage",
+		},
+		errOK: true,
+	}, {
+		name: "certFile",
+		config: testConfigGetter{
+			"tls_key":  "tls/centrifugo.key",
+			"tls_cert": "tls/centrifugo.cert",
+		},
+		fsys: fstest.MapFS{
+			"tls/centrifugo.key": &fstest.MapFile{
+				Data: []byte(testKeyPEM),
+			},
+			"tls/centrifugo.cert": &fstest.MapFile{
+				Data: []byte(testCertPEM),
+			},
+		},
+		expect: tls.Config{
+			Certificates: []tls.Certificate{testCertificate},
+		},
+	}, {
+		name: "certFileWithoutKey",
+		config: testConfigGetter{
+			"tls_cert": "tls/centrifugo.cert",
+		},
+	}, {
+		name: "keyFileWithoutCert",
+		config: testConfigGetter{
+			"tls_key": "tls/centrifugo.key",
+		},
+	}, {
+		name: "missingCertFile",
+		config: testConfigGetter{
+			"tls_key":  "tls/centrifugo.key",
+			"tls_cert": "tls/centrifugo.cert",
+		},
+		fsys: fstest.MapFS{
+			"tls/centrifugo.key": &fstest.MapFile{
+				Data: []byte(testKeyPEM),
+			},
+		},
+		errOK: true,
+	}, {
+		name: "missingKeyFile",
+		config: testConfigGetter{
+			"tls_key":  "tls/centrifugo.key",
+			"tls_cert": "tls/centrifugo.cert",
+		},
+		fsys: fstest.MapFS{
+			"tls/centrifugo.cert": &fstest.MapFile{
+				Data: []byte(testCertPEM),
+			},
+		},
+		errOK: true,
+	}, {
+		name: "badKeyPairFile",
+		config: testConfigGetter{
+			"tls_key":  "tls/centrifugo.key",
+			"tls_cert": "tls/centrifugo.cert",
+		},
+		fsys: fstest.MapFS{
+			"tls/centrifugo.key":  &fstest.MapFile{},
+			"tls/centrifugo.cert": &fstest.MapFile{},
+		},
+		errOK: true,
+	}, {
+		name: "rootCAPEM",
+		config: testConfigGetter{
+			"tls_root_ca_pem": testCertPEM,
+		},
+		expect: tls.Config{
+			RootCAs: testCertPool,
+		},
+	}, {
+		name: "badRootCAPEM",
+		config: testConfigGetter{
+			"tls_root_ca_pem": "garbage",
+		},
+		errOK: true,
+	}, {
+		name: "rootCAFile",
+		config: testConfigGetter{
+			"tls_root_ca": "certs.pem",
+		},
+		fsys: fstest.MapFS{
+			"certs.pem": &fstest.MapFile{
+				Data: []byte(testCertPEM),
+			},
+		},
+		expect: tls.Config{
+			RootCAs: testCertPool,
+		},
+	}, {
+		name: "missingRootCAFile",
+		config: testConfigGetter{
+			"tls_root_ca": "certs.pem",
+		},
+		errOK: true,
+	}, {
+		name: "badRootCAFile",
+		config: testConfigGetter{
+			"tls_root_ca": "certs.pem",
+		},
+		fsys: fstest.MapFS{
+			"certs.pem": &fstest.MapFile{},
+		},
+		errOK: true,
+	}, {
+		name: "prefixedWithAllFields",
+		config: testConfigGetter{
+			"test_tls_cert":                 "tls/centrifugo.cert",
+			"test_tls_key":                  "tls/centrifugo.key",
+			"test_tls_cert_pem":             "garbage",
+			"test_tls_key_pem":              "garbage",
+			"test_tls_root_ca":              "root.pem",
+			"test_tls_root_ca_pem":          "garbage",
+			"test_tls_server_name":          "example.com",
+			"test_tls_insecure_skip_verify": "true",
+		},
+		prefix: "test_",
+		fsys: fstest.MapFS{
+			"tls/centrifugo.key": &fstest.MapFile{
+				Data: []byte(testKeyPEM),
+			},
+			"tls/centrifugo.cert": &fstest.MapFile{
+				Data: []byte(testCertPEM),
+			},
+			"root.pem": &fstest.MapFile{
+				Data: []byte(testCertPEM),
+			},
+		},
+		expect: tls.Config{
+			ServerName:         "example.com",
+			InsecureSkipVerify: true,
+			RootCAs:            testCertPool,
+			Certificates:       []tls.Certificate{testCertificate},
+		},
+	}, {
+		name: "prefixedWithAllPEMFields",
+		config: testConfigGetter{
+			"test_tls_cert_pem":             testCertPEM,
+			"test_tls_key_pem":              testKeyPEM,
+			"test_tls_root_ca_pem":          testCertPEM,
+			"test_tls_server_name":          "example.com",
+			"test_tls_insecure_skip_verify": "true",
+		},
+		prefix: "test_",
+		expect: tls.Config{
+			ServerName:         "example.com",
+			InsecureSkipVerify: true,
+			RootCAs:            testCertPool,
+			Certificates:       []tls.Certificate{testCertificate},
+		},
+	}}
+	for i := range testCases {
+		tc := &testCases[i]
+		t.Run(tc.name, func(t *testing.T) {
+			config, err := MakeTLSConfig(tc.config, tc.prefix, tc.fsys.ReadFile)
+			switch {
+			case tc.errOK:
+				if err == nil {
+					t.Fatal("expected error")
+				}
+			case err != nil:
+				t.Fatal(err)
+			default:
+				checkTLSConfig(t, &tc.expect, config)
+			}
+		})
+	}
+}
+
+func checkTLSConfig(t *testing.T, a, b *tls.Config) {
+	if a.ServerName != b.ServerName {
+		t.Errorf(
+			"expected tls.Config.ServerName to be %q, but got %q",
+			a.ServerName, b.ServerName,
+		)
+	}
+	if a.InsecureSkipVerify != b.InsecureSkipVerify {
+		t.Errorf(
+			"expected tls.Config.InsecureSkipVerify to be %t, but got %t",
+			a.InsecureSkipVerify, b.InsecureSkipVerify,
+		)
+	}
+	if len(a.Certificates) != len(b.Certificates) {
+		// TODO: check that tls.Certificate instances are equal.
+		t.Errorf(
+			"expected tls.Config.Certificates length to be %d, but got %d",
+			len(a.Certificates), len(b.Certificates),
+		)
+	}
+	if !a.RootCAs.Equal(b.RootCAs) {
+		t.Error("expected tls.Config.RootCAs to be equal")
+	}
+}
+
+// newCertPoolFromPEM returns certificate pool for the given PEM-encoded
+// certificate bundle. Note that it currently ignores invalid blocks.
+func newCertPoolFromPEM(pem []byte) (*x509.CertPool, error) {
+	certPool := x509.NewCertPool()
+	ok := certPool.AppendCertsFromPEM(pem)
+	if !ok {
+		return nil, errors.New("no valid certificates found")
+	}
+	return certPool, nil
+}

--- a/internal/tools/tls_test.go
+++ b/internal/tools/tls_test.go
@@ -2,8 +2,6 @@ package tools
 
 import (
 	"crypto/tls"
-	"crypto/x509"
-	"errors"
 	"strconv"
 	"testing"
 	"testing/fstest"
@@ -286,15 +284,4 @@ func checkTLSConfig(t *testing.T, a, b *tls.Config) {
 	if !a.RootCAs.Equal(b.RootCAs) {
 		t.Error("expected tls.Config.RootCAs to be equal")
 	}
-}
-
-// newCertPoolFromPEM returns certificate pool for the given PEM-encoded
-// certificate bundle. Note that it currently ignores invalid blocks.
-func newCertPoolFromPEM(pem []byte) (*x509.CertPool, error) {
-	certPool := x509.NewCertPool()
-	ok := certPool.AppendCertsFromPEM(pem)
-	if !ok {
-		return nil, errors.New("no valid certificates found")
-	}
-	return certPool, nil
 }

--- a/main.go
+++ b/main.go
@@ -1318,18 +1318,18 @@ func getTLSConfig() (*tls.Config, error) {
 
 	} else if tlsEnabled {
 		// Autocert disabled - just try to use provided SSL cert and key files.
-		return tools.MakeTLSConfig(viper.GetViper(), "")
+		return tools.MakeTLSConfig(viper.GetViper(), "", os.ReadFile)
 	}
 
 	return nil, nil
 }
 
 func tlsConfigForGRPC() (*tls.Config, error) {
-	return tools.MakeTLSConfig(viper.GetViper(), "grpc_api_")
+	return tools.MakeTLSConfig(viper.GetViper(), "grpc_api_", os.ReadFile)
 }
 
 func tlsConfigForUniGRPC() (*tls.Config, error) {
-	return tools.MakeTLSConfig(viper.GetViper(), "uni_grpc_")
+	return tools.MakeTLSConfig(viper.GetViper(), "uni_grpc_", os.ReadFile)
 }
 
 type httpErrorLogWriter struct {
@@ -2435,7 +2435,7 @@ func addRedisShardCommonSettings(shardConf *centrifuge.RedisShardConfig) {
 	shardConf.ClientName = viper.GetString("redis_client_name")
 
 	if viper.GetBool("redis_tls") {
-		tlsConfig, err := tools.MakeTLSConfig(viper.GetViper(), "redis_")
+		tlsConfig, err := tools.MakeTLSConfig(viper.GetViper(), "redis_", os.ReadFile)
 		if err != nil {
 			log.Fatal().Msgf("error creating Redis TLS config: %v", err)
 		}
@@ -2498,7 +2498,7 @@ func getRedisShardConfigs() ([]centrifuge.RedisShardConfig, string, error) {
 			}
 			conf.SentinelClientName = viper.GetString("redis_sentinel_client_name")
 			if viper.GetBool("redis_sentinel_tls") {
-				tlsConfig, err := tools.MakeTLSConfig(viper.GetViper(), "redis_sentinel_")
+				tlsConfig, err := tools.MakeTLSConfig(viper.GetViper(), "redis_sentinel_", os.ReadFile)
 				if err != nil {
 					log.Fatal().Msgf("error creating Redis Sentinel TLS config: %v", err)
 				}

--- a/main.go
+++ b/main.go
@@ -236,6 +236,8 @@ var defaults = map[string]any{
 	"tls_key_pem":              "",
 	"tls_root_ca":              "",
 	"tls_root_ca_pem":          "",
+	"tls_client_ca":            "",
+	"tls_client_ca_pem":        "",
 	"tls_server_name":          "",
 	"tls_insecure_skip_verify": false,
 
@@ -315,6 +317,8 @@ var defaults = map[string]any{
 	"grpc_api_tls_key_pem":              "",
 	"grpc_api_tls_root_ca":              "",
 	"grpc_api_tls_root_ca_pem":          "",
+	"grpc_api_tls_client_ca":            "",
+	"grpc_api_tls_client_ca_pem":        "",
 	"grpc_api_tls_server_name":          "",
 	"grpc_api_tls_insecure_skip_verify": false,
 
@@ -357,6 +361,8 @@ var defaults = map[string]any{
 	"uni_grpc_tls_key_pem":              "",
 	"uni_grpc_tls_root_ca":              "",
 	"uni_grpc_tls_root_ca_pem":          "",
+	"uni_grpc_tls_client_ca":            "",
+	"uni_grpc_tls_client_ca_pem":        "",
 	"uni_grpc_tls_server_name":          "",
 	"uni_grpc_tls_insecure_skip_verify": false,
 
@@ -418,6 +424,8 @@ func init() {
 			prefix + "redis_tls_key_pem":                       "",
 			prefix + "redis_tls_root_ca":                       "",
 			prefix + "redis_tls_root_ca_pem":                   "",
+			prefix + "redis_tls_client_ca":                     "",
+			prefix + "redis_tls_client_ca_pem":                 "",
 			prefix + "redis_tls_server_name":                   "",
 			prefix + "redis_tls_insecure_skip_verify":          false,
 			prefix + "redis_sentinel_tls":                      false,
@@ -427,6 +435,8 @@ func init() {
 			prefix + "redis_sentinel_tls_key_pem":              "",
 			prefix + "redis_sentinel_tls_root_ca":              "",
 			prefix + "redis_sentinel_tls_root_ca_pem":          "",
+			prefix + "redis_sentinel_tls_client_ca":            "",
+			prefix + "redis_sentinel_tls_client_ca_pem":        "",
 			prefix + "redis_sentinel_tls_server_name":          "",
 			prefix + "redis_sentinel_tls_insecure_skip_verify": false,
 		}


### PR DESCRIPTION
## Proposed changes

This PR adds tests for and refactors `tools.MakeTLSConfig` and then adds support for enabling mutual TLS authentication for Centrifugo servers by setting `ClientCAs` and `ClientAuth` in `tls.Config`.