### PR TITLE
WebTransport: make it work with debug middleware, suppress errors

### DIFF
--- a/internal/middleware/log.go
+++ b/internal/middleware/log.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/quic-go/quic-go/http3"
+
 	"github.com/rs/zerolog/log"
 )
 
@@ -54,6 +56,14 @@ func (lrw *statusResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 		return nil, nil, fmt.Errorf("ResponseWriter doesn't support Hijacker interface")
 	}
 	return hijacker.Hijack()
+}
+
+func (lrw *statusResponseWriter) Connection() *http3.Conn {
+	return lrw.ResponseWriter.(http3.Hijacker).Connection()
+}
+
+func (lrw *statusResponseWriter) HTTPStream() *http3.Stream {
+	return lrw.ResponseWriter.(http3.HTTPStreamer).HTTPStream()
 }
 
 // Flush implements http.Flusher.


### PR DESCRIPTION
## Proposed changes

A couple of fixes for WebTransport:

* at some point it stopped working when debug log level is used due to missing interface implementations in custom ResponseWriter
* suppress some errors which are not really interesting since happen in normal client closure cases. 
