### PR TITLE
Log whether fips mode enabled on Centrifugo start

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/centrifugal/centrifugo/v6
 
-go 1.23.0
+go 1.24.0
 
 require (
 	cloud.google.com/go/pubsub v1.49.0

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"crypto/fips140"
 	"errors"
 	"net/http"
 	"os"
@@ -87,6 +88,10 @@ func Run(cmd *cobra.Command, configFile string) {
 		Str("runtime", runtime.Version()).
 		Int("pid", os.Getpid()).
 		Int("gomaxprocs", runtime.GOMAXPROCS(0))
+
+	if fips140.Enabled() { // See https://go.dev/doc/security/fips140.
+		entry = entry.Bool("fips", true)
+	}
 
 	if cfg.Broker.Enabled {
 		entry = entry.Str("broker", cfg.Broker.Type)

--- a/internal/jwks/manager_test.go
+++ b/internal/jwks/manager_test.go
@@ -19,7 +19,7 @@ type testKey struct {
 }
 
 func randomKeys() (*rsa.PrivateKey, *rsa.PublicKey, error) {
-	privateKey, err := rsa.GenerateKey(rand.Reader, 512)
+	privateKey, err := rsa.GenerateKey(rand.Reader, 1024)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
## Proposed changes

Starting from 1.24 Go can run crypto modules in FIPS 140-3 compatible mode. This can be controlled by GODEBUG, and we want to explicitly see that the mode is activated. See https://go.dev/doc/security/fips140
