### PR TITLE
Async consumers: content mode

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -57,7 +57,7 @@ func (h *Executor) SetRPCExtension(method string, handler RPCHandler) {
 	h.rpcExtension[method] = handler
 }
 
-func (h *Executor) processCmd(ctx context.Context, cmd *Command, i int, replies []*Reply) {
+func (h *Executor) processCmd(ctx context.Context, cmd *Command, i int, replies []*Reply) string {
 	var method string
 	if cmd.Publish != nil {
 		method = "publish"
@@ -118,6 +118,7 @@ func (h *Executor) processCmd(ctx context.Context, cmd *Command, i int, replies 
 	if replies[i].Error != nil {
 		incError(h.config.Protocol, method, replies[i].Error.Code)
 	}
+	return method
 }
 
 // batchRequestMaxConcurrency is applied for the parallel batch request.

--- a/internal/api/consuming.go
+++ b/internal/api/consuming.go
@@ -1,10 +1,14 @@
 package api
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
 
 	"github.com/centrifugal/centrifugo/v6/internal/apiproto"
+	"github.com/centrifugal/centrifugo/v6/internal/configtypes"
 
 	"github.com/centrifugal/centrifuge"
 	"github.com/rs/zerolog/log"
@@ -36,6 +40,56 @@ func NewConsumingHandler(n *centrifuge.Node, apiExecutor *Executor, c ConsumingH
 
 func (h *ConsumingHandler) logNonRetryableConsumingError(err error, method string) {
 	log.Error().Err(err).Str("method", method).Msg("non retryable error during consuming, skip message")
+}
+
+func (h *ConsumingHandler) DispatchPublication(
+	ctx context.Context, data []byte, idempotencyKey string, delta bool, channels ...string,
+) error {
+	if len(channels) == 0 {
+		return nil
+	}
+	if len(channels) == 1 {
+		req := &apiproto.PublishRequest{
+			Data:           data,
+			Channel:        channels[0],
+			IdempotencyKey: idempotencyKey,
+			Delta:          delta,
+		}
+		return h.Publish(ctx, req)
+	}
+	req := &apiproto.BroadcastRequest{
+		Data:           data,
+		Channels:       channels,
+		IdempotencyKey: idempotencyKey,
+		Delta:          delta,
+	}
+	return h.Broadcast(ctx, req)
+}
+
+func (h *ConsumingHandler) dispatchCommand(ctx context.Context, cmd *apiproto.Command) error {
+	replies := make([]*apiproto.Reply, 1)
+	method := h.api.processCmd(ctx, cmd, 0, replies)
+	reply := replies[0]
+	if cmd.Publish != nil {
+		if reply.Error != nil && reply.Error.Code == apiproto.ErrorInternal.Code {
+			return reply.Error
+		}
+	} else if cmd.Broadcast != nil {
+		if reply.Error != nil && reply.Error.Code == apiproto.ErrorInternal.Code {
+			return reply.Error
+		}
+		for _, response := range reply.Broadcast.Responses {
+			if response.Error != nil && response.Error.Code == apiproto.ErrorInternal.Code {
+				// Any internal error in any channel response will result into a retry by a consumer.
+				// To prevent duplicate messages publishers may use idempotency keys.
+				return response.Error
+			}
+		}
+	}
+	if reply.Error != nil {
+		h.logNonRetryableConsumingError(reply.Error, method)
+	}
+	return nil
 }
 
 func (h *ConsumingHandler) Publish(ctx context.Context, req *apiproto.PublishRequest) error {
@@ -76,8 +130,7 @@ func (h *ConsumingHandler) Broadcast(ctx context.Context, req *apiproto.Broadcas
 	return nil
 }
 
-// Dispatch processes commands received from asynchronous consumers.
-func (h *ConsumingHandler) Dispatch(ctx context.Context, method string, payload []byte) error {
+func (h *ConsumingHandler) dispatchMethodPayload(ctx context.Context, method string, payload []byte) error {
 	switch method {
 	case "publish":
 		_, err := h.handlePublish(ctx, payload)
@@ -92,7 +145,7 @@ func (h *ConsumingHandler) Dispatch(ctx context.Context, method string, payload 
 		return nil
 	case "broadcast":
 		// This one is special as we need to iterate over responses. Ideally we want to use
-		// code gen for Dispatch but need to make sure that broadcast logic is preserved.
+		// code gen for DispatchMethodPayload but need to make sure that broadcast logic is preserved.
 		res, err := h.handleBroadcast(ctx, payload)
 		if err != nil {
 			var apiError *apiproto.Error
@@ -172,3 +225,70 @@ func (h *ConsumingHandler) Dispatch(ctx context.Context, method string, payload 
 }
 
 var ErrInvalidData = errors.New("invalid data")
+
+// JSONRawOrString can decode payload from bytes and from JSON string. This gives
+// us better interoperability. For example, JSONB field is encoded as JSON string in
+// Debezium PostgreSQL connector.
+type JSONRawOrString json.RawMessage
+
+func (j *JSONRawOrString) UnmarshalJSON(data []byte) error {
+	if len(data) > 0 && data[0] == '"' {
+		// Unmarshal as a string, then convert the string to json.RawMessage.
+		var str string
+		if err := json.Unmarshal(data, &str); err != nil {
+			return err
+		}
+		*j = JSONRawOrString(str)
+	} else {
+		// Unmarshal directly as json.RawMessage
+		*j = data
+	}
+	return nil
+}
+
+// MarshalJSON returns m as the JSON encoding of m.
+func (j JSONRawOrString) MarshalJSON() ([]byte, error) {
+	if j == nil {
+		return []byte("null"), nil
+	}
+	return j, nil
+}
+
+type MethodWithRequestPayload struct {
+	Method  string          `json:"method"`
+	Payload JSONRawOrString `json:"payload"`
+}
+
+func (h *ConsumingHandler) DispatchAPICommand(ctx context.Context, mode configtypes.ConsumerContentMode, method string, payload []byte) error {
+	switch mode {
+	case configtypes.ConsumerContentModeMethodPayload:
+		if method != "" {
+			// If method is set then we expect payload to be encoded request.
+			return h.dispatchMethodPayload(ctx, method, payload)
+		}
+		var e MethodWithRequestPayload
+		err := json.Unmarshal(payload, &e)
+		if err != nil {
+			log.Error().Err(err).Msg("skip malformed consumed message")
+			return nil
+		}
+		return h.dispatchMethodPayload(ctx, e.Method, e.Payload)
+	case configtypes.ConsumerContentModeAPICommand:
+		var decoder apiproto.CommandDecoder
+		if bytes.HasPrefix(payload, []byte(`{`)) {
+			decoder = apiproto.GetCommandDecoder(payload)
+			defer apiproto.PutCommandDecoder(decoder)
+		} else {
+			decoder = apiproto.GetProtobufCommandDecoder(payload)
+			defer apiproto.PutProtobufCommandDecoder(decoder)
+		}
+		cmd, err := decoder.Decode()
+		if err != nil {
+			log.Error().Err(err).Msg("skip malformed consumed message")
+			return nil
+		}
+		return h.dispatchCommand(ctx, cmd)
+	default:
+		return fmt.Errorf("unknown content mode: %v", mode)
+	}
+}

--- a/internal/api/consuming.go
+++ b/internal/api/consuming.go
@@ -259,13 +259,14 @@ type MethodWithRequestPayload struct {
 	Payload JSONRawOrString `json:"payload"`
 }
 
-func (h *ConsumingHandler) DispatchAPICommand(ctx context.Context, mode configtypes.ConsumerContentMode, method string, payload []byte) error {
+func (h *ConsumingHandler) DispatchCommand(ctx context.Context, mode configtypes.ConsumerContentMode, method string, payload []byte) error {
 	switch mode {
 	case configtypes.ConsumerContentModeMethodPayload:
 		if method != "" {
 			// If method is set then we expect payload to be encoded request.
 			return h.dispatchMethodPayload(ctx, method, payload)
 		}
+		// Otherwise we expect payload to be MethodWithRequestPayload.
 		var e MethodWithRequestPayload
 		err := json.Unmarshal(payload, &e)
 		if err != nil {

--- a/internal/api/consuming_test.go
+++ b/internal/api/consuming_test.go
@@ -22,7 +22,7 @@ func TestNewConsumingHandler(t *testing.T) {
 		UseOpenTelemetry: false,
 	}), ConsumingHandlerConfig{})
 
-	// Bad request must be just logged but no errors other than Internal Error should be returned from Dispatch.
-	err = handler.Dispatch(context.Background(), "publish", []byte(`{}`))
+	// Bad request must be just logged but no errors other than Internal Error should be returned from DispatchMethodPayload.
+	err = handler.dispatchMethodPayload(context.Background(), "publish", []byte(`{}`))
 	require.NoError(t, err)
 }

--- a/internal/apiproto/decode.go
+++ b/internal/apiproto/decode.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"strconv"
 	"strings"
+
+	"google.golang.org/protobuf/proto"
 )
 
 // UnmarshalJSON helps to unmarshal command method when set as string.
@@ -52,6 +54,31 @@ func (d *JSONCommandDecoder) Reset(data []byte) {
 func (d *JSONCommandDecoder) Decode() (*Command, error) {
 	var c Command
 	err := d.decoder.Decode(&c)
+	if err != nil {
+		return nil, err
+	}
+	return &c, nil
+}
+
+// ProtobufCommandDecoder ...
+type ProtobufCommandDecoder struct {
+	data []byte
+}
+
+func NewProtobufCommandDecoder(data []byte) *ProtobufCommandDecoder {
+	return &ProtobufCommandDecoder{
+		data: data,
+	}
+}
+
+// Reset ...
+func (d *ProtobufCommandDecoder) Reset(data []byte) {
+	d.data = data
+}
+
+func (d *ProtobufCommandDecoder) Decode() (*Command, error) {
+	var c Command
+	err := proto.Unmarshal(d.data, &c)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/apiproto/encoding.go
+++ b/internal/apiproto/encoding.go
@@ -5,8 +5,9 @@ import (
 )
 
 var (
-	jsonReplyEncoderPool   sync.Pool
-	jsonCommandDecoderPool sync.Pool
+	jsonReplyEncoderPool       sync.Pool
+	jsonCommandDecoderPool     sync.Pool
+	protobufCommandDecoderPool sync.Pool
 )
 
 // GetReplyEncoder ...
@@ -38,6 +39,22 @@ func GetCommandDecoder(data []byte) CommandDecoder {
 // PutCommandDecoder ...
 func PutCommandDecoder(d CommandDecoder) {
 	jsonCommandDecoderPool.Put(d)
+}
+
+// GetProtobufCommandDecoder ...
+func GetProtobufCommandDecoder(data []byte) CommandDecoder {
+	e := protobufCommandDecoderPool.Get()
+	if e == nil {
+		return NewProtobufCommandDecoder(data)
+	}
+	decoder := e.(CommandDecoder)
+	decoder.Reset(data)
+	return decoder
+}
+
+// PutProtobufCommandDecoder ...
+func PutProtobufCommandDecoder(d CommandDecoder) {
+	protobufCommandDecoderPool.Put(d)
 }
 
 // GetParamsDecoder ...

--- a/internal/app/log.go
+++ b/internal/app/log.go
@@ -29,6 +29,9 @@ func logStartWarnings(cfg config.Config, cfgMeta config.Meta) {
 	for _, key := range cfgMeta.UnknownEnvs {
 		log.Warn().Str("var", key).Msg("unknown var in environment")
 	}
+	for _, msg := range cfgMeta.DeprecationWarnings {
+		log.Warn().Msg(msg)
+	}
 }
 
 type httpErrorLogWriter struct {

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -226,7 +226,8 @@ func Run(cmd *cobra.Command, configFile string) {
 			UniSSE:        cfg.UniSSE.Enabled,
 			UniGRPC:       cfg.UniGRPC.Enabled,
 
-			EnabledConsumers: usage.GetEnabledConsumers(cfg.Consumers),
+			EnabledConsumers:     usage.GetEnabledConsumers(cfg.Consumers),
+			EnabledConsumerModes: usage.GetEnabledConsumerModes(cfg.Consumers),
 
 			GrpcAPI:             cfg.GrpcAPI.Enabled,
 			SubscribeToPersonal: cfg.Client.SubscribeToUserPersonalChannel.Enabled,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -108,10 +108,11 @@ type Config struct {
 }
 
 type Meta struct {
-	FileNotFound bool
-	UnknownKeys  []string
-	UnknownEnvs  []string
-	KnownEnvVars map[string]envconfig.VarInfo
+	FileNotFound        bool
+	UnknownKeys         []string
+	UnknownEnvs         []string
+	KnownEnvVars        map[string]envconfig.VarInfo
+	DeprecationWarnings []string
 }
 
 func DefineFlags(rootCmd *cobra.Command) {
@@ -239,7 +240,11 @@ func GetConfig(cmd *cobra.Command, configFile string) (Config, Meta, error) {
 	meta.UnknownEnvs = checkEnvironmentVars(knownEnvVars)
 	meta.KnownEnvVars = knownEnvVars
 
-	return *conf, meta, nil
+	cfg := *conf
+	cfg, deprecationWarnings := applyConfigMigrations(cfg)
+	meta.DeprecationWarnings = deprecationWarnings
+
+	return cfg, meta, nil
 }
 
 func extendKnownEnvVars(knownEnvVars map[string]envconfig.VarInfo, varInfo []envconfig.VarInfo) {

--- a/internal/config/migrations.go
+++ b/internal/config/migrations.go
@@ -1,0 +1,21 @@
+package config
+
+import (
+	"fmt"
+
+	"github.com/centrifugal/centrifugo/v6/internal/configtypes"
+)
+
+func applyConfigMigrations(cfg Config) (Config, []string) {
+	var warnings []string
+	for i, consumer := range cfg.Consumers {
+		if consumer.Type == configtypes.ConsumerTypeKafka {
+			if consumer.Kafka.PublicationDataMode.Enabled {
+				warnings = append(warnings, fmt.Sprintf("consumers[%d].kafka.publication_data_mode.enabled is deprecated "+
+					"and will be removed in future releases, set consumers[%d].content_mode to 'publication_data' instead", i, i))
+				cfg.Consumers[i].ContentMode = configtypes.ConsumerContentModePublicationData
+			}
+		}
+	}
+	return cfg, warnings
+}

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -120,14 +120,17 @@ func (c Config) Validate() error {
 		if !slices.Contains(configtypes.KnownConsumerTypes, config.Type) {
 			return fmt.Errorf("unknown consumer type: %s", config.Type)
 		}
+		if !slices.Contains(configtypes.KnownConsumerContentModes, config.ContentMode) {
+			return fmt.Errorf("unknown consumer content mode: %s", config.ContentMode)
+		}
 		if config.Enabled {
 			switch config.Type {
 			case configtypes.ConsumerTypeKafka:
-				if err := config.Kafka.Validate(); err != nil {
+				if err := config.Kafka.Validate(config); err != nil {
 					return fmt.Errorf("in consumer %s (kafka): %w", config.Name, err)
 				}
 			case configtypes.ConsumerTypePostgres:
-				if err := config.Postgres.Validate(); err != nil {
+				if err := config.Postgres.Validate(config); err != nil {
 					return fmt.Errorf("in consumer %s (postgres): %w", config.Name, err)
 				}
 			default:

--- a/internal/configtypes/types.go
+++ b/internal/configtypes/types.go
@@ -587,6 +587,13 @@ var KnownConsumerTypes = []string{
 	ConsumerTypeKafka,
 }
 
+type ConsumerContentMode string
+
+const (
+	ConsumerContentModeMethodPayload ConsumerContentMode = "api_method_request_payload"
+	ConsumerContentModeAPICommand    ConsumerContentMode = "api_command"
+)
+
 type Consumer struct {
 	// Name is a unique name required for each consumer.
 	Name string `mapstructure:"name" json:"name" envconfig:"name" yaml:"name" toml:"name"`
@@ -596,6 +603,9 @@ type Consumer struct {
 
 	// Type describes the type of consumer.
 	Type string `mapstructure:"type" json:"type" envconfig:"type" yaml:"type" toml:"type"`
+
+	// ContentMode gives a hint to Centrifugo how to extract API command from incoming messages.
+	ContentMode ConsumerContentMode `mapstructure:"content_mode" json:"content_mode" envconfig:"content_mode" yaml:"content_mode" toml:"content_mode"`
 
 	// Postgres allows defining options for consumer of postgresql type.
 	Postgres PostgresConsumerConfig `mapstructure:"postgresql" json:"postgresql" envconfig:"postgresql" yaml:"postgresql" toml:"postgresql"`

--- a/internal/consuming/consuming.go
+++ b/internal/consuming/consuming.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/centrifugal/centrifugo/v6/internal/apiproto"
 	"github.com/centrifugal/centrifugo/v6/internal/configtypes"
 	"github.com/centrifugal/centrifugo/v6/internal/service"
 
@@ -15,9 +14,8 @@ import (
 type ConsumerConfig = configtypes.Consumer
 
 type Dispatcher interface {
-	Dispatch(ctx context.Context, method string, data []byte) error
-	Publish(ctx context.Context, req *apiproto.PublishRequest) error
-	Broadcast(ctx context.Context, req *apiproto.BroadcastRequest) error
+	DispatchAPICommand(ctx context.Context, mode configtypes.ConsumerContentMode, method string, data []byte) error
+	DispatchPublication(ctx context.Context, data []byte, idempotencyKey string, delta bool, channels ...string) error
 }
 
 func New(nodeID string, dispatcher Dispatcher, configs []ConsumerConfig) ([]service.Service, error) {
@@ -26,18 +24,19 @@ func New(nodeID string, dispatcher Dispatcher, configs []ConsumerConfig) ([]serv
 	var services []service.Service
 	for _, config := range configs {
 		if !config.Enabled { // Important to keep this check inside specific type for proper config validation.
-			log.Info().Str("consumer_name", config.Name).Str("consumer_type", config.Type).Msg("consumer is not enabled, skip")
+			log.Info().Str("consumer_name", config.Name).Str("consumer_type", config.Type).
+				Msg("consumer is not enabled, skip")
 			continue
 		}
 		switch config.Type {
 		case configtypes.ConsumerTypePostgres:
-			consumer, err := NewPostgresConsumer(config.Name, dispatcher, config.Postgres, metrics)
+			consumer, err := NewPostgresConsumer(config.Name, config.ContentMode, dispatcher, config.Postgres, metrics)
 			if err != nil {
 				return nil, fmt.Errorf("error initializing PostgreSQL consumer (%s): %w", config.Name, err)
 			}
 			services = append(services, consumer)
 		case configtypes.ConsumerTypeKafka:
-			consumer, err := NewKafkaConsumer(config.Name, nodeID, dispatcher, config.Kafka, metrics)
+			consumer, err := NewKafkaConsumer(config.Name, config.ContentMode, nodeID, dispatcher, config.Kafka, metrics)
 			if err != nil {
 				return nil, fmt.Errorf("error initializing Kafka consumer (%s): %w", config.Name, err)
 			}

--- a/internal/consuming/consuming.go
+++ b/internal/consuming/consuming.go
@@ -14,7 +14,7 @@ import (
 type ConsumerConfig = configtypes.Consumer
 
 type Dispatcher interface {
-	DispatchAPICommand(ctx context.Context, mode configtypes.ConsumerContentMode, method string, data []byte) error
+	DispatchCommand(ctx context.Context, mode configtypes.ConsumerContentMode, method string, data []byte) error
 	DispatchPublication(ctx context.Context, data []byte, idempotencyKey string, delta bool, channels ...string) error
 }
 
@@ -24,7 +24,9 @@ func New(nodeID string, dispatcher Dispatcher, configs []ConsumerConfig) ([]serv
 	var services []service.Service
 	for _, config := range configs {
 		if !config.Enabled { // Important to keep this check inside specific type for proper config validation.
-			log.Info().Str("consumer_name", config.Name).Str("consumer_type", config.Type).
+			log.Info().
+				Str("consumer_name", config.Name).
+				Str("consumer_type", config.Type).
 				Msg("consumer is not enabled, skip")
 			continue
 		}
@@ -44,7 +46,10 @@ func New(nodeID string, dispatcher Dispatcher, configs []ConsumerConfig) ([]serv
 		default:
 			return nil, fmt.Errorf("unknown consumer type: %s", config.Type)
 		}
-		log.Info().Str("consumer_name", config.Name).Str("consumer_type", config.Type).Msg("running consumer")
+		log.Info().
+			Str("consumer_name", config.Name).
+			Str("consumer_type", config.Type).
+			Msg("running consumer")
 	}
 
 	for _, config := range configs {

--- a/internal/consuming/kafka_test.go
+++ b/internal/consuming/kafka_test.go
@@ -34,7 +34,7 @@ type MockDispatcher struct {
 	onDispatchPublication func(ctx context.Context, data []byte, idempotencyKey string, delta bool, channels ...string) error
 }
 
-func (m *MockDispatcher) DispatchAPICommand(ctx context.Context, mode configtypes.ConsumerContentMode, method string, data []byte) error {
+func (m *MockDispatcher) DispatchCommand(ctx context.Context, mode configtypes.ConsumerContentMode, method string, data []byte) error {
 	return m.onDispatchAPICommand(ctx, mode, method, data)
 }
 
@@ -756,7 +756,6 @@ func TestKafkaConsumer_GreenScenario_PublicationDataMode(t *testing.T) {
 		Topics:        []string{testKafkaTopic},
 		ConsumerGroup: uuid.New().String(),
 		PublicationDataMode: configtypes.KafkaPublicationDataModeConfig{
-			Enabled:              true,
 			ChannelsHeader:       "centrifugo-channels",
 			IdempotencyKeyHeader: "centrifugo-idempotency-key",
 			DeltaHeader:          "centrifugo-delta",
@@ -790,7 +789,7 @@ func TestKafkaConsumer_GreenScenario_PublicationDataMode(t *testing.T) {
 		},
 	}
 
-	consumer, err := NewKafkaConsumer("test", configtypes.ConsumerContentModeMethodPayload,
+	consumer, err := NewKafkaConsumer("test", configtypes.ConsumerContentModePublicationData,
 		uuid.NewString(), mockDispatcher, config, newCommonMetrics(prometheus.NewRegistry()))
 	require.NoError(t, err)
 

--- a/internal/consuming/postgresql.go
+++ b/internal/consuming/postgresql.go
@@ -21,7 +21,8 @@ const (
 )
 
 func NewPostgresConsumer(
-	name string, mode configtypes.ConsumerContentMode, dispatcher Dispatcher, config PostgresConfig, metrics *commonMetrics,
+	name string, mode configtypes.ConsumerContentMode, dispatcher Dispatcher,
+	config PostgresConfig, metrics *commonMetrics,
 ) (*PostgresConsumer, error) {
 	if config.DSN == "" {
 		return nil, errors.New("dsn is required")
@@ -179,7 +180,7 @@ func (c *PostgresConsumer) processOnce(ctx context.Context, partition int) (int,
 	var dispatchErr error
 
 	for _, event := range events {
-		dispatchErr = c.dispatcher.DispatchAPICommand(ctx, c.mode, event.Method, event.Payload)
+		dispatchErr = c.dispatcher.DispatchCommand(ctx, c.mode, event.Method, event.Payload)
 		if dispatchErr != nil {
 			// Stop here, all processed events will be removed, and we will start from this one.
 			log.Error().Err(dispatchErr).Str("consumer_name", c.name).Str("method", event.Method).Msg("error processing consumed event")

--- a/internal/consuming/postgresql_test.go
+++ b/internal/consuming/postgresql_test.go
@@ -134,8 +134,8 @@ func TestPostgresConsumer_GreenScenario(t *testing.T) {
 		PartitionPollInterval:        configtypes.Duration(300 * time.Millisecond),
 		PartitionNotificationChannel: testNotificationChannel,
 	}
-	consumer, err := NewPostgresConsumer("test", &MockDispatcher{
-		onDispatch: func(ctx context.Context, method string, data []byte) error {
+	consumer, err := NewPostgresConsumer("test", configtypes.ConsumerContentModeMethodPayload, &MockDispatcher{
+		onDispatchAPICommand: func(ctx context.Context, mode configtypes.ConsumerContentMode, method string, data []byte) error {
 			require.Equal(t, testMethod, method)
 			require.Equal(t, testPayload, data)
 			close(eventReceived)
@@ -191,8 +191,8 @@ func TestPostgresConsumer_SeveralConsumers(t *testing.T) {
 	numConsumers := 10
 
 	for i := 0; i < numConsumers; i++ {
-		consumer, err := NewPostgresConsumer("test", &MockDispatcher{
-			onDispatch: func(ctx context.Context, method string, data []byte) error {
+		consumer, err := NewPostgresConsumer("test", configtypes.ConsumerContentModeMethodPayload, &MockDispatcher{
+			onDispatchAPICommand: func(ctx context.Context, mode configtypes.ConsumerContentMode, method string, data []byte) error {
 				require.Equal(t, testMethod, method)
 				require.Equal(t, testPayload, data)
 				close(eventReceived)
@@ -249,8 +249,8 @@ func TestPostgresConsumer_NotificationTrigger(t *testing.T) {
 
 	numEvents := 0
 
-	consumer, err := NewPostgresConsumer("test", &MockDispatcher{
-		onDispatch: func(ctx context.Context, method string, data []byte) error {
+	consumer, err := NewPostgresConsumer("test", configtypes.ConsumerContentModeMethodPayload, &MockDispatcher{
+		onDispatchAPICommand: func(ctx context.Context, mode configtypes.ConsumerContentMode, method string, data []byte) error {
 			require.Equal(t, testMethod, method)
 			require.Equal(t, testPayload, data)
 			numEvents++
@@ -317,8 +317,8 @@ func TestPostgresConsumer_DifferentPartitions(t *testing.T) {
 
 	var dispatchMu sync.Mutex
 
-	consumer, err := NewPostgresConsumer("test", &MockDispatcher{
-		onDispatch: func(ctx context.Context, method string, data []byte) error {
+	consumer, err := NewPostgresConsumer("test", configtypes.ConsumerContentModeMethodPayload, &MockDispatcher{
+		onDispatchAPICommand: func(ctx context.Context, mode configtypes.ConsumerContentMode, method string, data []byte) error {
 			dispatchMu.Lock()
 			defer dispatchMu.Unlock()
 			require.Equal(t, testMethod, method)


### PR DESCRIPTION
## Proposed changes

Turns out we need one more mode for asynchronous consumers: API command represented as `Command` from [api Protobuf schema](https://github.com/centrifugal/centrifugo/blob/29faff1c9a7e183c5a06172c5686da1441c4a4b1/internal/apiproto/api.proto#L43). This enables using binary data in asynchronous consumers which is not possible with current format.

We add `content_mode` to the top level of `Consumer` configuration object.

Tree modes exist:

* `api_method_payload` – default
* `api_command` - `Command` from Protobuf schema, both JSON and Protobuf versions can be used
* `publication_data` - looks like raw publication data should be set over the `content_mode` too in this case

For PostgreSQL:

1. Default stays `api_method_payload`. So everything is backwards compatible.
2. Users who want to use `api_command` can do this by setting `content_mode` to `api_command`. In that case `method` in the PostgreSQL outbox table may be empty string. Using binary column type for `payload` will work for Centrifugo if someone wants to pass binary commands over the outbox table.
3. `publication_data` is not supported for PostgreSQL.

For Kafka:

1. Default stays `api_method_payload`. So everything is backwards compatible.
2. Users who want to use `api_command` can do this by setting `content_mode` to `api_command`.
3. `publication_data` will switch to publication data mode. `publication_data_mode.enabled` option becomes deprecated. Also, Centrifugo now comes with default headers to extract publication channels (`centrifugo-channels`), idempotency key (`centrifugo-idempotency-key`) and delta flag (`centrifugo-delta`). So minimal configuration for Kafka consumer in publication mode may look:

```json
{
  "consumers": [
    {
      "enabled": true,
      "name": "mykafka",
      "type": "kafka",
      "content_mode": "publication_data",
      "kafka": {
        "brokers": ["localhost:29092"],
        "topics": ["postgres.public.chat_cdc"],
        "consumer_group": "centrifugo"
      }
    }
  ]
}
```

## TODO

`Command` in Protobuf schema now has some legacy fields, used by Centrifugo admin UI. Probably we should get rid of them now to reduce confusion how to build Command for async consumers.
