### PR TITLE
Nats JetStream consumer improvements

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   nats:
-    image: nats:2.9-alpine
+    image: nats:2.10-alpine
     container_name: nats_server
     command: ["-js"]
     ports:

--- a/internal/configtypes/types.go
+++ b/internal/configtypes/types.go
@@ -838,6 +838,8 @@ type NatsJetStreamConsumerConfig struct {
 	DurableConsumerName string `mapstructure:"durable_consumer_name" json:"durable_consumer_name" toml:"durable_consumer_name" yaml:"durable_consumer_name"`
 	// Ordered enables JetStream's ordered consumer mode.
 	// In this mode, only one consumer instance receives messages at a time, preserving exact order.
+	// Ordered consumers are push consumers in Nats and they can't be durable, so DurableConsumerName must not be
+	// used with ordered consumers.
 	Ordered bool `mapstructure:"ordered" json:"ordered" toml:"ordered" yaml:"ordered"`
 	// MethodHeader is the NATS message header used to extract the method name for dispatching commands.
 	MethodHeader string `mapstructure:"method_header" json:"method_header" toml:"method_header" yaml:"method_header"`

--- a/internal/configtypes/types.go
+++ b/internal/configtypes/types.go
@@ -836,11 +836,6 @@ type NatsJetStreamConsumerConfig struct {
 	Subjects []string `mapstructure:"subjects" json:"subjects" toml:"subjects" yaml:"subjects"`
 	// DurableConsumerName sets the name of the durable JetStream consumer to use.
 	DurableConsumerName string `mapstructure:"durable_consumer_name" json:"durable_consumer_name" toml:"durable_consumer_name" yaml:"durable_consumer_name"`
-	// Ordered enables JetStream's ordered consumer mode.
-	// In this mode, only one consumer instance receives messages at a time, preserving exact order.
-	// Ordered consumers are push consumers in Nats and they can't be durable, so DurableConsumerName must not be
-	// used with ordered consumers.
-	Ordered bool `mapstructure:"ordered" json:"ordered" toml:"ordered" yaml:"ordered"`
 	// MethodHeader is the NATS message header used to extract the method name for dispatching commands.
 	MethodHeader string `mapstructure:"method_header" json:"method_header" toml:"method_header" yaml:"method_header"`
 	// PublicationDataMode configures extraction of pre-formatted publication data from message headers.
@@ -875,11 +870,8 @@ func (cfg NatsJetStreamConsumerConfig) Validate() error {
 	if cfg.StreamName == "" {
 		return errors.New("stream_name is required")
 	}
-	if cfg.Ordered && cfg.DurableConsumerName != "" {
-		return errors.New("durable_consumer_name can't be used for ordered consumer")
-	}
-	if !cfg.Ordered && cfg.DurableConsumerName == "" {
-		return errors.New("durable_consumer_name is required for unordered consumer")
+	if cfg.DurableConsumerName == "" {
+		return errors.New("durable_consumer_name is required for consumer")
 	}
 	if cfg.PublicationDataMode.Enabled && cfg.PublicationDataMode.ChannelsHeader == "" {
 		return errors.New("channels_header is required for publication data mode")

--- a/internal/configtypes/types.go
+++ b/internal/configtypes/types.go
@@ -830,7 +830,9 @@ type NatsJetStreamConsumerConfig struct {
 	Password string `mapstructure:"password" json:"password" toml:"password" yaml:"password"`
 	// Token is an alternative authentication mechanism if CredentialsFile and Username are not provided.
 	Token string `mapstructure:"token" json:"token" toml:"token" yaml:"token"`
-	// Subjects is the list of NATS subjects (topics) to subscribe to.
+	// StreamName is the name of the NATS JetStream stream to use.
+	StreamName string `mapstructure:"stream_name" json:"stream_name" toml:"stream_name" yaml:"stream_name"`
+	// Subjects is the list of NATS subjects (topics) to filter.
 	Subjects []string `mapstructure:"subjects" json:"subjects" toml:"subjects" yaml:"subjects"`
 	// DurableConsumerName sets the name of the durable JetStream consumer to use.
 	DurableConsumerName string `mapstructure:"durable_consumer_name" json:"durable_consumer_name" toml:"durable_consumer_name" yaml:"durable_consumer_name"`
@@ -868,11 +870,14 @@ func (cfg NatsJetStreamConsumerConfig) Validate() error {
 	if cfg.URL == "" {
 		return errors.New("url is required")
 	}
-	if len(cfg.Subjects) == 0 {
-		return errors.New("subjects can't be empty")
+	if cfg.StreamName == "" {
+		return errors.New("stream_name is required")
 	}
-	if cfg.DurableConsumerName == "" {
-		return errors.New("durable is required")
+	if cfg.Ordered && cfg.DurableConsumerName != "" {
+		return errors.New("durable_consumer_name can't be used for ordered consumer")
+	}
+	if !cfg.Ordered && cfg.DurableConsumerName == "" {
+		return errors.New("durable_consumer_name is required for unordered consumer")
 	}
 	if cfg.PublicationDataMode.Enabled && cfg.PublicationDataMode.ChannelsHeader == "" {
 		return errors.New("channels_header is required for publication data mode")

--- a/internal/configtypes/types.go
+++ b/internal/configtypes/types.go
@@ -836,6 +836,10 @@ type NatsJetStreamConsumerConfig struct {
 	Subjects []string `mapstructure:"subjects" json:"subjects" toml:"subjects" yaml:"subjects"`
 	// DurableConsumerName sets the name of the durable JetStream consumer to use.
 	DurableConsumerName string `mapstructure:"durable_consumer_name" json:"durable_consumer_name" toml:"durable_consumer_name" yaml:"durable_consumer_name"`
+	// DeliverPolicy is the NATS JetStream delivery policy for the consumer. By default, it is set to "new". Possible values: `new`, `all`.
+	DeliverPolicy string `mapstructure:"deliver_policy" default:"new" json:"deliver_policy" toml:"deliver_policy" yaml:"deliver_policy"`
+	// MaxAckPending is the maximum number of unacknowledged messages that can be pending for the consumer.
+	MaxAckPending int `mapstructure:"max_ack_pending" default:"100" json:"max_ack_pending" toml:"max_ack_pending" yaml:"max_ack_pending"`
 	// MethodHeader is the NATS message header used to extract the method name for dispatching commands.
 	MethodHeader string `mapstructure:"method_header" json:"method_header" toml:"method_header" yaml:"method_header"`
 	// PublicationDataMode configures extraction of pre-formatted publication data from message headers.
@@ -872,6 +876,9 @@ func (cfg NatsJetStreamConsumerConfig) Validate() error {
 	}
 	if cfg.DurableConsumerName == "" {
 		return errors.New("durable_consumer_name is required for consumer")
+	}
+	if cfg.DeliverPolicy != "new" && cfg.DeliverPolicy != "all" {
+		return errors.New("deliver_policy must be either 'new' or 'all'")
 	}
 	if cfg.PublicationDataMode.Enabled && cfg.PublicationDataMode.ChannelsHeader == "" {
 		return errors.New("channels_header is required for publication data mode")

--- a/internal/consuming/nats_jetstream.go
+++ b/internal/consuming/nats_jetstream.go
@@ -88,15 +88,14 @@ func NewNatsJetStreamConsumer(
 	}
 	c.nc = nc
 
-	consumeCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	createCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	jsConsumer, err := createJetStreamConsumer(consumeCtx, nc, cfg)
+	jsConsumer, err := createJetStreamConsumer(createCtx, nc, cfg)
 	if err != nil {
 		nc.Close()
 		return nil, fmt.Errorf("failed to create JetStream consumer: %w", err)
 	}
 	c.consumer = jsConsumer
-
 	return c, nil
 }
 

--- a/internal/consuming/nats_jetstream.go
+++ b/internal/consuming/nats_jetstream.go
@@ -107,11 +107,17 @@ func createJetStreamConsumer(ctx context.Context, nc *nats.Conn, cfg NatsJetStre
 	if err != nil {
 		return nil, fmt.Errorf("failed to create JetStream context: %w", err)
 	}
+	deliverPolicy := jetstream.DeliverNewPolicy
+	if cfg.DeliverPolicy == "all" {
+		deliverPolicy = jetstream.DeliverAllPolicy
+	}
 	return js.CreateOrUpdateConsumer(ctx, cfg.StreamName, jetstream.ConsumerConfig{
-		FilterSubjects: cfg.Subjects,
+		Name:           cfg.DurableConsumerName,
 		Durable:        cfg.DurableConsumerName,
-		DeliverPolicy:  jetstream.DeliverNewPolicy,
+		FilterSubjects: cfg.Subjects,
+		DeliverPolicy:  deliverPolicy,
 		AckWait:        30 * time.Second,
+		MaxAckPending:  cfg.MaxAckPending,
 	})
 }
 

--- a/internal/consuming/nats_jetstream_test.go
+++ b/internal/consuming/nats_jetstream_test.go
@@ -5,18 +5,20 @@ package consuming
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/nats-io/nats.go"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
 )
 
-func TestNatsJetStreamConsumer(t *testing.T) {
+func testNatsJetStreamConsumer(t *testing.T, ordered bool) {
 	url := "nats://localhost:4222"
 	subject := "test.subject" + uuid.NewString()
-	durable := "test-durable" + uuid.NewString()
+	durableConsumerName := "test-durable-" + uuid.NewString()
 
 	nc, err := nats.Connect(url)
 	if err != nil {
@@ -54,35 +56,51 @@ func TestNatsJetStreamConsumer(t *testing.T) {
 	}
 
 	cfg := NatsJetStreamConsumerConfig{
-		URL:                 url,
-		Subjects:            []string{subject},
-		DurableConsumerName: durable,
-		Ordered:             false,         // Change to true to test ordered mode.
-		MethodHeader:        "test-method", // This header key will be used to extract the command method.
+		URL:          url,
+		StreamName:   streamName,
+		Subjects:     []string{subject},
+		Ordered:      ordered,
+		MethodHeader: "test-method", // This header key will be used to extract the command method.
 		// PublicationDataMode remains disabled for this test.
 	}
+	if !ordered {
+		cfg.DurableConsumerName = durableConsumerName
+	}
+	fmt.Println(ordered, cfg.DurableConsumerName)
 
 	consumer, err := NewNatsJetStreamConsumer(cfg, dispatcher, testCommon(prometheus.NewRegistry()))
 	if err != nil {
 		t.Fatalf("failed to create NATS JetStream consumer: %v", err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	go func() {
 		if err := consumer.Run(ctx); err != nil && !errors.Is(err, context.Canceled) {
 			t.Errorf("consumer error: %v", err)
 		}
 	}()
-
 	// Publish a message. Using a header (test-method) to specify that payload is PublishRequest.
 	msg := nats.NewMsg(subject)
 	msg.Data = []byte("Hello, NATS JetStream!")
 	msg.Header.Set("test-method", "publish")
 	_, err = js.PublishMsg(msg)
-	if err != nil {
-		t.Fatalf("failed to publish message: %v", err)
+	require.NoError(t, err, "failed to publish message")
+	waitCh(t, done, 5*time.Second, "timeout waiting for message processing")
+}
+
+func TestNatsJetStreamConsumer(t *testing.T) {
+	testCases := []struct {
+		name    string
+		ordered bool
+	}{
+		{name: "unordered", ordered: false},
+		{name: "ordered", ordered: true},
 	}
 
-	waitCh(t, done, 5*time.Second, "timeout waiting for message processing")
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			testNatsJetStreamConsumer(t, tc.ordered)
+		})
+	}
 }

--- a/internal/consuming/nats_jetstream_test.go
+++ b/internal/consuming/nats_jetstream_test.go
@@ -5,7 +5,6 @@ package consuming
 import (
 	"context"
 	"errors"
-	"fmt"
 	"testing"
 	"time"
 
@@ -15,7 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func testNatsJetStreamConsumer(t *testing.T, ordered bool) {
+func testNatsJetStreamConsumer(t *testing.T) {
 	url := "nats://localhost:4222"
 	subject := "test.subject" + uuid.NewString()
 	durableConsumerName := "test-durable-" + uuid.NewString()
@@ -56,17 +55,13 @@ func testNatsJetStreamConsumer(t *testing.T, ordered bool) {
 	}
 
 	cfg := NatsJetStreamConsumerConfig{
-		URL:          url,
-		StreamName:   streamName,
-		Subjects:     []string{subject},
-		Ordered:      ordered,
-		MethodHeader: "test-method", // This header key will be used to extract the command method.
+		URL:                 url,
+		StreamName:          streamName,
+		Subjects:            []string{subject},
+		DurableConsumerName: durableConsumerName,
+		MethodHeader:        "test-method", // This header key will be used to extract the command method.
 		// PublicationDataMode remains disabled for this test.
 	}
-	if !ordered {
-		cfg.DurableConsumerName = durableConsumerName
-	}
-	fmt.Println(ordered, cfg.DurableConsumerName)
 
 	consumer, err := NewNatsJetStreamConsumer(cfg, dispatcher, testCommon(prometheus.NewRegistry()))
 	if err != nil {
@@ -91,16 +86,14 @@ func testNatsJetStreamConsumer(t *testing.T, ordered bool) {
 
 func TestNatsJetStreamConsumer(t *testing.T) {
 	testCases := []struct {
-		name    string
-		ordered bool
+		name string
 	}{
-		{name: "unordered", ordered: false},
-		{name: "ordered", ordered: true},
+		{name: "green"},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			testNatsJetStreamConsumer(t, tc.ordered)
+			testNatsJetStreamConsumer(t)
 		})
 	}
 }

--- a/internal/consuming/nats_jetstream_test.go
+++ b/internal/consuming/nats_jetstream_test.go
@@ -5,7 +5,7 @@ package consuming
 import (
 	"context"
 	"errors"
-	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -14,77 +14,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 )
-
-func testNatsJetStreamConsumer(t *testing.T) {
-	url := "nats://localhost:4222"
-	subject := "test.subject" + uuid.NewString()
-	durableConsumerName := "test-durable-" + uuid.NewString()
-
-	nc, err := nats.Connect(url)
-	if err != nil {
-		t.Fatalf("failed to connect to NATS: %v", err)
-	}
-	defer nc.Close()
-
-	js, err := nc.JetStream()
-	if err != nil {
-		t.Fatalf("failed to create JetStream context: %v", err)
-	}
-
-	// Ensure a stream exists for our subject.
-	streamName := "TEST_STREAM" + uuid.NewString()
-	_, err = js.StreamInfo(streamName)
-	if err != nil {
-		// Assume the stream doesn't exist; create it using in-memory storage.
-		_, err = js.AddStream(&nats.StreamConfig{
-			Name:     streamName,
-			Subjects: []string{subject},
-			Storage:  nats.MemoryStorage,
-		})
-		if err != nil {
-			t.Fatalf("failed to add stream: %v", err)
-		}
-	}
-
-	done := make(chan struct{})
-
-	dispatcher := &MockDispatcher{
-		onDispatchCommand: func(ctx context.Context, method string, data []byte) error {
-			close(done)
-			return nil
-		},
-	}
-
-	cfg := NatsJetStreamConsumerConfig{
-		URL:                 url,
-		StreamName:          streamName,
-		Subjects:            []string{subject},
-		DurableConsumerName: durableConsumerName,
-		DeliverPolicy:       "new",
-		MethodHeader:        "test-method", // This header key will be used to extract the command method.
-		// PublicationDataMode remains disabled for this test.
-	}
-
-	consumer, err := NewNatsJetStreamConsumer(cfg, dispatcher, testCommon(prometheus.NewRegistry()))
-	if err != nil {
-		t.Fatalf("failed to create NATS JetStream consumer: %v", err)
-	}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	go func() {
-		if err := consumer.Run(ctx); err != nil && !errors.Is(err, context.Canceled) {
-			t.Errorf("consumer error: %v", err)
-		}
-	}()
-	// Publish a message. Using a header (test-method) to specify that payload is PublishRequest.
-	msg := nats.NewMsg(subject)
-	msg.Data = []byte("Hello, NATS JetStream!")
-	msg.Header.Set("test-method", "publish")
-	_, err = js.PublishMsg(msg)
-	require.NoError(t, err, "failed to publish message")
-	waitCh(t, done, 5*time.Second, "timeout waiting for message processing")
-}
 
 func TestNatsJetStreamConsumer(t *testing.T) {
 	t.Parallel()
@@ -101,7 +30,7 @@ func TestNatsJetStreamConsumer(t *testing.T) {
 	}
 }
 
-func testNatsJetStreamConsumerConcurrentConsumers(t *testing.T) {
+func testNatsJetStreamConsumer(t *testing.T) {
 	url := "nats://localhost:4222"
 	subject := "test.subject." + uuid.NewString()
 	durableConsumerName := "test-durable-" + uuid.NewString()
@@ -121,15 +50,12 @@ func testNatsJetStreamConsumerConcurrentConsumers(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	var mu sync.Mutex
-	var receivedBy []string
+	var receivedNum atomic.Int64
 
 	createConsumer := func(name string, done chan struct{}) *NatsJetStreamConsumer {
 		dispatcher := &MockDispatcher{
 			onDispatchCommand: func(ctx context.Context, method string, data []byte) error {
-				mu.Lock()
-				receivedBy = append(receivedBy, name)
-				mu.Unlock()
+				receivedNum.Add(int64(1))
 				close(done)
 				return nil
 			},
@@ -179,32 +105,7 @@ func testNatsJetStreamConsumerConcurrentConsumers(t *testing.T) {
 	_, err = js.PublishMsg(msg)
 	require.NoError(t, err)
 
-	select {
-	case <-done1:
-	case <-done2:
-	case <-time.After(5 * time.Second):
-		t.Fatal("timeout waiting for message to be consumed")
-	}
-
+	waitAnyCh(t, []chan struct{}{done1, done2}, 5*time.Second, "timeout waiting for message processing")
 	time.Sleep(500 * time.Millisecond) // Give a short delay in case both try to ack
-
-	mu.Lock()
-	defer mu.Unlock()
-	require.Len(t, receivedBy, 1, "only one consumer should have received the message")
-	t.Logf("Message was processed by: %s", receivedBy[0])
-}
-
-func TestNatsJetStreamConsumer_ConcurrentConsumers(t *testing.T) {
-	t.Parallel()
-	testCases := []struct {
-		name string
-	}{
-		{name: "basic"},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			testNatsJetStreamConsumerConcurrentConsumers(t)
-		})
-	}
+	require.Equal(t, int64(1), receivedNum.Load(), "only one consumer should have received the message")
 }

--- a/internal/consuming/readme.md
+++ b/internal/consuming/readme.md
@@ -21,6 +21,7 @@ Config:
       "type": "nats_jetstream",
       "nats_jetstream": {
         "url": "nats://localhost:4222",
+        "stream_name": "TEST",
         "subjects": ["test"],
         "durable_consumer_name": "centrifugo"
       }

--- a/internal/consuming/redis_stream_test.go
+++ b/internal/consuming/redis_stream_test.go
@@ -19,6 +19,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestRedisStreamConsumer tests the Redis Stream consumer which is used to consume
+// two different streams.
 func TestRedisStreamConsumer(t *testing.T) {
 	t.Parallel()
 	done1 := make(chan struct{})
@@ -94,7 +96,9 @@ func TestRedisStreamConsumer(t *testing.T) {
 	waitCh(t, done2, 5*time.Second, "timeout waiting for message processing")
 }
 
-func TestRedisStreamConsumer_OnlyOneGetsMessage(t *testing.T) {
+// TestRedisStreamConsumer_ConcurrentConsumers tests that only one consumer processes
+// the message when multiple consumers are running with the same consumer group.
+func TestRedisStreamConsumer_ConcurrentConsumers(t *testing.T) {
 	t.Parallel()
 	done := make(chan string, 1)
 

--- a/internal/consuming/redis_stream_test.go
+++ b/internal/consuming/redis_stream_test.go
@@ -5,6 +5,8 @@ package consuming
 import (
 	"bytes"
 	"context"
+	"errors"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -18,6 +20,7 @@ import (
 )
 
 func TestRedisStreamConsumer(t *testing.T) {
+	t.Parallel()
 	done1 := make(chan struct{})
 	done2 := make(chan struct{})
 
@@ -89,4 +92,82 @@ func TestRedisStreamConsumer(t *testing.T) {
 
 	waitCh(t, done1, 5*time.Second, "timeout waiting for message processing")
 	waitCh(t, done2, 5*time.Second, "timeout waiting for message processing")
+}
+
+func TestRedisStreamConsumer_OnlyOneGetsMessage(t *testing.T) {
+	t.Parallel()
+	done := make(chan string, 1)
+
+	var receivedNum atomic.Int64
+
+	dispatcher := func(name string) *MockDispatcher {
+		return &MockDispatcher{
+			onDispatchCommand: func(ctx context.Context, method string, data []byte) error {
+				receivedNum.Add(1)
+				close(done)
+				return nil
+			},
+		}
+	}
+
+	streamName := "TEST_STREAM_" + uuid.NewString()
+	consumerGroup := "group_" + uuid.NewString()
+
+	cfg := RedisStreamConsumerConfig{
+		Redis: configtypes.Redis{
+			Address: []string{"localhost:6379"},
+		},
+		Streams:       []string{streamName},
+		ConsumerGroup: consumerGroup,
+		PayloadValue:  "payload",
+		NumWorkers:    1,
+	}
+
+	// Build shards once to share producer
+	shards, _, err := redisshard.BuildRedisShards(configtypes.Redis{
+		Address: []string{"localhost:6379"},
+	})
+	require.NoError(t, err)
+
+	// Start first consumer
+	ctx1, cancel1 := context.WithCancel(context.Background())
+	defer cancel1()
+	consumer1, err := NewRedisStreamConsumer(cfg, dispatcher("consumer1"), testCommon(prometheus.NewRegistry()))
+	require.NoError(t, err)
+	go func() {
+		if err := consumer1.Run(ctx1); err != nil && !errors.Is(err, context.Canceled) {
+			t.Errorf("consumer1 error: %v", err)
+		}
+	}()
+
+	// Start second consumer
+	ctx2, cancel2 := context.WithCancel(context.Background())
+	defer cancel2()
+	consumer2, err := NewRedisStreamConsumer(cfg, dispatcher("consumer2"), testCommon(prometheus.NewRegistry()))
+	require.NoError(t, err)
+	go func() {
+		if err := consumer2.Run(ctx2); err != nil && !errors.Is(err, context.Canceled) {
+			t.Errorf("consumer2 error: %v", err)
+		}
+	}()
+
+	// Send message.
+	producer, err := redisqueue.NewProducer(shards[0], redisqueue.ProducerOptions{
+		Stream: streamName,
+	})
+	require.NoError(t, err)
+	err = producer.Enqueue(&redisqueue.Message{
+		Values: map[string]string{
+			"payload": "test",
+		},
+	})
+	require.NoError(t, err)
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for message processing")
+	}
+	time.Sleep(500 * time.Millisecond) // prevent any second dispatch.
+	require.Equal(t, int64(1), receivedNum.Load(), "only one consumer should process the message")
 }


### PR DESCRIPTION
## Proposed changes

After the feedback from @matsuev some changes:

* turned out Nats Jetstream has new client - migrating to it
* for in-memory stream Nats consumer does not handle reconnections properly after Nats restart (it does this for ordered, but not for normal) – so upon getting heartbeat errors restarting the consumer now. So once stream appears – Centrifugo now resubscribes properly.
*  Nats 2.10 is minimal because it supports many subjects to filter
* StreamName is necessary for consumer now
* drop ordered consumer as messages are not load-balanced in that case

