### PR TITLE
Fix setting custom TTL in gensubtoken cli

### DIFF
--- a/main.go
+++ b/main.go
@@ -34,8 +34,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/centrifugal/centrifugo/v5/internal/redisnatsbroker"
-
 	"github.com/centrifugal/centrifugo/v5/internal/admin"
 	"github.com/centrifugal/centrifugo/v5/internal/api"
 	"github.com/centrifugal/centrifugo/v5/internal/build"
@@ -52,6 +50,7 @@ import (
 	"github.com/centrifugal/centrifugo/v5/internal/notify"
 	"github.com/centrifugal/centrifugo/v5/internal/origin"
 	"github.com/centrifugal/centrifugo/v5/internal/proxy"
+	"github.com/centrifugal/centrifugo/v5/internal/redisnatsbroker"
 	"github.com/centrifugal/centrifugo/v5/internal/rule"
 	"github.com/centrifugal/centrifugo/v5/internal/service"
 	"github.com/centrifugal/centrifugo/v5/internal/survey"
@@ -1074,8 +1073,8 @@ func main() {
 				user = "anonymous user"
 			}
 			exp := "without expiration"
-			if genTokenTTL >= 0 {
-				exp = fmt.Sprintf("with expiration TTL %s", time.Duration(genTokenTTL)*time.Second)
+			if genSubTokenTTL >= 0 {
+				exp = fmt.Sprintf("with expiration TTL %s", time.Duration(genSubTokenTTL)*time.Second)
 			}
 			if genSubTokenQuiet {
 				fmt.Print(token)


### PR DESCRIPTION
## Proposed changes

Buggy behaviour (`--ttl` option did not work, default expiration was used):

```
./centrifugo gensubtoken --channel test --ttl 101010
HMAC SHA-256 JWT for anonymous user and channel "test" with expiration TTL 168h0m0s:
eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.ey....[STRIPPED]
```

Fixed behaviour:

```
./centrifugo gensubtoken --channel test --ttl 101010
HMAC SHA-256 JWT for anonymous user and channel "test" with expiration TTL 28h3m30s:
eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.ey....[STRIPPED]
```
