### PR TITLE
Fix flags priority: must override envs

### DIFF
--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -141,8 +141,10 @@ func Setup(cfg config.Config) (centrifuge.LogHandler, func()) {
 		}
 	}
 
+	levelFound := true
 	logLevel, ok := logLevelMatches[strings.ToUpper(cfg.Log.Level)]
 	if !ok {
+		levelFound = false
 		logLevel = zerolog.InfoLevel
 	}
 	zerolog.SetGlobalLevel(logLevel)
@@ -150,6 +152,10 @@ func Setup(cfg config.Config) (centrifuge.LogHandler, func()) {
 	if len(writers) > 0 {
 		mw := io.MultiWriter(writers...)
 		log.Logger = log.Output(mw)
+	}
+
+	if !levelFound {
+		log.Warn().Msgf("unknown log level %s, defaulting to INFO", cfg.Log.Level)
 	}
 
 	return newCentrifugeLogHandler().Handle, func() {


### PR DESCRIPTION
## Proposed changes

There was a regression in Centrifugo v6: command-line flags do not override env vars now. According to the [doc](https://centrifugal.dev/docs/server/configuration#configuration-sources) they should:

```
Centrifugo can be configured in several ways:

* using command-line flags (highest priority – flags override everything)
* environment variables (medium priority – env vars override config file options)
* configuration file (lowest priority).
```

This PR fixes it by skipping processing of set flags.

This changes behavior, but after some consideration seems a better step since we follow documented behavior, it worked like this in previous Centrifugo versions, more natural and generally should not affect production setups which rarely using cmd-line flags.

 
