### PR TITLE
Fix none log level using proper zerolog level

### DIFF
--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -26,7 +26,7 @@ const (
 )
 
 var logLevelMatches = map[string]zerolog.Level{
-	"NONE":  zerolog.NoLevel,
+	"NONE":  zerolog.Disabled,
 	"TRACE": zerolog.TraceLevel,
 	"DEBUG": zerolog.DebugLevel,
 	"INFO":  zerolog.InfoLevel,


### PR DESCRIPTION
## Proposed changes

`NoLevel` means no explicit level, while `Disabled` disables logging entirely.
