### PR TITLE
Kafka consumer: proper parallelism for partition processing

### DIFF
--- a/internal/consuming/kafka_test.go
+++ b/internal/consuming/kafka_test.go
@@ -60,6 +60,36 @@ func produceTestMessage(topic string, message []byte) error {
 	return nil
 }
 
+func produceTestMessageToPartition(topic string, message []byte, partition int32) error {
+	partitioner := kgo.BasicConsistentPartitioner(func(topic string) func(*kgo.Record, int) int {
+		return func(r *kgo.Record, n int) int {
+			return int(r.Partition)
+		}
+	})
+
+	// Create a new client.
+	client, err := kgo.NewClient(
+		kgo.SeedBrokers(testKafkaBrokerURL),
+		kgo.RecordPartitioner(partitioner),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create Kafka client: %w", err)
+	}
+	defer client.Close()
+
+	// Produce a message until we hit desired partition.
+	res := client.ProduceSync(context.Background(), &kgo.Record{
+		Topic: topic, Partition: partition, Value: message})
+	if res.FirstErr() != nil {
+		return fmt.Errorf("failed to produce message: %w", err)
+	}
+	producedPartition := res[0].Record.Partition
+	if producedPartition != partition {
+		return fmt.Errorf("failed to produce message to partition %d, produced to %d", partition, producedPartition)
+	}
+	return nil
+}
+
 func createTestTopic(ctx context.Context, topicName string, numPartitions int32, replicationFactor int16) error {
 	cl, err := kgo.NewClient(kgo.SeedBrokers(testKafkaBrokerURL))
 	if err != nil {
@@ -68,9 +98,6 @@ func createTestTopic(ctx context.Context, topicName string, numPartitions int32,
 	defer cl.Close()
 
 	client := kadm.NewClient(cl)
-	if err != nil {
-		return fmt.Errorf("failed to create Kafka admin client: %w", err)
-	}
 	defer client.Close()
 
 	// Create the topic
@@ -258,4 +285,144 @@ func TestKafkaConsumer_RetryAfterDispatchError(t *testing.T) {
 	require.Equal(t, numFailures, retryCount)
 	cancel()
 	waitCh(t, consumerClosed, 30*time.Second, "timeout waiting for consumer closed")
+}
+
+// In this test we simulate a scenario where a partition is blocked and the partition consumer
+// is stuck on it. We want to make sure that the consumer is not blocked and can still process
+// messages from other topics.
+func TestKafkaConsumer_BlockedPartitionDoesNotBlockAnotherTopic(t *testing.T) {
+	t.Parallel()
+	testKafkaTopic1 := "consumer_test_1_" + uuid.New().String()
+	testKafkaTopic2 := "consumer_test_1_" + uuid.New().String()
+
+	testPayload1 := []byte(`{"key":"value1"}`)
+	testPayload2 := []byte(`{"key":"value2"}`)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	err := createTestTopic(ctx, testKafkaTopic1, 1, 1)
+	require.NoError(t, err)
+
+	err = createTestTopic(ctx, testKafkaTopic2, 1, 1)
+	require.NoError(t, err)
+
+	event1Received := make(chan struct{})
+	event2Received := make(chan struct{})
+	consumerClosed := make(chan struct{})
+	doneCh := make(chan struct{})
+
+	config := KafkaConfig{
+		Brokers:       []string{testKafkaBrokerURL},
+		Topics:        []string{testKafkaTopic1, testKafkaTopic2},
+		ConsumerGroup: uuid.New().String(),
+	}
+
+	numCalls := 0
+
+	mockDispatcher := &MockDispatcher{
+		onDispatch: func(ctx context.Context, method string, data []byte) error {
+			if numCalls == 0 {
+				numCalls++
+				close(event1Received)
+				// Block till the event2 received. This must not block the consumer and event2
+				// must still be processed successfully.
+				<-event2Received
+				return nil
+			}
+			close(event2Received)
+			return nil
+		},
+	}
+	consumer, err := NewKafkaConsumer("test", uuid.NewString(), &MockLogger{}, mockDispatcher, config)
+	require.NoError(t, err)
+
+	go func() {
+		err = produceTestMessage(testKafkaTopic1, testPayload1)
+		require.NoError(t, err)
+
+		// Wait until the first message is received to make sure messages read by separate PollRecords calls.
+		<-event1Received
+		err = produceTestMessage(testKafkaTopic2, testPayload2)
+		require.NoError(t, err)
+	}()
+
+	go func() {
+		err := consumer.Run(ctx)
+		require.ErrorIs(t, err, context.Canceled)
+		close(consumerClosed)
+	}()
+
+	waitCh(t, event2Received, 30*time.Second, "timeout waiting for event 2")
+	cancel()
+	waitCh(t, consumerClosed, 30*time.Second, "timeout waiting for consumer closed")
+	close(doneCh)
+}
+
+// In this test we simulate a scenario where a partition is blocked and the partition consumer
+// is stuck on it. We want to make sure that the consumer is not blocked and can still process
+// messages from other topic partitions.
+func TestKafkaConsumer_BlockedPartitionDoesNotBlockAnotherPartition(t *testing.T) {
+	t.Parallel()
+	testKafkaTopic1 := "consumer_test_1_" + uuid.New().String()
+
+	testPayload1 := []byte(`{"key":"value1"}`)
+	testPayload2 := []byte(`{"key":"value2"}`)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	err := createTestTopic(ctx, testKafkaTopic1, 2, 1)
+	require.NoError(t, err)
+
+	event1Received := make(chan struct{})
+	event2Received := make(chan struct{})
+	consumerClosed := make(chan struct{})
+	doneCh := make(chan struct{})
+
+	config := KafkaConfig{
+		Brokers:       []string{testKafkaBrokerURL},
+		Topics:        []string{testKafkaTopic1},
+		ConsumerGroup: uuid.New().String(),
+	}
+
+	numCalls := 0
+
+	mockDispatcher := &MockDispatcher{
+		onDispatch: func(ctx context.Context, method string, data []byte) error {
+			if numCalls == 0 {
+				numCalls++
+				close(event1Received)
+				// Block till the event2 received. This must not block the consumer and event2
+				// must still be processed successfully.
+				<-event2Received
+				return nil
+			}
+			close(event2Received)
+			return nil
+		},
+	}
+	consumer, err := NewKafkaConsumer("test", uuid.NewString(), &MockLogger{}, mockDispatcher, config)
+	require.NoError(t, err)
+
+	go func() {
+		err = produceTestMessageToPartition(testKafkaTopic1, testPayload1, 0)
+		require.NoError(t, err)
+
+		// Wait until the first message is received to make sure messages read by separate PollRecords calls.
+		<-event1Received
+		err = produceTestMessageToPartition(testKafkaTopic1, testPayload2, 1)
+		require.NoError(t, err)
+	}()
+
+	go func() {
+		err := consumer.Run(ctx)
+		require.ErrorIs(t, err, context.Canceled)
+		close(consumerClosed)
+	}()
+
+	waitCh(t, event2Received, 30*time.Second, "timeout waiting for event 2")
+	cancel()
+	waitCh(t, consumerClosed, 30*time.Second, "timeout waiting for consumer closed")
+	close(doneCh)
 }


### PR DESCRIPTION
## Proposed changes

Pause processing partition to not block poll for a long time and not poll partition while it's being processed. This improves parallelism of partition processing and avoids theoretical stack of Kafka polling when parititon is processing message for a long time. 
