### PR TITLE
Fix flaky TestHandleRefreshWithoutProxyServerStart test

### DIFF
--- a/internal/proxy/refresh_handler_test.go
+++ b/internal/proxy/refresh_handler_test.go
@@ -187,14 +187,14 @@ func TestHandleRefreshWithoutProxyServerStart(t *testing.T) {
 	httpTestCase := newRefreshHandlerHTTPTestCase(context.Background(), "/refresh")
 	httpTestCase.Teardown()
 
-	expectedReply := centrifuge.RefreshReply{
-		ExpireAt: time.Now().Unix() + 60,
-	}
-
 	cases := newRefreshHandlerTestCases(httpTestCase, grpcTestCase)
 	for _, c := range cases {
 		reply, err := c.invokeHandle()
 		require.NoError(t, err, c.protocol)
+
+		expectedReply := centrifuge.RefreshReply{
+			ExpireAt: time.Now().Unix() + 60,
+		}
 		require.Equal(t, expectedReply, reply, c.protocol)
 	}
 }


### PR DESCRIPTION
Fixes #910 

`expectedReply` is created before we start iterating over test cases, and the clock is ticking, so the server can respond in the next second. 

Before the change, it hit the issue 1-3 times in 1000 runs: 
```
 $ go test ./internal/proxy -run TestHandleRefreshWithoutProxyServerStart -count 1000
--- FAIL: TestHandleRefreshWithoutProxyServerStart (0.00s)
    refresh_handler_test.go:198: 
                Error Trace:    /Users/amakhov/www/centrifugo/internal/proxy/refresh_handler_test.go:198
                Error:          Not equal: 
                                expected: centrifuge.RefreshReply{Expired:false, ExpireAt:1733732303, Info:[]uint8(nil)}
                                actual  : centrifuge.RefreshReply{Expired:false, ExpireAt:1733732304, Info:[]uint8(nil)}
                                
                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -2,3 +2,3 @@
                                  Expired: (bool) false,
                                - ExpireAt: (int64) 1733732303,
                                + ExpireAt: (int64) 1733732304,
                                  Info: ([]uint8) <nil>
                Test:           TestHandleRefreshWithoutProxyServerStart
                Messages:       http
FAIL
FAIL    github.com/centrifugal/centrifugo/v5/internal/proxy     4.763s
FAIL
```

With the fix there is no failures in 10000 runs: 
```
$ go test ./internal/proxy -run TestHandleRefreshWithoutProxyServerStart -count 10000
ok      github.com/centrifugal/centrifugo/v5/internal/proxy     68.674s
```