### PR TITLE
Fix memory leak in Kafka backpressure mechanism

### DIFF
--- a/internal/cli/configdoc/schema.json
+++ b/internal/cli/configdoc/schema.json
@@ -7014,7 +7014,7 @@
             "level": 3,
             "type": "int",
             "default": "1000",
-            "comment": "PartitionQueueMaxSize is the maximum number of items in partition queue before pausing consuming from a partition.\nThe actual queue size may exceed this value on `max_poll_records`, so this acts more like a threshold.\nIf zero, pausing is done on every poll. If set, pausing only happens when queue size exceeds this threshold.",
+            "comment": "PartitionQueueMaxSize is the maximum number of items in partition queue before pausing consuming from a partition.\nThe actual queue size may exceed this value on `max_poll_records`, so this acts more like a threshold.\nIf -1, pausing is done on every poll. If set, pausing only happens when queue size exceeds this threshold.",
             "is_complex_type": false
           },
           {

--- a/internal/configtypes/types.go
+++ b/internal/configtypes/types.go
@@ -766,7 +766,7 @@ type KafkaConsumerConfig struct {
 	FetchReadUncommitted bool `mapstructure:"fetch_read_uncommitted" json:"fetch_read_uncommitted" envconfig:"fetch_read_uncommitted" default:"false" yaml:"fetch_read_uncommitted" toml:"fetch_read_uncommitted"`
 	// PartitionQueueMaxSize is the maximum number of items in partition queue before pausing consuming from a partition.
 	// The actual queue size may exceed this value on `max_poll_records`, so this acts more like a threshold.
-	// If zero, pausing is done on every poll. If set, pausing only happens when queue size exceeds this threshold.
+	// If -1, pausing is done on every poll. If set, pausing only happens when queue size exceeds this threshold.
 	PartitionQueueMaxSize int `mapstructure:"partition_queue_max_size" json:"partition_queue_max_size" envconfig:"partition_queue_max_size" default:"1000" yaml:"partition_queue_max_size" toml:"partition_queue_max_size"`
 
 	// TLS for the connection to Kafka.

--- a/internal/consuming/kafka.go
+++ b/internal/consuming/kafka.go
@@ -652,6 +652,7 @@ func (q *unboundedQueue) Pop() (kgo.FetchTopicPartition, bool) {
 	item := q.items[0]
 	q.items[0] = kgo.FetchTopicPartition{} // Clear the first item for faster GC.
 	q.items = q.items[1:]
+	q.numRecords -= len(item.Records)
 
 	return item, true
 }

--- a/internal/consuming/kafka.go
+++ b/internal/consuming/kafka.go
@@ -65,6 +65,11 @@ func NewKafkaConsumer(
 	if config.FetchMaxWait == 0 {
 		config.FetchMaxWait = configtypes.Duration(500 * time.Millisecond)
 	}
+	if config.PartitionQueueMaxSize == -1 {
+		config.PartitionQueueMaxSize = 0
+	} else if config.PartitionQueueMaxSize == 0 {
+		config.PartitionQueueMaxSize = 1000
+	}
 	consumer := &KafkaConsumer{
 		nodeID:     common.nodeID,
 		dispatcher: dispatcher,
@@ -268,7 +273,7 @@ func (c *KafkaConsumer) pollUntilFatal(ctx context.Context) error {
 				partitionsToPause := map[string][]int32{p.Topic: {p.Partition}}
 				if _, paused := pausedTopicPartitions[tp]; !paused {
 					// Only pause if queue threshold would be exceeded after adding records, or if threshold is 0 (always pause).
-					shouldPause := c.config.PartitionQueueMaxSize == 0 || consumer.queue.Len()+len(p.Records) >= c.config.PartitionQueueMaxSize
+					shouldPause := consumer.queue.NumRecords()+len(p.Records) >= c.config.PartitionQueueMaxSize
 					if shouldPause {
 						// Pause partition BEFORE submitting to queue to avoid race condition
 						// between pause and resume operations.
@@ -600,10 +605,11 @@ func (pc *partitionConsumer) consume() {
 
 // unboundedQueue implements an unbounded queue for FetchTopicPartition
 type unboundedQueue struct {
-	mu       sync.RWMutex
-	items    []kgo.FetchTopicPartition
-	notEmpty chan struct{}
-	closed   bool
+	mu         sync.RWMutex
+	items      []kgo.FetchTopicPartition
+	numRecords int
+	notEmpty   chan struct{}
+	closed     bool
 }
 
 func newUnboundedQueue() *unboundedQueue {
@@ -622,6 +628,7 @@ func (q *unboundedQueue) Push(item kgo.FetchTopicPartition) bool {
 	}
 
 	q.items = append(q.items, item)
+	q.numRecords += len(item.Records)
 
 	// Signal that queue is not empty.
 	select {
@@ -643,15 +650,16 @@ func (q *unboundedQueue) Pop() (kgo.FetchTopicPartition, bool) {
 	// We do not expect many items in the queue, so we can use a simple slice pop operation and
 	// not worry about memory being reserved for the underlying slice.
 	item := q.items[0]
+	q.items[0] = kgo.FetchTopicPartition{} // Clear the first item for faster GC.
 	q.items = q.items[1:]
 
 	return item, true
 }
 
-func (q *unboundedQueue) Len() int {
+func (q *unboundedQueue) NumRecords() int {
 	q.mu.RLock()
 	defer q.mu.RUnlock()
-	return len(q.items)
+	return q.numRecords
 }
 
 func (q *unboundedQueue) Close() {

--- a/internal/consuming/kafka_test.go
+++ b/internal/consuming/kafka_test.go
@@ -487,9 +487,10 @@ func TestKafkaConsumer_PausePartitions(t *testing.T) {
 	beforePauseCh := make(chan topicPartition)
 
 	config := KafkaConfig{
-		Brokers:       []string{testKafkaBrokerURL},
-		Topics:        []string{testKafkaTopic},
-		ConsumerGroup: uuid.New().String(),
+		Brokers:               []string{testKafkaBrokerURL},
+		Topics:                []string{testKafkaTopic},
+		ConsumerGroup:         uuid.New().String(),
+		PartitionQueueMaxSize: -1,
 	}
 
 	numCalls := 0


### PR DESCRIPTION
## Proposed changes

Fixes regression introduced in Centrifugo v6.2.3

Due to the fact we looked at number of items in queue instead of number of records memory usage could grow significantly since partitions were not paused much longer than required.
