### PR TITLE
Handle jwks optional alg

### DIFF
--- a/internal/jwtverify/token_verifier_jwt.go
+++ b/internal/jwtverify/token_verifier_jwt.go
@@ -229,7 +229,7 @@ func (j *jwksManager) verify(token *jwt.Token, tokenVars map[string]any) error {
 		keySetAlgorithm := spec.Algorithm
 		if keySetAlgorithm == "" { // "alg" is optional: https://datatracker.ietf.org/doc/html/rfc7517#section-4.4.
 			switch token.Header().Algorithm {
-			case jwt.RS256, jwt.RS384, jwt.RS512:
+			case jwt.RS256, jwt.RS384, jwt.RS512: // Only allow algorithms from RSA family.
 				keySetAlgorithm = string(token.Header().Algorithm)
 			default:
 				return fmt.Errorf("%w: no match in algorithms", errUnsupportedAlgorithm)
@@ -251,7 +251,7 @@ func (j *jwksManager) verify(token *jwt.Token, tokenVars map[string]any) error {
 		keySetAlgorithm := spec.Algorithm
 		if keySetAlgorithm == "" { // "alg" is optional: https://datatracker.ietf.org/doc/html/rfc7517#section-4.4.
 			switch token.Header().Algorithm {
-			case jwt.ES256, jwt.ES384, jwt.ES512:
+			case jwt.ES256, jwt.ES384, jwt.ES512: // Only allow algorithms from EC family.
 				keySetAlgorithm = string(token.Header().Algorithm)
 			default:
 				return fmt.Errorf("%w: no match in algorithms", errUnsupportedAlgorithm)

--- a/internal/jwtverify/token_verifier_jwt.go
+++ b/internal/jwtverify/token_verifier_jwt.go
@@ -226,9 +226,19 @@ func (j *jwksManager) verify(token *jwt.Token, tokenVars map[string]any) error {
 			return errPublicKeyInvalid
 		}
 
-		verifier, err := jwt.NewVerifierRS(jwt.Algorithm(spec.Algorithm), pubKey)
+		keySetAlgorithm := spec.Algorithm
+		if keySetAlgorithm == "" { // "alg" is optional: https://datatracker.ietf.org/doc/html/rfc7517#section-4.4.
+			switch token.Header().Algorithm {
+			case jwt.RS256, jwt.RS384, jwt.RS512:
+				keySetAlgorithm = string(token.Header().Algorithm)
+			default:
+				return fmt.Errorf("%w: no match in algorithms", errUnsupportedAlgorithm)
+			}
+		}
+
+		verifier, err := jwt.NewVerifierRS(jwt.Algorithm(keySetAlgorithm), pubKey)
 		if err != nil {
-			return fmt.Errorf("%w: %s", errUnsupportedAlgorithm, spec.Algorithm)
+			return fmt.Errorf("%w: %s", errUnsupportedAlgorithm, keySetAlgorithm)
 		}
 
 		return verifier.Verify(token)
@@ -238,9 +248,19 @@ func (j *jwksManager) verify(token *jwt.Token, tokenVars map[string]any) error {
 			return errPublicKeyInvalid
 		}
 
-		verifier, err := jwt.NewVerifierES(jwt.Algorithm(spec.Algorithm), pubKey)
+		keySetAlgorithm := spec.Algorithm
+		if keySetAlgorithm == "" { // "alg" is optional: https://datatracker.ietf.org/doc/html/rfc7517#section-4.4.
+			switch token.Header().Algorithm {
+			case jwt.ES256, jwt.ES384, jwt.ES512:
+				keySetAlgorithm = string(token.Header().Algorithm)
+			default:
+				return fmt.Errorf("%w: no match in algorithms", errUnsupportedAlgorithm)
+			}
+		}
+
+		verifier, err := jwt.NewVerifierES(jwt.Algorithm(keySetAlgorithm), pubKey)
 		if err != nil {
-			return fmt.Errorf("%w: %s", errUnsupportedAlgorithm, spec.Algorithm)
+			return fmt.Errorf("%w: %s", errUnsupportedAlgorithm, keySetAlgorithm)
 		}
 
 		return verifier.Verify(token)


### PR DESCRIPTION
## Proposed changes

Relates #961 

This should make the case with missing `alg` in Key Set work automatically. The only caveat is that theoretically the algorithm used by provider may differ from the one in token (but still in the same family - RSA or EC) – but this must be safe, the verification must always fail.