### PR TITLE
Support unmarshaling of duration in env json

### DIFF
--- a/internal/configtypes/duration.go
+++ b/internal/configtypes/duration.go
@@ -19,6 +19,31 @@ func (d Duration) ToDuration() time.Duration {
 	return time.Duration(d)
 }
 
+// UnmarshalJSON interprets numeric values as nanoseconds (default behavior),
+// and strings using time.ParseDuration.
+func (d *Duration) UnmarshalJSON(b []byte) error {
+	// Check if it's a string (starts with a quote).
+	if len(b) > 0 && b[0] == '"' {
+		var str string
+		if err := json.Unmarshal(b, &str); err != nil {
+			return err
+		}
+		parsed, err := time.ParseDuration(str)
+		if err != nil {
+			return err
+		}
+		*d = Duration(parsed)
+		return nil
+	}
+	// Otherwise assume it's a numeric value in nanoseconds.
+	var ns int64
+	if err := json.Unmarshal(b, &ns); err != nil {
+		return err
+	}
+	*d = Duration(ns)
+	return nil
+}
+
 // MarshalJSON for JSON encoding.
 func (d Duration) MarshalJSON() ([]byte, error) {
 	durationStr := time.Duration(d).String()


### PR DESCRIPTION
## Proposed changes

Fixes error:

```
CENTRIFUGO_CHANNEL_NAMESPACES='[{"name":"test","history_size":1,"history_ttl":"300s","force_recovery":true,"force_recovery_mode":"cache"}]' centrifugo
{"level":"fatal","error":"error processing env: envconfig.Process: assigning CENTRIFUGO_CHANNEL_NAMESPACES to NAMESPACES: converting '[{\"name\":\"test\",\"history_size\":1,\"history_ttl\":\"300s\",\"force_recovery\":true,\"force_recovery_mode\":\"cache\"}]' to type configtypes.ChannelNamespaces. details: failed to unmarshal JSON array: json: cannot unmarshal string into Go struct field ChannelNamespace.ChannelOptions.history_ttl of type configtypes.Duration","time":"2025-04-16T11:42:15+02:00","message":"error getting config"}
```
