### PR TITLE
Add partition buffer to optimize processing

### DIFF
--- a/internal/consuming/kafka.go
+++ b/internal/consuming/kafka.go
@@ -34,6 +34,12 @@ type KafkaConfig struct {
 	SASLMechanism string `mapstructure:"sasl_mechanism" json:"sasl_mechanism"`
 	SASLUser      string `mapstructure:"sasl_user" json:"sasl_user"`
 	SASLPassword  string `mapstructure:"sasl_password" json:"sasl_password"`
+
+	// PartitionBufferSize is the size of the buffer for each partition consumer.
+	// This is the number of records that can be buffered before the consumer
+	// will pause fetching records from Kafka. By default, this is 16.
+	// Set to -1 to use non-buffered channel.
+	PartitionBufferSize int `mapstructure:"partition_buffer_size" json:"partition_buffer_size"`
 }
 
 type topicPartition struct {
@@ -266,21 +272,6 @@ func (c *KafkaConsumer) pollUntilFatal(ctx context.Context) error {
 
 				tp := topicPartition{p.Topic, p.Partition}
 
-				partitionsToPause := map[string][]int32{p.Topic: {p.Partition}}
-				// PauseFetchPartitions here to not poll partition until records are processed.
-				// This allows parallel processing of records from different partitions, without
-				// keeping records in memory and blocking rebalance. Resume will be called after
-				// records are processed by c.consumers[tp].
-				c.client.PauseFetchPartitions(partitionsToPause)
-
-				// resumeConsuming is a helper function to be called if context is done or partition
-				// consumer is closed before records were sent to it. It's not strictly necessary
-				// to resume consuming upon context done since we do not re-use the client after that,
-				// but it seems a good thing to do from the cleanup perspective.
-				resumeConsuming := func() {
-					c.client.ResumeFetchPartitions(partitionsToPause)
-				}
-
 				// Since we are using BlockRebalanceOnPoll, we can be
 				// sure this partition consumer exists:
 				// * onAssigned is guaranteed to be called before we
@@ -289,12 +280,17 @@ func (c *KafkaConsumer) pollUntilFatal(ctx context.Context) error {
 				// and be deleted before re-allowing polling.
 				select {
 				case <-ctx.Done():
-					resumeConsuming()
 					return
 				case <-c.consumers[tp].quit:
-					resumeConsuming()
 					return
 				case c.consumers[tp].recs <- p:
+				default:
+					partitionsToPause := map[string][]int32{p.Topic: {p.Partition}}
+					// PauseFetchPartitions here to not poll partition until records are processed.
+					// This allows parallel processing of records from different partitions, without
+					// keeping records in memory and blocking rebalance. Resume will be called after
+					// records are processed by c.consumers[tp].
+					c.client.PauseFetchPartitions(partitionsToPause)
 				}
 			})
 			c.client.AllowRebalance()
@@ -329,7 +325,15 @@ func (c *KafkaConsumer) reInitClient(ctx context.Context) error {
 	return nil
 }
 
+const defaultPartitionBufferSize = 16
+
 func (c *KafkaConsumer) assigned(ctx context.Context, cl *kgo.Client, assigned map[string][]int32) {
+	bufferSize := c.config.PartitionBufferSize
+	if bufferSize == -1 {
+		bufferSize = 0
+	} else if bufferSize == 0 {
+		bufferSize = defaultPartitionBufferSize
+	}
 	for topic, partitions := range assigned {
 		for _, partition := range partitions {
 			pc := &partitionConsumer{
@@ -342,7 +346,7 @@ func (c *KafkaConsumer) assigned(ctx context.Context, cl *kgo.Client, assigned m
 
 				quit: make(chan struct{}),
 				done: make(chan struct{}),
-				recs: make(chan kgo.FetchTopicPartition),
+				recs: make(chan kgo.FetchTopicPartition, bufferSize),
 			}
 			c.consumers[topicPartition{topic, partition}] = pc
 			go pc.consume()

--- a/internal/consuming/kafka_test.go
+++ b/internal/consuming/kafka_test.go
@@ -357,66 +357,73 @@ func TestKafkaConsumer_BlockedPartitionDoesNotBlockAnotherTopic(t *testing.T) {
 // is stuck on it. We want to make sure that the consumer is not blocked and can still process
 // messages from other topic partitions.
 func TestKafkaConsumer_BlockedPartitionDoesNotBlockAnotherPartition(t *testing.T) {
-	t.Parallel()
-	testKafkaTopic1 := "consumer_test_1_" + uuid.New().String()
+	partitionBufferSizes := []int{-1, 0}
 
-	testPayload1 := []byte(`{"key":"value1"}`)
-	testPayload2 := []byte(`{"key":"value2"}`)
+	for _, partitionBufferSize := range partitionBufferSizes {
+		t.Run(fmt.Sprintf("partition_buffer_size_%d", partitionBufferSize), func(t *testing.T) {
+			t.Parallel()
+			testKafkaTopic1 := "consumer_test_1_" + uuid.New().String()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
+			testPayload1 := []byte(`{"key":"value1"}`)
+			testPayload2 := []byte(`{"key":"value2"}`)
 
-	err := createTestTopic(ctx, testKafkaTopic1, 2, 1)
-	require.NoError(t, err)
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
 
-	event1Received := make(chan struct{})
-	event2Received := make(chan struct{})
-	consumerClosed := make(chan struct{})
-	doneCh := make(chan struct{})
+			err := createTestTopic(ctx, testKafkaTopic1, 2, 1)
+			require.NoError(t, err)
 
-	config := KafkaConfig{
-		Brokers:       []string{testKafkaBrokerURL},
-		Topics:        []string{testKafkaTopic1},
-		ConsumerGroup: uuid.New().String(),
-	}
+			event1Received := make(chan struct{})
+			event2Received := make(chan struct{})
+			consumerClosed := make(chan struct{})
+			doneCh := make(chan struct{})
 
-	numCalls := 0
-
-	mockDispatcher := &MockDispatcher{
-		onDispatch: func(ctx context.Context, method string, data []byte) error {
-			if numCalls == 0 {
-				numCalls++
-				close(event1Received)
-				// Block till the event2 received. This must not block the consumer and event2
-				// must still be processed successfully.
-				<-event2Received
-				return nil
+			config := KafkaConfig{
+				Brokers:             []string{testKafkaBrokerURL},
+				Topics:              []string{testKafkaTopic1},
+				ConsumerGroup:       uuid.New().String(),
+				PartitionBufferSize: partitionBufferSize,
 			}
-			close(event2Received)
-			return nil
-		},
+
+			numCalls := 0
+
+			mockDispatcher := &MockDispatcher{
+				onDispatch: func(ctx context.Context, method string, data []byte) error {
+					if numCalls == 0 {
+						numCalls++
+						close(event1Received)
+						// Block till the event2 received. This must not block the consumer and event2
+						// must still be processed successfully.
+						<-event2Received
+						return nil
+					}
+					close(event2Received)
+					return nil
+				},
+			}
+			consumer, err := NewKafkaConsumer("test", uuid.NewString(), &MockLogger{}, mockDispatcher, config)
+			require.NoError(t, err)
+
+			go func() {
+				err = produceTestMessageToPartition(testKafkaTopic1, testPayload1, 0)
+				require.NoError(t, err)
+
+				// Wait until the first message is received to make sure messages read by separate PollRecords calls.
+				<-event1Received
+				err = produceTestMessageToPartition(testKafkaTopic1, testPayload2, 1)
+				require.NoError(t, err)
+			}()
+
+			go func() {
+				err := consumer.Run(ctx)
+				require.ErrorIs(t, err, context.Canceled)
+				close(consumerClosed)
+			}()
+
+			waitCh(t, event2Received, 30*time.Second, "timeout waiting for event 2")
+			cancel()
+			waitCh(t, consumerClosed, 30*time.Second, "timeout waiting for consumer closed")
+			close(doneCh)
+		})
 	}
-	consumer, err := NewKafkaConsumer("test", uuid.NewString(), &MockLogger{}, mockDispatcher, config)
-	require.NoError(t, err)
-
-	go func() {
-		err = produceTestMessageToPartition(testKafkaTopic1, testPayload1, 0)
-		require.NoError(t, err)
-
-		// Wait until the first message is received to make sure messages read by separate PollRecords calls.
-		<-event1Received
-		err = produceTestMessageToPartition(testKafkaTopic1, testPayload2, 1)
-		require.NoError(t, err)
-	}()
-
-	go func() {
-		err := consumer.Run(ctx)
-		require.ErrorIs(t, err, context.Canceled)
-		close(consumerClosed)
-	}()
-
-	waitCh(t, event2Received, 30*time.Second, "timeout waiting for event 2")
-	cancel()
-	waitCh(t, consumerClosed, 30*time.Second, "timeout waiting for consumer closed")
-	close(doneCh)
 }


### PR DESCRIPTION
## Proposed changes

Using channel buffer helps to avoid dropping messages already consumed from Kafka when rate inside partition is high enough. We still not blocking partition processing when buffer is full with the help of `default` branch in `select`. 
