### PR TITLE
Postgresql consumer: option to use try lock

### DIFF
--- a/internal/cli/configdoc/schema.json
+++ b/internal/cli/configdoc/schema.json
@@ -6914,6 +6914,16 @@
                 "is_complex_type": false
               }
             ]
+          },
+          {
+            "field": "consumers[].postgresql.use_try_lock",
+            "name": "use_try_lock",
+            "go_name": "UseTryLock",
+            "level": 3,
+            "type": "bool",
+            "default": "false",
+            "comment": "UseTryLock when enabled tells Centrifugo to use pg_try_advisory_xact_lock instead of pg_advisory_xact_lock.",
+            "is_complex_type": false
           }
         ]
       },

--- a/internal/configtypes/types.go
+++ b/internal/configtypes/types.go
@@ -723,6 +723,8 @@ type PostgresConsumerConfig struct {
 	PartitionPollInterval        Duration  `mapstructure:"partition_poll_interval" json:"partition_poll_interval" envconfig:"partition_poll_interval" default:"300ms" yaml:"partition_poll_interval" toml:"partition_poll_interval"`
 	PartitionNotificationChannel string    `mapstructure:"partition_notification_channel" json:"partition_notification_channel" envconfig:"partition_notification_channel" yaml:"partition_notification_channel" toml:"partition_notification_channel"`
 	TLS                          TLSConfig `mapstructure:"tls" json:"tls" envconfig:"tls" yaml:"tls" toml:"tls"`
+	// UseTryLock when enabled tells Centrifugo to use pg_try_advisory_xact_lock instead of pg_advisory_xact_lock.
+	UseTryLock bool `mapstructure:"use_try_lock" json:"use_try_lock" envconfig:"use_try_lock" default:"false" yaml:"use_try_lock" toml:"use_try_lock"`
 }
 
 func (c PostgresConsumerConfig) Validate() error {


### PR DESCRIPTION
## Proposed changes

New option for PG consumer `use_try_lock` (boolean, default `false`) to use `pg_try_advisory_xact_lock` instead of `pg_advisory_xact_lock` for locking outbox table. This may help to reduce the number of long-running transactions on PG side. 
