### PR TITLE
Change Dockerfile to run app under non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,20 @@
 FROM alpine:3.18
 
-RUN apk --no-cache upgrade && apk --no-cache add ca-certificates
+ARG USER=centrifugo
+ARG UID=1000
+ARG GID=1000
 
-COPY centrifugo /usr/local/bin/centrifugo 
+RUN addgroup -S -g $GID $USER && \
+    adduser -S -G $USER -u $UID $USER
+
+RUN apk --no-cache upgrade && \
+    apk --no-cache add ca-certificates && \
+    update-ca-certificates
+
+USER $USER
 
 WORKDIR /centrifugo
+
+COPY centrifugo /usr/local/bin/centrifugo
 
 CMD ["centrifugo"]


### PR DESCRIPTION
This PR updates the Dockerfile to improve security by running the application as a non-root user inside the container. This change ensures that the application no longer runs with root privileges, following best practices for containerized environments.

For more information, refer to the following resources:
* [Sysdig's Dockerfile Best Practices](https://sysdig.com/learn-cloud-native/dockerfile-best-practices/#1-1-rootless-containers)
* [Kubernetes Security Checklist](https://kubernetes.io/docs/concepts/security/security-checklist/#images)
