### PR TITLE
Fix usage stats: report engine/broker/presence_manager types

### DIFF
--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -344,7 +344,7 @@ func (s *Sender) prepareMetrics() ([]*metric, error) {
 		metrics = append(metrics, createPoint("broker_type."+s.features.BrokerType))
 	}
 	if s.features.PresenceManagerEnabled {
-		metrics = append(metrics, createPoint("presence_manager."+s.features.PresenceManagerType))
+		metrics = append(metrics, createPoint("presence_manager_type."+s.features.PresenceManagerType))
 	}
 
 	if s.features.Websocket {


### PR DESCRIPTION
## Proposed changes

Fix usage stats engine/broker/presence_manager types mistakenly fully removed in the previous PR.
