### PR TITLE
Add client rpc ping extension

### DIFF
--- a/main.go
+++ b/main.go
@@ -196,6 +196,9 @@ var defaults = map[string]any{
 
 	"rpc_namespace_boundary": ":",
 
+	"rpc_ping":        false,
+	"rpc_ping_method": "ping",
+
 	"user_subscribe_to_personal":      false,
 	"user_personal_channel_namespace": "",
 	"user_personal_single_connection": false,
@@ -697,6 +700,13 @@ func main() {
 			err = clientHandler.Setup()
 			if err != nil {
 				log.Fatal().Msgf("error setting up client handler: %v", err)
+			}
+			if viper.GetBool("rpc_ping") {
+				pingMethod := viper.GetString("rpc_ping_method")
+				log.Info().Str("method", pingMethod).Msg("RPC ping extension enabled")
+				clientHandler.SetRPCExtension(pingMethod, func(c client.Client, e centrifuge.RPCEvent) (centrifuge.RPCReply, error) {
+					return centrifuge.RPCReply{}, nil
+				})
 			}
 
 			surveyCaller := survey.NewCaller(node)


### PR DESCRIPTION
## Proposed changes

Relates to #842 The approach is not to introduce a new command in client protocol but use RPC extension for the task. This makes all SDKs ready to be used automatically. The feature must be enabled in configuration:

```json
{
  ...
  "rpc_ping": true,
  "rpc_ping_method": "ping"
}
```

Then on SDK side:

```javascript
const startTime = performance.now();
centrifuge.rpc('ping', {}).then(function() {
  const endTime = performance.now();
  console.log('rtt', ((endTime - startTime)).toFixed(2).toString(), 'ms');  // Output example: rtt 0.90 ms
})
```
