### PR TITLE
Kafka consumer: per-partition size-limited queue for backpressure, configurable fetch_max_wait

### DIFF
--- a/internal/configtypes/types.go
+++ b/internal/configtypes/types.go
@@ -749,7 +749,8 @@ type KafkaConsumerConfig struct {
 	// FetchMaxWait is the maximum time to wait for records when polling.
 	// If not set, defaults to 500ms.
 	FetchMaxWait Duration `mapstructure:"fetch_max_wait" json:"fetch_max_wait" envconfig:"fetch_max_wait" default:"500ms" yaml:"fetch_max_wait" toml:"fetch_max_wait"`
-	// PartitionQueueMaxSize is the maximum number of items in partition queue before pausing.
+	// PartitionQueueMaxSize is the maximum number of items in partition queue before pausing consuming from a partition.
+	// The actual queue size may exceed this value on `max_poll_records`, so this acts more like a threshold.
 	// If zero, pausing is done on every poll. If set, pausing only happens when queue size exceeds this threshold.
 	PartitionQueueMaxSize int `mapstructure:"partition_queue_max_size" json:"partition_queue_max_size" envconfig:"partition_queue_max_size" default:"1000" yaml:"partition_queue_max_size" toml:"partition_queue_max_size"`
 

--- a/internal/configtypes/types.go
+++ b/internal/configtypes/types.go
@@ -743,6 +743,9 @@ type KafkaConsumerConfig struct {
 	Topics         []string `mapstructure:"topics" json:"topics" envconfig:"topics" yaml:"topics" toml:"topics"`
 	ConsumerGroup  string   `mapstructure:"consumer_group" json:"consumer_group" envconfig:"consumer_group" yaml:"consumer_group" toml:"consumer_group"`
 	MaxPollRecords int      `mapstructure:"max_poll_records" json:"max_poll_records" envconfig:"max_poll_records" default:"100" yaml:"max_poll_records" toml:"max_poll_records"`
+	// FetchMaxBytes is the maximum number of bytes to fetch from Kafka in a single request.
+	// If not set the default 50MB is used.
+	FetchMaxBytes int32 `mapstructure:"fetch_max_bytes" json:"fetch_max_bytes" envconfig:"fetch_max_bytes" yaml:"fetch_max_bytes" toml:"fetch_max_bytes"`
 
 	// TLS for the connection to Kafka.
 	TLS TLSConfig `mapstructure:"tls" json:"tls" envconfig:"tls" yaml:"tls" toml:"tls"`
@@ -751,10 +754,6 @@ type KafkaConsumerConfig struct {
 	SASLMechanism string `mapstructure:"sasl_mechanism" json:"sasl_mechanism" envconfig:"sasl_mechanism" yaml:"sasl_mechanism" toml:"sasl_mechanism"`
 	SASLUser      string `mapstructure:"sasl_user" json:"sasl_user" envconfig:"sasl_user" yaml:"sasl_user" toml:"sasl_user"`
 	SASLPassword  string `mapstructure:"sasl_password" json:"sasl_password" envconfig:"sasl_password" yaml:"sasl_password" toml:"sasl_password"`
-
-	// FetchMaxBytes is the maximum number of bytes to fetch from Kafka in a single request.
-	// If not set the default 50MB is used.
-	FetchMaxBytes int32 `mapstructure:"fetch_max_bytes" json:"fetch_max_bytes" envconfig:"fetch_max_bytes" yaml:"fetch_max_bytes" toml:"fetch_max_bytes"`
 
 	// MethodHeader is a header name to extract method name from Kafka message.
 	// If provided in message, then payload must be just a serialized API request object.

--- a/internal/configtypes/types.go
+++ b/internal/configtypes/types.go
@@ -746,6 +746,12 @@ type KafkaConsumerConfig struct {
 	// FetchMaxBytes is the maximum number of bytes to fetch from Kafka in a single request.
 	// If not set the default 50MB is used.
 	FetchMaxBytes int32 `mapstructure:"fetch_max_bytes" json:"fetch_max_bytes" envconfig:"fetch_max_bytes" yaml:"fetch_max_bytes" toml:"fetch_max_bytes"`
+	// FetchMaxWait is the maximum time to wait for records when polling.
+	// If not set, defaults to 500ms.
+	FetchMaxWait Duration `mapstructure:"fetch_max_wait" json:"fetch_max_wait" envconfig:"fetch_max_wait" default:"500ms" yaml:"fetch_max_wait" toml:"fetch_max_wait"`
+	// PartitionQueueMaxSize is the maximum number of items in partition queue before pausing.
+	// If zero, pausing is done on every poll. If set, pausing only happens when queue size exceeds this threshold.
+	PartitionQueueMaxSize int `mapstructure:"partition_queue_max_size" json:"partition_queue_max_size" envconfig:"partition_queue_max_size" default:"1000" yaml:"partition_queue_max_size" toml:"partition_queue_max_size"`
 
 	// TLS for the connection to Kafka.
 	TLS TLSConfig `mapstructure:"tls" json:"tls" envconfig:"tls" yaml:"tls" toml:"tls"`

--- a/internal/configtypes/types.go
+++ b/internal/configtypes/types.go
@@ -752,11 +752,6 @@ type KafkaConsumerConfig struct {
 	SASLUser      string `mapstructure:"sasl_user" json:"sasl_user" envconfig:"sasl_user" yaml:"sasl_user" toml:"sasl_user"`
 	SASLPassword  string `mapstructure:"sasl_password" json:"sasl_password" envconfig:"sasl_password" yaml:"sasl_password" toml:"sasl_password"`
 
-	// PartitionBufferSize is the size of the buffer for each partition consumer.
-	// This is the number of records that can be buffered before the consumer
-	// will pause fetching records from Kafka. By default, this is 16.
-	PartitionBufferSize int `mapstructure:"partition_buffer_size" json:"partition_buffer_size" envconfig:"partition_buffer_size" default:"16" yaml:"partition_buffer_size" toml:"partition_buffer_size"`
-
 	// FetchMaxBytes is the maximum number of bytes to fetch from Kafka in a single request.
 	// If not set the default 50MB is used.
 	FetchMaxBytes int32 `mapstructure:"fetch_max_bytes" json:"fetch_max_bytes" envconfig:"fetch_max_bytes" yaml:"fetch_max_bytes" toml:"fetch_max_bytes"`

--- a/internal/consuming/kafka.go
+++ b/internal/consuming/kafka.go
@@ -63,7 +63,7 @@ func NewKafkaConsumer(
 		config.MaxPollRecords = 100
 	}
 	if config.FetchMaxWait == 0 {
-		config.FetchMaxWait = configtypes.Duration(200 * time.Millisecond)
+		config.FetchMaxWait = configtypes.Duration(500 * time.Millisecond)
 	}
 	consumer := &KafkaConsumer{
 		nodeID:     common.nodeID,

--- a/internal/consuming/kafka.go
+++ b/internal/consuming/kafka.go
@@ -216,8 +216,6 @@ func (c *KafkaConsumer) pollUntilFatal(ctx context.Context) error {
 		case <-ctx.Done():
 			return ctx.Err()
 		default:
-			// PollRecords is recommended when using BlockRebalanceOnPoll.
-			// Need to ensure that processor loop complete fast enough to not block a rebalance for too long.
 			fetches := c.client.PollRecords(ctx, c.config.MaxPollRecords)
 			if fetches.IsClientClosed() {
 				return nil
@@ -246,8 +244,6 @@ func (c *KafkaConsumer) pollUntilFatal(ctx context.Context) error {
 
 				tp := topicPartition{p.Topic, p.Partition}
 
-				// Since we are using BlockRebalanceOnPoll, we can be
-				// sure this partition consumer exists
 				consumer := c.consumers[tp]
 				if consumer == nil {
 					return

--- a/internal/consuming/kafka.go
+++ b/internal/consuming/kafka.go
@@ -96,6 +96,7 @@ func (c *KafkaConsumer) initClient() (*kgo.Client, error) {
 		kgo.BlockRebalanceOnPoll(),
 		kgo.ClientID(kafkaClientID),
 		kgo.InstanceID(c.getInstanceID()),
+		kgo.FetchMaxWait(200 * time.Millisecond),
 	}
 	if c.config.FetchMaxBytes > 0 {
 		opts = append(opts, kgo.FetchMaxBytes(c.config.FetchMaxBytes))

--- a/internal/consuming/kafka.go
+++ b/internal/consuming/kafka.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/centrifugal/centrifugo/v6/internal/api"
 	"github.com/centrifugal/centrifugo/v6/internal/configtypes"
+	"github.com/centrifugal/centrifugo/v6/internal/logging"
 
 	"github.com/twmb/franz-go/pkg/kgo"
 	"github.com/twmb/franz-go/pkg/kmsg"
@@ -60,9 +61,6 @@ func NewKafkaConsumer(
 	}
 	if config.MaxPollRecords == 0 {
 		config.MaxPollRecords = 100
-	}
-	if config.PartitionBufferSize < 0 {
-		return nil, errors.New("partition buffer size can't be negative")
 	}
 	consumer := &KafkaConsumer{
 		nodeID:     common.nodeID,
@@ -237,71 +235,58 @@ func (c *KafkaConsumer) pollUntilFatal(ctx context.Context) error {
 				return fmt.Errorf("poll error: %w", errors.Join(errs...))
 			}
 
+			// Track which partitions we've paused in this poll cycle.
 			pausedTopicPartitions := map[topicPartition]struct{}{}
+
 			fetches.EachPartition(func(p kgo.FetchTopicPartition) {
 				if len(p.Records) == 0 {
 					return
 				}
 
 				tp := topicPartition{p.Topic, p.Partition}
-				if _, paused := pausedTopicPartitions[tp]; paused {
-					// We have already paused this partition during this poll, so we should not
-					// process records from it anymore. We will resume partition processing with the
-					// correct offset soon, after we have space in recs buffer.
+
+				// Since we are using BlockRebalanceOnPoll, we can be
+				// sure this partition consumer exists
+				consumer := c.consumers[tp]
+				if consumer == nil {
 					return
 				}
 
-				// Since we are using BlockRebalanceOnPoll, we can be
-				// sure this partition consumer exists:
-				// * onAssigned is guaranteed to be called before we
-				// fetch offsets for newly added partitions
-				// * onRevoked waits for partition consumers to quit
-				// and be deleted before re-allowing polling.
 				select {
 				case <-ctx.Done():
 					return
-				case <-c.consumers[tp].quit:
+				case <-consumer.quit:
 					return
-				case c.consumers[tp].recs <- p:
-					if c.testOnlyConfig.fetchTopicPartitionSubmittedCh != nil { // Only set in tests.
-						c.testOnlyConfig.fetchTopicPartitionSubmittedCh <- p
-					}
 				default:
-					if c.testOnlyConfig.topicPartitionBeforePauseCh != nil { // Only set in tests.
+				}
+
+				partitionsToPause := map[string][]int32{p.Topic: {p.Partition}}
+				if _, paused := pausedTopicPartitions[tp]; !paused {
+					// Pause partition BEFORE submitting to queue to avoid race condition
+					// between pause and resume operations.
+					if c.testOnlyConfig.topicPartitionBeforePauseCh != nil {
 						c.testOnlyConfig.topicPartitionBeforePauseCh <- tp
 					}
-					if c.testOnlyConfig.topicPartitionPauseProceedCh != nil { // Only set in tests.
+					if c.testOnlyConfig.topicPartitionPauseProceedCh != nil {
 						<-c.testOnlyConfig.topicPartitionPauseProceedCh
 					}
-
-					partitionsToPause := map[string][]int32{p.Topic: {p.Partition}}
-					// PauseFetchPartitions here to not poll partition until records are processed.
-					// This allows parallel processing of records from different partitions, without
-					// keeping records in memory and blocking rebalance. Resume will be called after
-					// records are processed by c.consumers[tp].
 					c.client.PauseFetchPartitions(partitionsToPause)
-					defer func() {
-						// There is a chance that message processor resumed partition processing before
-						// we called PauseFetchPartitions above. Such a race was observed in a service
-						// under CPU throttling conditions. In that case Pause is called after Resume,
-						// and topic is never resumed after that. To avoid we check if the channel current
-						// len is less than cap, if len < cap => we can be sure that buffer has space now,
-						// so we can resume partition processing. If it is not, this means that the records
-						// are still not processed and resume will be called eventually after processing by
-						// partition consumer. See also TestKafkaConsumer_TestPauseAfterResumeRace test case.
-						if len(c.consumers[tp].recs) < cap(c.consumers[tp].recs) {
-							c.client.ResumeFetchPartitions(partitionsToPause)
-						}
-					}()
-
 					pausedTopicPartitions[tp] = struct{}{}
-					// To poll next time since correct offset we need to set it manually to the offset of
-					// the first record in the batch. Otherwise, next poll will return the next record batch,
-					// and we will lose the current one.
-					epochOffset := kgo.EpochOffset{Epoch: -1, Offset: p.Records[0].Offset}
-					c.client.SetOffsets(map[string]map[int32]kgo.EpochOffset{p.Topic: {p.Partition: epochOffset}})
+				}
+
+				// Now submit to unbounded queue after pausing.
+				if !consumer.queue.Push(p) {
+					// Queue is closed, partition consumer is shutting down
+					// Resume the partition since we paused it but won't process
+					c.client.ResumeFetchPartitions(partitionsToPause)
+					return
+				}
+
+				if c.testOnlyConfig.fetchTopicPartitionSubmittedCh != nil {
+					c.testOnlyConfig.fetchTopicPartitionSubmittedCh <- p
 				}
 			})
+
 			c.client.AllowRebalance()
 		}
 	}
@@ -334,13 +319,7 @@ func (c *KafkaConsumer) reInitClient(ctx context.Context) error {
 	return nil
 }
 
-const defaultPartitionBufferSize = 8
-
 func (c *KafkaConsumer) assigned(ctx context.Context, cl *kgo.Client, assigned map[string][]int32) {
-	bufferSize := c.config.PartitionBufferSize
-	if bufferSize == 0 {
-		bufferSize = defaultPartitionBufferSize
-	}
 	for topic, partitions := range assigned {
 		for _, partition := range partitions {
 			quitCh := make(chan struct{})
@@ -363,9 +342,9 @@ func (c *KafkaConsumer) assigned(ctx context.Context, cl *kgo.Client, assigned m
 				name:         c.name,
 				common:       c.common,
 
-				quit: quitCh,
-				done: make(chan struct{}),
-				recs: make(chan kgo.FetchTopicPartition, bufferSize),
+				quit:  quitCh,
+				done:  make(chan struct{}),
+				queue: newUnboundedQueue(),
 			}
 			c.consumers[topicPartition{topic, partition}] = pc
 			go pc.consume()
@@ -399,6 +378,7 @@ func (c *KafkaConsumer) killConsumers(lost map[string][]int32) {
 			tp := topicPartition{topic, partition}
 			pc := c.consumers[tp]
 			delete(c.consumers, tp)
+			pc.queue.Close()
 			close(pc.quit)
 			wg.Add(1)
 			go func() { <-pc.done; wg.Done() }()
@@ -416,9 +396,9 @@ type partitionConsumer struct {
 	name         string
 	common       *consumerCommon
 
-	quit chan struct{}
-	done chan struct{}
-	recs chan kgo.FetchTopicPartition
+	quit  chan struct{}
+	done  chan struct{}
+	queue *unboundedQueue
 }
 
 func getUint64HeaderValue(record *kgo.Record, headerKey string) (uint64, error) {
@@ -487,8 +467,13 @@ func (pc *partitionConsumer) processPublicationDataRecord(ctx context.Context, r
 		pc.common.log.Error().Err(err).Str("topic", record.Topic).Int32("partition", record.Partition).Msg("error parsing delta header value, skip message")
 		return nil
 	}
-	channels := strings.Split(getHeaderValue(record, pc.config.PublicationDataMode.ChannelsHeader), ",")
-	if len(channels) == 0 {
+	channelsHeader := getHeaderValue(record, pc.config.PublicationDataMode.ChannelsHeader)
+	if channelsHeader == "" {
+		pc.common.log.Info().Str("topic", record.Topic).Int32("partition", record.Partition).Msg("no channels found, skip message")
+		return nil
+	}
+	channels := strings.Split(channelsHeader, ",")
+	if len(channels) == 0 || (len(channels) == 1 && channels[0] == "") {
 		pc.common.log.Info().Str("topic", record.Topic).Int32("partition", record.Partition).Msg("no channels found, skip message")
 		return nil
 	}
@@ -556,20 +541,124 @@ func (pc *partitionConsumer) processRecords(records []*kgo.Record) {
 }
 
 func (pc *partitionConsumer) consume() {
+	if logging.Enabled(logging.DebugLevel) {
+		pc.common.log.Debug().Str("topic", pc.topic).Int32("partition", pc.partition).Msg("starting partition consumer")
+	}
 	defer close(pc.done)
+	defer pc.queue.Close()
+	defer func() {
+		if logging.Enabled(logging.DebugLevel) {
+			// Queue is closed, partition consumer is shutting down.
+			pc.common.log.Debug().Str("topic", pc.topic).Int32("partition", pc.partition).Msg("partition consumer shutting down")
+		}
+	}()
+
 	partitionsToResume := map[string][]int32{pc.topic: {pc.partition}}
 	resumeConsuming := func() {
 		pc.cl.ResumeFetchPartitions(partitionsToResume)
 	}
 	defer resumeConsuming()
+
 	for {
 		select {
 		case <-pc.partitionCtx.Done():
 			return
-		case p := <-pc.recs:
-			pc.processRecords(p.Records)
-			// After processing records, we can resume partition processing (if it was paused, no-op otherwise).
-			resumeConsuming()
+		case <-pc.queue.NotEmpty():
+			if pc.queue.IsClosed() {
+				return
+			}
+			// Process all available items in the queue.
+			for {
+				select {
+				case <-pc.partitionCtx.Done():
+					return
+				default:
+				}
+				p, ok := pc.queue.Pop()
+				if !ok {
+					break
+				}
+				pc.processRecords(p.Records)
+				// Resume partition after processing this batch. Only one additional batch will
+				// be added to the queue before we pause again.
+				resumeConsuming()
+			}
 		}
 	}
+}
+
+// unboundedQueue implements an unbounded queue for FetchTopicPartition
+type unboundedQueue struct {
+	mu       sync.RWMutex
+	items    []kgo.FetchTopicPartition
+	notEmpty chan struct{}
+	closed   bool
+}
+
+func newUnboundedQueue() *unboundedQueue {
+	return &unboundedQueue{
+		items:    make([]kgo.FetchTopicPartition, 0),
+		notEmpty: make(chan struct{}, 1),
+	}
+}
+
+func (q *unboundedQueue) Push(item kgo.FetchTopicPartition) bool {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	if q.closed {
+		return false
+	}
+
+	q.items = append(q.items, item)
+
+	// Signal that queue is not empty.
+	select {
+	case q.notEmpty <- struct{}{}:
+	default:
+	}
+
+	return true
+}
+
+func (q *unboundedQueue) Pop() (kgo.FetchTopicPartition, bool) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	if q.closed || len(q.items) == 0 {
+		return kgo.FetchTopicPartition{}, false
+	}
+
+	// We do not expect many items in the queue, so we can use a simple slice pop operation and
+	// not worry about memory being reserved for the underlying slice.
+	item := q.items[0]
+	q.items = q.items[1:]
+
+	return item, true
+}
+
+func (q *unboundedQueue) Len() int {
+	q.mu.RLock()
+	defer q.mu.RUnlock()
+	return len(q.items)
+}
+
+func (q *unboundedQueue) Close() {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	if !q.closed {
+		q.closed = true
+		close(q.notEmpty)
+	}
+}
+
+func (q *unboundedQueue) IsClosed() bool {
+	q.mu.RLock()
+	defer q.mu.RUnlock()
+	return q.closed
+}
+
+func (q *unboundedQueue) NotEmpty() <-chan struct{} {
+	return q.notEmpty
 }

--- a/internal/consuming/kafka_test.go
+++ b/internal/consuming/kafka_test.go
@@ -401,83 +401,76 @@ func TestKafkaConsumer_BlockedPartitionDoesNotBlockAnotherTopic(t *testing.T) {
 // is stuck on it. We want to make sure that the consumer is not blocked and can still process
 // messages from other topic partitions.
 func TestKafkaConsumer_BlockedPartitionDoesNotBlockAnotherPartition(t *testing.T) {
-	partitionBufferSizes := []int{0, 1}
+	t.Parallel()
+	testKafkaTopic1 := "consumer_test_1_" + uuid.New().String()
 
-	for _, partitionBufferSize := range partitionBufferSizes {
-		t.Run(fmt.Sprintf("partition_buffer_size_%d", partitionBufferSize), func(t *testing.T) {
-			t.Parallel()
-			testKafkaTopic1 := "consumer_test_1_" + uuid.New().String()
+	testPayload1 := []byte(`{"key":"value1"}`)
+	testPayload2 := []byte(`{"key":"value2"}`)
 
-			testPayload1 := []byte(`{"key":"value1"}`)
-			testPayload2 := []byte(`{"key":"value2"}`)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
 
-			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-			defer cancel()
+	err := createTestTopic(ctx, testKafkaTopic1, 2, 1)
+	require.NoError(t, err)
 
-			err := createTestTopic(ctx, testKafkaTopic1, 2, 1)
-			require.NoError(t, err)
+	event1Received := make(chan struct{})
+	event2Received := make(chan struct{})
+	consumerClosed := make(chan struct{})
+	doneCh := make(chan struct{})
 
-			event1Received := make(chan struct{})
-			event2Received := make(chan struct{})
-			consumerClosed := make(chan struct{})
-			doneCh := make(chan struct{})
-
-			config := KafkaConfig{
-				Brokers:             []string{testKafkaBrokerURL},
-				Topics:              []string{testKafkaTopic1},
-				ConsumerGroup:       uuid.New().String(),
-				PartitionBufferSize: partitionBufferSize,
-			}
-
-			numCalls := 0
-
-			mockDispatcher := &MockDispatcher{
-				onDispatchCommand: func(ctx context.Context, method string, data []byte) error {
-					if numCalls == 0 {
-						numCalls++
-						close(event1Received)
-						// Block till the event2 received. This must not block the consumer and event2
-						// must still be processed successfully.
-						<-event2Received
-						return nil
-					}
-					close(event2Received)
-					return nil
-				},
-			}
-			consumer, err := NewKafkaConsumer(
-				config, mockDispatcher, testCommon(prometheus.NewRegistry()))
-			require.NoError(t, err)
-
-			go func() {
-				err = produceTestMessageToPartition(testKafkaTopic1, testPayload1, 0)
-				require.NoError(t, err)
-
-				// Wait until the first message is received to make sure messages read by separate PollRecords calls.
-				<-event1Received
-				err = produceTestMessageToPartition(testKafkaTopic1, testPayload2, 1)
-				require.NoError(t, err)
-			}()
-
-			go func() {
-				err := consumer.Run(ctx)
-				require.ErrorIs(t, err, context.Canceled)
-				close(consumerClosed)
-			}()
-
-			waitCh(t, event2Received, 30*time.Second, "timeout waiting for event 2")
-			cancel()
-			waitCh(t, consumerClosed, 30*time.Second, "timeout waiting for consumer closed")
-			close(doneCh)
-		})
+	config := KafkaConfig{
+		Brokers:       []string{testKafkaBrokerURL},
+		Topics:        []string{testKafkaTopic1},
+		ConsumerGroup: uuid.New().String(),
 	}
+
+	numCalls := 0
+
+	mockDispatcher := &MockDispatcher{
+		onDispatchCommand: func(ctx context.Context, method string, data []byte) error {
+			if numCalls == 0 {
+				numCalls++
+				close(event1Received)
+				// Block till the event2 received. This must not block the consumer and event2
+				// must still be processed successfully.
+				<-event2Received
+				return nil
+			}
+			close(event2Received)
+			return nil
+		},
+	}
+	consumer, err := NewKafkaConsumer(
+		config, mockDispatcher, testCommon(prometheus.NewRegistry()))
+	require.NoError(t, err)
+
+	go func() {
+		err = produceTestMessageToPartition(testKafkaTopic1, testPayload1, 0)
+		require.NoError(t, err)
+
+		// Wait until the first message is received to make sure messages read by separate PollRecords calls.
+		<-event1Received
+		err = produceTestMessageToPartition(testKafkaTopic1, testPayload2, 1)
+		require.NoError(t, err)
+	}()
+
+	go func() {
+		err := consumer.Run(ctx)
+		require.ErrorIs(t, err, context.Canceled)
+		close(consumerClosed)
+	}()
+
+	waitCh(t, event2Received, 30*time.Second, "timeout waiting for event 2")
+	cancel()
+	waitCh(t, consumerClosed, 30*time.Second, "timeout waiting for consumer closed")
+	close(doneCh)
 }
+
 func TestKafkaConsumer_PausePartitions(t *testing.T) {
 	t.Parallel()
 	testKafkaTopic := "consumer_test_" + uuid.New().String()
 	testPayload1 := []byte(`{"key":"value1"}`)
 	testPayload2 := []byte(`{"key":"value2"}`)
-	testPayload3 := []byte(`{"key":"value3"}`)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
@@ -487,7 +480,6 @@ func TestKafkaConsumer_PausePartitions(t *testing.T) {
 
 	event1Received := make(chan struct{})
 	event2Received := make(chan struct{})
-	event3Received := make(chan struct{})
 	consumerClosed := make(chan struct{})
 	doneCh := make(chan struct{})
 
@@ -498,8 +490,6 @@ func TestKafkaConsumer_PausePartitions(t *testing.T) {
 		Brokers:       []string{testKafkaBrokerURL},
 		Topics:        []string{testKafkaTopic},
 		ConsumerGroup: uuid.New().String(),
-
-		PartitionBufferSize: 1,
 	}
 
 	numCalls := 0
@@ -518,11 +508,8 @@ func TestKafkaConsumer_PausePartitions(t *testing.T) {
 				close(event1Received)
 				<-unblockCh
 				return nil
-			} else if numCalls == 2 {
-				close(event2Received)
-				return nil
 			}
-			close(event3Received)
+			close(event2Received)
 			return nil
 		},
 	}
@@ -535,21 +522,17 @@ func TestKafkaConsumer_PausePartitions(t *testing.T) {
 	go func() {
 		err = produceTestMessage(testKafkaTopic, testPayload1, nil)
 		require.NoError(t, err)
+		<-beforePauseCh // Wait for triggering the partition pause.
 		<-fetchSubmittedCh
 		<-event1Received
-
-		err = produceTestMessage(testKafkaTopic, testPayload2, nil)
-		require.NoError(t, err)
-		<-fetchSubmittedCh
+		// Unblock the message processing.
+		close(unblockCh)
 
 		// At this point message 1 is being processed and the next produced message must
 		// cause a partition pause.
-		err = produceTestMessage(testKafkaTopic, testPayload3, nil)
+		err = produceTestMessage(testKafkaTopic, testPayload2, nil)
 		require.NoError(t, err)
 		<-beforePauseCh // Wait for triggering the partition pause.
-
-		// Unblock the message processing.
-		close(unblockCh)
 		<-fetchSubmittedCh
 	}()
 
@@ -561,7 +544,6 @@ func TestKafkaConsumer_PausePartitions(t *testing.T) {
 
 	waitCh(t, event1Received, 30*time.Second, "timeout waiting for event 1")
 	waitCh(t, event2Received, 30*time.Second, "timeout waiting for event 2")
-	waitCh(t, event3Received, 30*time.Second, "timeout waiting for event 3")
 	cancel()
 	waitCh(t, consumerClosed, 30*time.Second, "timeout waiting for consumer closed")
 	close(doneCh)
@@ -572,16 +554,15 @@ func TestKafkaConsumer_WorksCorrectlyInLoadedTopic(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {
-		numPartitions   int32
-		numMessages     int
-		partitionBuffer int
+		numPartitions int32
+		numMessages   int
 	}{
-		//{numPartitions: 1, numMessages: 1000, partitionBuffer: 1}
-		{numPartitions: 10, numMessages: 10000, partitionBuffer: 1},
+		//{numPartitions: 1, numMessages: 1000}
+		{numPartitions: 10, numMessages: 10000},
 	}
 
 	for _, tc := range testCases {
-		name := fmt.Sprintf("partitions=%d,messages=%d,buffer=%d", tc.numPartitions, tc.numMessages, tc.partitionBuffer)
+		name := fmt.Sprintf("partitions=%d,messages=%d", tc.numPartitions, tc.numMessages)
 		t.Run(name, func(t *testing.T) {
 			testKafkaTopic := "consumer_test_" + uuid.New().String()
 
@@ -606,10 +587,9 @@ func TestKafkaConsumer_WorksCorrectlyInLoadedTopic(t *testing.T) {
 				},
 			}
 			config := KafkaConfig{
-				Brokers:             []string{testKafkaBrokerURL},
-				Topics:              []string{testKafkaTopic},
-				ConsumerGroup:       uuid.New().String(),
-				PartitionBufferSize: tc.partitionBuffer,
+				Brokers:       []string{testKafkaBrokerURL},
+				Topics:        []string{testKafkaTopic},
+				ConsumerGroup: uuid.New().String(),
 			}
 			consumer, err := NewKafkaConsumer(
 				config, mockDispatcher, testCommon(prometheus.NewRegistry()))
@@ -659,108 +639,6 @@ func TestKafkaConsumer_WorksCorrectlyInLoadedTopic(t *testing.T) {
 			close(doneCh)
 		})
 	}
-}
-
-// TestKafkaConsumer_TestPauseAfterResumeRace tests a scenario where a partition was
-// paused after it was resumed and partition never processed any messages after that.
-func TestKafkaConsumer_TestPauseAfterResumeRace(t *testing.T) {
-	t.Parallel()
-	testKafkaTopic := "consumer_test_" + uuid.New().String()
-	testPayload1 := []byte(`{"input":"value1"}`)
-	testPayload2 := []byte(`{"input":"value2"}`)
-	testPayload3 := []byte(`{"input":"value3"}`)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Second)
-	defer cancel()
-
-	err := createTestTopic(ctx, testKafkaTopic, 1, 1)
-	require.NoError(t, err)
-
-	consumerClosed := make(chan struct{})
-	doneCh := make(chan struct{})
-
-	messageCh := make(chan struct{}, 128)
-
-	partitionBeforePauseCh := make(chan topicPartition)
-	partitionPauseProceedCh := make(chan struct{})
-	fetchSubmittedCh := make(chan kgo.FetchTopicPartition)
-
-	config := KafkaConfig{
-		Brokers:             []string{testKafkaBrokerURL},
-		Topics:              []string{testKafkaTopic},
-		ConsumerGroup:       uuid.New().String(),
-		PartitionBufferSize: 1,
-	}
-
-	count := 0
-	proceedCh := make(chan struct{})
-	firstMessageReceived := make(chan struct{})
-
-	mockDispatcher := &MockDispatcher{
-		onDispatchCommand: func(ctx context.Context, method string, data []byte) error {
-			if count == 0 {
-				close(firstMessageReceived)
-				// Block until we are allowed to proceed
-				t.Logf("waiting for proceed")
-				<-proceedCh
-				t.Logf("proceeding")
-			}
-			count++
-			messageCh <- struct{}{}
-			t.Logf("message processed")
-			return nil
-		},
-	}
-	consumer, err := NewKafkaConsumer(
-		config, mockDispatcher, testCommon(prometheus.NewRegistry()))
-	require.NoError(t, err)
-
-	consumer.testOnlyConfig = testOnlyConfig{
-		topicPartitionBeforePauseCh:    partitionBeforePauseCh,
-		topicPartitionPauseProceedCh:   partitionPauseProceedCh,
-		fetchTopicPartitionSubmittedCh: fetchSubmittedCh,
-	}
-
-	go func() {
-		err := consumer.Run(ctx)
-		require.ErrorIs(t, err, context.Canceled)
-		close(consumerClosed)
-	}()
-
-	go func() {
-		err = produceTestMessage(testKafkaTopic, testPayload1, nil)
-		require.NoError(t, err)
-
-		<-fetchSubmittedCh
-		t.Logf("fetch 1 submitted")
-
-		// This one should be buffered.
-		err = produceTestMessage(testKafkaTopic, testPayload2, nil)
-		require.NoError(t, err)
-
-		<-fetchSubmittedCh
-		t.Logf("fetch 2 submitted")
-
-		// This message pauses the partition consumer.
-		err = produceTestMessage(testKafkaTopic, testPayload3, nil)
-		require.NoError(t, err)
-		<-partitionBeforePauseCh
-		close(proceedCh)
-		// Give consumer some time to process messages, so we can be sure that resume was called.
-		time.Sleep(time.Second)
-		// And now we can proceed so that partition will be paused after resume.
-		close(partitionPauseProceedCh)
-		// Wait for the third message submitted for processing.
-		<-fetchSubmittedCh
-	}()
-
-	for i := 0; i < 3; i++ {
-		<-messageCh
-	}
-
-	cancel()
-	waitCh(t, consumerClosed, 30*time.Second, "timeout waiting for consumer closed")
-	close(doneCh)
 }
 
 func TestKafkaConsumer_GreenScenario_PublicationDataMode(t *testing.T) {

--- a/internal/consuming/kafka_test.go
+++ b/internal/consuming/kafka_test.go
@@ -800,11 +800,13 @@ func runConsumptionIteration(b *testing.B, topic string, numMessages int, iterat
 	}
 
 	config := KafkaConfig{
-		Brokers:        []string{testKafkaBrokerURL},
-		Topics:         []string{topic},
-		ConsumerGroup:  uuid.New().String(),
-		MaxPollRecords: 1000,
-		FetchMaxBytes:  10 * 1024 * 1024, // 1 MB.
+		Brokers:               []string{testKafkaBrokerURL},
+		Topics:                []string{topic},
+		ConsumerGroup:         uuid.New().String(),
+		MaxPollRecords:        1000,
+		FetchMaxBytes:         10 * 1024 * 1024, // 1 MB.
+		FetchMaxWait:          configtypes.Duration(200 * time.Millisecond),
+		PartitionQueueMaxSize: 1000,
 	}
 
 	consumer, err := NewKafkaConsumer(

--- a/internal/consuming/kafka_test.go
+++ b/internal/consuming/kafka_test.go
@@ -803,7 +803,7 @@ func runConsumptionIteration(b *testing.B, topic string, numMessages int, iterat
 		Brokers:               []string{testKafkaBrokerURL},
 		Topics:                []string{topic},
 		ConsumerGroup:         uuid.New().String(),
-		MaxPollRecords:        1000,
+		MaxPollRecords:        100,
 		FetchMaxBytes:         10 * 1024 * 1024, // 1 MB.
 		FetchMaxWait:          configtypes.Duration(200 * time.Millisecond),
 		PartitionQueueMaxSize: 1000,

--- a/internal/consuming/kafka_test.go
+++ b/internal/consuming/kafka_test.go
@@ -804,7 +804,7 @@ func runConsumptionIteration(b *testing.B, topic string, numMessages int, iterat
 		Topics:                []string{topic},
 		ConsumerGroup:         uuid.New().String(),
 		MaxPollRecords:        100,
-		FetchMaxBytes:         10 * 1024 * 1024, // 1 MB.
+		FetchMaxBytes:         10 * 1024 * 1024, // 10 MB.
 		FetchMaxWait:          configtypes.Duration(200 * time.Millisecond),
 		PartitionQueueMaxSize: 1000,
 	}

--- a/internal/consuming/kafka_test.go
+++ b/internal/consuming/kafka_test.go
@@ -803,8 +803,8 @@ func runConsumptionIteration(b *testing.B, topic string, numMessages int, iterat
 		Brokers:        []string{testKafkaBrokerURL},
 		Topics:         []string{topic},
 		ConsumerGroup:  uuid.New().String(),
-		MaxPollRecords: 100,
-		FetchMaxBytes:  1 * 1024 * 1024, // 1 MB.
+		MaxPollRecords: 1000,
+		FetchMaxBytes:  10 * 1024 * 1024, // 1 MB.
 	}
 
 	consumer, err := NewKafkaConsumer(


### PR DESCRIPTION
## Proposed changes

This is a refactoring of Kafka consumer which aims to simplify the code and avoid SetOffsets call during poll loop.

We also tune fetch max wait time here to be 500ms instead of 5000ms since there is a chance that loaded partition may be paused until fetch returns (if no other partitions are active at this point - fetch blocks for up to 5 seconds).

With the changes made PR improves consumer throughput (according to added benchmark) in 3 times, having 30k msgs per seconds instead of 10k msgs per second (mostly due to fetch max wait time tuning).

New options:

* `fetch_max_wait` - duration, default 500ms
* `partition_queue_max_size` - int, default 1000
