### PR TITLE
Fix and improve redis mode logging

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.38.8
 	github.com/aws/aws-sdk-go-v2/service/sts v1.34.0
 	github.com/aws/smithy-go v1.22.4
-	github.com/centrifugal/centrifuge v0.36.2
+	github.com/centrifugal/centrifuge v0.36.3-0.20250713050025-7a42ce66691c
 	github.com/centrifugal/protocol v0.16.1
 	github.com/cristalhq/jwt/v5 v5.4.0
 	github.com/go-viper/mapstructure/v2 v2.3.0

--- a/go.sum
+++ b/go.sum
@@ -69,8 +69,8 @@ github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6r
 github.com/cenkalti/backoff/v5 v5.0.2 h1:rIfFVxEf1QsI7E1ZHfp/B4DF/6QBAUhmgkxc0H7Zss8=
 github.com/cenkalti/backoff/v5 v5.0.2/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/centrifugal/centrifuge v0.36.2 h1:MDq/oPolpYK5srz9QD6WicQFjX40/cUgMGY4lIpqcOk=
-github.com/centrifugal/centrifuge v0.36.2/go.mod h1:PFPw7lPhnOaZrOGnrZjgcfS5YpxEYAi9RxsOSCxflOw=
+github.com/centrifugal/centrifuge v0.36.3-0.20250713050025-7a42ce66691c h1:Hso7WmdviQb4fSteDS6GAvDMWu4UYegIKALN9H/uQHI=
+github.com/centrifugal/centrifuge v0.36.3-0.20250713050025-7a42ce66691c/go.mod h1:PFPw7lPhnOaZrOGnrZjgcfS5YpxEYAi9RxsOSCxflOw=
 github.com/centrifugal/protocol v0.16.1 h1:uj6RgPyVDypl24w1lmGEXJ/8rjMoTQ4AZkFC5PeEVlo=
 github.com/centrifugal/protocol v0.16.1/go.mod h1:Hcx0Xy/MhCT85Zno3umflh91oJ+FCKk9EPk/MINZhmQ=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -136,7 +136,7 @@ func Run(cmd *cobra.Command, configFile string) {
 		}
 	}
 
-	modes, err := configureEngines(node, cfgContainer)
+	err = configureEngines(node, cfgContainer)
 	if err != nil {
 		log.Fatal().Err(err).Msg("configure engines error")
 	}
@@ -216,13 +216,10 @@ func Run(cmd *cobra.Command, configFile string) {
 			Version:                build.Version,
 			EngineEnabled:          !cfg.Broker.Enabled || !cfg.PresenceManager.Enabled,
 			EngineType:             cfg.Engine.Type,
-			EngineMode:             modes.engineMode,
 			BrokerEnabled:          cfg.Broker.Enabled,
 			BrokerType:             cfg.Broker.Type,
-			BrokerMode:             modes.brokerMode,
 			PresenceManagerEnabled: cfg.PresenceManager.Enabled,
 			PresenceManagerType:    cfg.PresenceManager.Type,
-			PresenceManagerMode:    modes.presenceManagerMode,
 
 			Websocket:     !cfg.WebSocket.Disabled,
 			HTTPStream:    cfg.HTTPStream.Enabled,

--- a/internal/confighelpers/redis_test.go
+++ b/internal/confighelpers/redis_test.go
@@ -1,0 +1,46 @@
+package confighelpers
+
+import "testing"
+
+func TestMergeModes(t *testing.T) {
+	tests := []struct {
+		input    []string
+		expected string
+	}{
+		{
+			input:    []string{"cluster", "cluster", "standalone", "sentinel", "sentinel", "cluster"},
+			expected: "cluster-x2,standalone,sentinel-x2,cluster",
+		},
+		{
+			input:    []string{"standalone"},
+			expected: "standalone",
+		},
+		{
+			input:    []string{"sentinel", "sentinel", "sentinel"},
+			expected: "sentinel-x3",
+		},
+		{
+			input:    []string{"cluster", "standalone", "sentinel"},
+			expected: "cluster,standalone,sentinel",
+		},
+		{
+			input:    []string{},
+			expected: "",
+		},
+		{
+			input:    []string{"a", "a", "a", "b", "b", "c", "a"},
+			expected: "a-x3,b-x2,c,a",
+		},
+		{
+			input:    []string{"a", "b", "b", "b", "c", "c", "d", "d", "d", "d"},
+			expected: "a,b-x3,c-x2,d-x4",
+		},
+	}
+
+	for _, test := range tests {
+		got := mergeModes(test.input)
+		if got != test.expected {
+			t.Errorf("mergeModes(%v) = %q; want %q", test.input, got, test.expected)
+		}
+	}
+}

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -71,13 +71,10 @@ type Features struct {
 	// Engine or broker/presence manager usage.
 	EngineEnabled          bool
 	EngineType             string
-	EngineMode             string
 	BrokerEnabled          bool
 	BrokerType             string
-	BrokerMode             string
 	PresenceManagerEnabled bool
 	PresenceManagerType    string
-	PresenceManagerMode    string
 
 	// Transports.
 	Websocket     bool
@@ -334,34 +331,11 @@ func (s *Sender) prepareMetrics() ([]*metric, error) {
 	version := strings.Replace(s.features.Version, ".", "_", -1)
 	edition := strings.ToLower(s.features.Edition)
 
-	engineMode := s.features.EngineMode
-	if engineMode == "" {
-		engineMode = "default"
-	}
-	brokerMode := s.features.BrokerMode
-	if brokerMode == "" {
-		brokerMode = "default"
-	}
-	presenceManagerMode := s.features.PresenceManagerMode
-	if presenceManagerMode == "" {
-		presenceManagerMode = "default"
-	}
-
 	var metrics []*metric
 
 	metrics = append(metrics, createPoint("total"))
 	metrics = append(metrics, createPoint("version."+version+".edition."+edition))
 	metrics = append(metrics, createPoint("arch."+runtime.GOARCH+".os."+runtime.GOOS))
-
-	if s.features.EngineEnabled {
-		metrics = append(metrics, createPoint("engine."+s.features.EngineType+".mode."+engineMode))
-	}
-	if s.features.BrokerEnabled {
-		metrics = append(metrics, createPoint("broker."+s.features.BrokerType+".mode."+brokerMode))
-	}
-	if s.features.PresenceManagerEnabled {
-		metrics = append(metrics, createPoint("presence_manager."+s.features.PresenceManagerType+".mode."+presenceManagerMode))
-	}
 
 	if s.features.Websocket {
 		metrics = append(metrics, createPoint("transports_enabled.websocket"))


### PR DESCRIPTION
## Proposed changes

Relates #1008 

Now Redis mode should be logged correctly. Also, we now use a more detailed string for app-level sharding case which shows modes for all shards joined in a format like `engine_mode=sharded(2):cluster-x2` - which tells that app-level sharding is enabled with 2 shards in total and then each shard mode is described (joining consecutive same modes together). 
