### PR TITLE
Add missing delta_publish top-level default

### DIFF
--- a/main.go
+++ b/main.go
@@ -140,6 +140,7 @@ var defaults = map[string]any{
 	"redis_presence_hash_field_ttl":      false,
 
 	"allowed_delta_types": []centrifuge.DeltaType{},
+	"delta_publish":       false,
 
 	"presence":                      false,
 	"join_leave":                    false,


### PR DESCRIPTION
## Proposed changes

Results into warning on start:

```
{"level":"warn","key":"CENTRIFUGO_DELTA_PUBLISH","time":"2024-10-06T08:48:22Z","message":"unknown key found in the environment"}
```
