### PR TITLE
Use grouped dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,8 @@ updates:
       - dependency-name: github.com/centrifugal/centrifuge # updates manually
     groups:
       go-packages:
-        patterns: '*'
+        patterns:
+          - '*'
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,9 @@ updates:
     directory: "/"
     schedule:
       interval: monthly
+    groups:
+      go-packages:
+        patterns: '*'
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,9 @@ updates:
     directory: "/"
     schedule:
       interval: monthly
+    ignore:
+      - dependency-name: github.com/gorilla/websocket      # v1.5.1 breaks
+      - dependency-name: github.com/centrifugal/centrifuge # updates manually
     groups:
       go-packages:
         patterns: '*'


### PR DESCRIPTION
Use grouped dependabot version updates to reduce dependabot PR noise.

See
- https://github.blog/changelog/2023-08-24-grouped-version-updates-for-dependabot-are-generally-available/
- https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups

Here is a grouped PR from my repo as an example: https://github.com/j178/leetgo/pull/269