### PR TITLE
cf_connect for unidirectional WebSocket, tests for uni transports

### DIFF
--- a/internal/unihttpstream/handler_test.go
+++ b/internal/unihttpstream/handler_test.go
@@ -1,0 +1,196 @@
+package unihttpstream
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/centrifugal/centrifugo/v6/internal/configtypes"
+	"github.com/centrifugal/centrifugo/v6/internal/middleware"
+
+	"github.com/centrifugal/centrifuge"
+	"github.com/centrifugal/protocol"
+	"github.com/stretchr/testify/require"
+)
+
+func ensureHTTPStreamMessageHasClient(t *testing.T, data string) {
+	t.Log(data)
+	var reply protocol.Reply
+	err := json.Unmarshal([]byte(data), &reply)
+	require.NoError(t, err)
+	require.NotEmpty(t, reply.Connect.Client)
+}
+
+func readHTTPStreamMessage(reader *bufio.Reader) (string, error) {
+	line, err := reader.ReadString('\n')
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(line), nil
+}
+
+func TestUnidirectionalHTTPStream(t *testing.T) {
+	t.Parallel()
+	node, err := centrifuge.New(centrifuge.Config{})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = node.Shutdown(context.Background()) })
+
+	node.OnConnecting(func(ctx context.Context, event centrifuge.ConnectEvent) (centrifuge.ConnectReply, error) {
+		return centrifuge.ConnectReply{
+			Credentials: &centrifuge.Credentials{},
+		}, nil
+	})
+
+	config := configtypes.UniHTTPStream{
+		MaxRequestBodySize: 65536,
+	}
+
+	pingPong := centrifuge.PingPongConfig{
+		PingInterval: 5 * time.Second,
+		PongTimeout:  1 * time.Second,
+	}
+
+	handler := NewHandler(node, config, pingPong)
+
+	server := httptest.NewServer(middleware.LogRequest(handler))
+	t.Cleanup(func() { server.Close() })
+
+	t.Run("successful connection with POST body", func(t *testing.T) {
+		connectReq := `{}`
+		resp, err := http.Post(server.URL, "application/json", strings.NewReader(connectReq))
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		require.Equal(t, "text/plain; charset=utf-8", resp.Header.Get("Content-Type"))
+
+		reader := bufio.NewReader(resp.Body)
+		message, err := readHTTPStreamMessage(reader)
+		require.NoError(t, err)
+		ensureHTTPStreamMessageHasClient(t, message)
+	})
+
+	t.Run("invalid connect request in POST body", func(t *testing.T) {
+		resp, err := http.Post(server.URL, "application/json", strings.NewReader("invalid-json"))
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+
+		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	})
+
+	t.Run("empty POST body", func(t *testing.T) {
+		resp, err := http.Post(server.URL, "application/json", strings.NewReader(""))
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+
+		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	})
+
+	t.Run("GET method not allowed", func(t *testing.T) {
+		resp, err := http.Get(server.URL)
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+
+		require.Equal(t, http.StatusMethodNotAllowed, resp.StatusCode)
+	})
+
+	t.Run("PUT method not allowed", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodPut, server.URL, strings.NewReader("{}"))
+		require.NoError(t, err)
+
+		client := &http.Client{}
+		resp, err := client.Do(req)
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+
+		require.Equal(t, http.StatusMethodNotAllowed, resp.StatusCode)
+	})
+
+	t.Run("OPTIONS method", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodOptions, server.URL, nil)
+		require.NoError(t, err)
+
+		client := &http.Client{}
+		resp, err := client.Do(req)
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+
+		require.Equal(t, http.StatusNoContent, resp.StatusCode)
+		require.Equal(t, "300", resp.Header.Get("Access-Control-Max-Age"))
+		require.Equal(t, "POST, OPTIONS", resp.Header.Get("Access-Control-Allow-Methods"))
+	})
+
+	t.Run("large request body", func(t *testing.T) {
+		// Create a request body larger than typical limits
+		largeBody := strings.Repeat("a", 100000)
+		connectReq := `{"data":"` + largeBody + `"}`
+
+		resp, err := http.Post(server.URL, "application/json", strings.NewReader(connectReq))
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+
+		// Should either work or return an appropriate error status
+		if resp.StatusCode != http.StatusOK {
+			require.True(t, resp.StatusCode == http.StatusBadRequest || resp.StatusCode == http.StatusRequestEntityTooLarge)
+		}
+	})
+
+	t.Run("connection timeout", func(t *testing.T) {
+		t.Parallel()
+		client := &http.Client{
+			Timeout: 1 * time.Second,
+		}
+
+		resp, err := client.Post(server.URL, "application/json", strings.NewReader("{}"))
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		// Try to read but expect timeout
+		reader := bufio.NewReader(resp.Body)
+		_, err = readHTTPStreamMessage(reader)
+		// This may or may not error depending on timing, but connection should work initially
+	})
+
+	t.Run("ping cycle", func(t *testing.T) {
+		t.Parallel()
+		resp, err := http.Post(server.URL, "application/json", strings.NewReader("{}"))
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		reader := bufio.NewReader(resp.Body)
+
+		// Read connect response
+		message, err := readHTTPStreamMessage(reader)
+		require.NoError(t, err)
+		ensureHTTPStreamMessageHasClient(t, message)
+
+		for {
+			message, err = readHTTPStreamMessage(reader)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if strings.TrimSpace(message) == "{}" {
+				t.Logf("centrifugal protocol ping received: %s", message)
+				return
+			}
+		}
+	})
+
+	t.Run("malformed JSON in body", func(t *testing.T) {
+		malformedJSON := `{"incomplete": json`
+		resp, err := http.Post(server.URL, "application/json", strings.NewReader(malformedJSON))
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+
+		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	})
+}

--- a/internal/unihttpstream/handler_test.go
+++ b/internal/unihttpstream/handler_test.go
@@ -140,24 +140,6 @@ func TestUnidirectionalHTTPStream(t *testing.T) {
 		}
 	})
 
-	t.Run("connection timeout", func(t *testing.T) {
-		t.Parallel()
-		client := &http.Client{
-			Timeout: 1 * time.Second,
-		}
-
-		resp, err := client.Post(server.URL, "application/json", strings.NewReader("{}"))
-		require.NoError(t, err)
-		defer func() { _ = resp.Body.Close() }()
-
-		require.Equal(t, http.StatusOK, resp.StatusCode)
-
-		// Try to read but expect timeout
-		reader := bufio.NewReader(resp.Body)
-		_, err = readHTTPStreamMessage(reader)
-		// This may or may not error depending on timing, but connection should work initially
-	})
-
 	t.Run("ping cycle", func(t *testing.T) {
 		t.Parallel()
 		resp, err := http.Post(server.URL, "application/json", strings.NewReader("{}"))

--- a/internal/unisse/handler.go
+++ b/internal/unisse/handler.go
@@ -49,6 +49,7 @@ func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			_, err := json.Parse(convert.StringToBytes(connectRequestString), &req, json.ZeroCopy)
 			if err != nil {
 				log.Info().Err(err).Str("transport", transportName).Msg("error unmarshalling connect request")
+				w.WriteHeader(http.StatusBadRequest)
 				return
 			}
 		} else {

--- a/internal/unisse/handler_test.go
+++ b/internal/unisse/handler_test.go
@@ -1,0 +1,189 @@
+package unisse
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/centrifugal/centrifugo/v6/internal/configtypes"
+	"github.com/centrifugal/centrifugo/v6/internal/middleware"
+
+	"github.com/centrifugal/centrifuge"
+	"github.com/centrifugal/protocol"
+	"github.com/stretchr/testify/require"
+)
+
+func ensureSSEMessageHasClient(t *testing.T, data string) {
+	t.Log(data)
+	// SSE messages come in the format "data: {...}\n\n".
+	if !strings.HasPrefix(data, "data: ") {
+		t.Fatalf("Expected SSE message to start with 'data: ', got: %s (len: %d)", data, len(data))
+	}
+	jsonData := strings.TrimPrefix(data, "data: ")
+	jsonData = strings.TrimSpace(jsonData)
+
+	var reply protocol.Reply
+	err := json.Unmarshal([]byte(jsonData), &reply)
+	require.NoError(t, err)
+	require.NotEmpty(t, reply.Connect.Client)
+}
+
+func readSSEMessage(reader *bufio.Reader) (string, error) {
+	var lines []string
+	for {
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			return "", err
+		}
+		line = strings.TrimSpace(line)
+		if line == "" {
+			// Empty line marks end of SSE message
+			if len(lines) > 0 {
+				break
+			}
+			// Skip initial empty lines (like the \r\n at the beginning)
+			continue
+		}
+		lines = append(lines, line)
+	}
+	return strings.Join(lines, "\n"), nil
+}
+
+func TestUnidirectionalSSE(t *testing.T) {
+	t.Parallel()
+	node, err := centrifuge.New(centrifuge.Config{})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = node.Shutdown(context.Background()) })
+
+	node.OnConnecting(func(ctx context.Context, event centrifuge.ConnectEvent) (centrifuge.ConnectReply, error) {
+		return centrifuge.ConnectReply{
+			Credentials: &centrifuge.Credentials{},
+		}, nil
+	})
+
+	config := configtypes.UniSSE{
+		MaxRequestBodySize: 65536,
+	}
+
+	pingPong := centrifuge.PingPongConfig{
+		PingInterval: 5 * time.Second,
+		PongTimeout:  1 * time.Second,
+	}
+
+	handler := NewHandler(node, config, pingPong)
+
+	server := httptest.NewServer(middleware.LogRequest(handler))
+	t.Cleanup(func() { server.Close() })
+
+	t.Run("successful connection with URL params", func(t *testing.T) {
+		connectReq := `{}`
+		params := url.Values{}
+		params.Set(connectUrlParam, connectReq)
+
+		resp, err := http.Get(server.URL + "?" + params.Encode())
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		require.Equal(t, "text/event-stream; charset=utf-8", resp.Header.Get("Content-Type"))
+		require.Contains(t, resp.Header.Get("Cache-Control"), "no-cache")
+
+		reader := bufio.NewReader(resp.Body)
+		message, err := readSSEMessage(reader)
+		require.NoError(t, err)
+		ensureSSEMessageHasClient(t, message)
+	})
+
+	t.Run("successful connection with POST body", func(t *testing.T) {
+		connectReq := `{}`
+		resp, err := http.Post(server.URL, "application/json", strings.NewReader(connectReq))
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		require.Equal(t, "text/event-stream; charset=utf-8", resp.Header.Get("Content-Type"))
+
+		reader := bufio.NewReader(resp.Body)
+		message, err := readSSEMessage(reader)
+		require.NoError(t, err)
+		ensureSSEMessageHasClient(t, message)
+	})
+
+	t.Run("invalid connect request in URL params", func(t *testing.T) {
+		params := url.Values{}
+		params.Set(connectUrlParam, "invalid-json")
+
+		resp, err := http.Get(server.URL + "?" + params.Encode())
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+
+		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	})
+
+	t.Run("invalid connect request in POST body", func(t *testing.T) {
+		resp, err := http.Post(server.URL, "application/json", strings.NewReader("invalid-json"))
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+
+		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	})
+
+	t.Run("unsupported method", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodPut, server.URL, nil)
+		require.NoError(t, err)
+
+		client := &http.Client{}
+		resp, err := client.Do(req)
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+
+		require.Equal(t, http.StatusMethodNotAllowed, resp.StatusCode)
+	})
+
+	t.Run("connect request without parameters", func(t *testing.T) {
+		resp, err := http.Get(server.URL)
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		require.Equal(t, "text/event-stream; charset=utf-8", resp.Header.Get("Content-Type"))
+
+		reader := bufio.NewReader(resp.Body)
+		message, err := readSSEMessage(reader)
+		require.NoError(t, err)
+		ensureSSEMessageHasClient(t, message)
+	})
+
+	t.Run("ping cycle", func(t *testing.T) {
+		t.Parallel()
+		resp, err := http.Get(server.URL)
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		reader := bufio.NewReader(resp.Body)
+
+		// Read connect response
+		message, err := readSSEMessage(reader)
+		require.NoError(t, err)
+		ensureSSEMessageHasClient(t, message)
+
+		for {
+			message, err := readSSEMessage(reader)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if strings.Contains(message, "data: {}") {
+				t.Logf("centrifugal protocol ping received: %s", message)
+				return
+			}
+		}
+	})
+}

--- a/internal/uniws/config.go
+++ b/internal/uniws/config.go
@@ -13,6 +13,7 @@ import (
 // Defaults.
 const (
 	DefaultWebsocketPingInterval     = 25 * time.Second
+	DefaultWebsocketPongTimeout      = 10 * time.Second
 	DefaultWebsocketWriteTimeout     = 1 * time.Second
 	DefaultWebsocketMessageSizeLimit = 65536 // 64KB
 )

--- a/internal/uniws/handler.go
+++ b/internal/uniws/handler.go
@@ -30,10 +30,6 @@ type Handler struct {
 // The value should be a properly encoded JSON object representing protocol.ConnectRequest.
 const connectUrlParam = "cf_connect"
 
-// defaultConnectWait is the default time to wait for a connect request from the client.
-// It matches centrifuge.Config.ClientStaleCloseDelay.
-const defaultConnectWait = 15 * time.Second
-
 var writeBufferPool = &sync.Pool{}
 
 // NewHandler creates new Handler.
@@ -147,7 +143,6 @@ func (s *Handler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 		}
 
 		if req == nil {
-			_ = conn.SetReadDeadline(time.Now().Add(defaultConnectWait))
 			_, data, err := conn.ReadMessage()
 			if err != nil {
 				return
@@ -157,7 +152,6 @@ func (s *Handler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 				log.Info().Err(err).Str("transport", transportName).Msg("error unmarshalling connect request")
 				return
 			}
-			_ = conn.SetReadDeadline(time.Time{})
 		}
 
 		if pingInterval > 0 {

--- a/internal/uniws/handler.go
+++ b/internal/uniws/handler.go
@@ -30,7 +30,9 @@ type Handler struct {
 // The value should be a properly encoded JSON object representing protocol.ConnectRequest.
 const connectUrlParam = "cf_connect"
 
-const defaultConnectWait = 5 * time.Second
+// defaultConnectWait is the default time to wait for a connect request from the client.
+// It matches centrifuge.Config.ClientStaleCloseDelay.
+const defaultConnectWait = 15 * time.Second
 
 var writeBufferPool = &sync.Pool{}
 

--- a/internal/uniws/handler_test.go
+++ b/internal/uniws/handler_test.go
@@ -1,0 +1,188 @@
+package uniws
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/centrifugal/centrifugo/v6/internal/configtypes"
+	"github.com/centrifugal/centrifugo/v6/internal/middleware"
+	"github.com/centrifugal/centrifugo/v6/internal/websocket"
+
+	"github.com/centrifugal/centrifuge"
+	"github.com/centrifugal/protocol"
+	"github.com/stretchr/testify/require"
+)
+
+func ensureMessageHasClient(t *testing.T, data []byte) {
+	t.Log(string(data))
+	var reply protocol.Reply
+	err := json.Unmarshal(data, &reply)
+	require.NoError(t, err)
+	require.NotEmpty(t, reply.Connect.Client)
+}
+
+func TestUnidirectionalWebSocket(t *testing.T) {
+	t.Parallel()
+	node, err := centrifuge.New(centrifuge.Config{})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = node.Shutdown(context.Background()) })
+
+	node.OnConnecting(func(ctx context.Context, event centrifuge.ConnectEvent) (centrifuge.ConnectReply, error) {
+		return centrifuge.ConnectReply{
+			Credentials: &centrifuge.Credentials{},
+		}, nil
+	})
+
+	config := configtypes.UniWebSocket{
+		ReadBufferSize:   1024,
+		WriteBufferSize:  1024,
+		WriteTimeout:     configtypes.Duration(time.Second),
+		MessageSizeLimit: 65536,
+	}
+
+	pingPong := centrifuge.PingPongConfig{
+		PingInterval: 5 * time.Second,
+		PongTimeout:  1 * time.Second,
+	}
+
+	handler := NewHandler(node, config, func(r *http.Request) bool {
+		t.Logf("Checking origin: %s", r.Header.Get("Origin"))
+		return r.Header.Get("Origin") == "" || r.Header.Get("Origin") == "https://example.com"
+	}, pingPong)
+
+	server := httptest.NewServer(middleware.LogRequest(handler))
+	t.Cleanup(func() { server.Close() })
+
+	waitServer := func() {
+		t.Helper()
+		// Wait for server to start.
+		for {
+			t.Logf("Waiting for server to start: %s", server.URL)
+			resp, err := http.Get(server.URL)
+			if err != nil {
+				time.Sleep(100 * time.Millisecond)
+				continue
+			}
+			_ = resp.Body.Close()
+			break
+		}
+	}
+	waitServer()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+
+	t.Run("successful upgrade", func(t *testing.T) {
+		dialer := websocket.Dialer{}
+		conn, _, _, err := dialer.Dial(wsURL, http.Header{"Origin": []string{"https://example.com"}})
+		require.NoError(t, err)
+		defer func() { _ = conn.Close() }()
+
+		connectMsg := `{}`
+		err = conn.WriteMessage(websocket.TextMessage, []byte(connectMsg))
+		require.NoError(t, err)
+
+		_, data, err := conn.ReadMessage()
+		require.NoError(t, err)
+		ensureMessageHasClient(t, data)
+	})
+
+	t.Run("invalid connect request", func(t *testing.T) {
+		dialer := websocket.Dialer{}
+		conn, _, _, err := dialer.Dial(wsURL, http.Header{"Origin": []string{"https://example.com"}})
+		require.NoError(t, err)
+		defer func() { _ = conn.Close() }()
+
+		connectMsg := `invalid`
+		err = conn.WriteMessage(websocket.TextMessage, []byte(connectMsg))
+		require.NoError(t, err)
+
+		_, _, err = conn.ReadMessage()
+		require.Error(t, err)
+	})
+
+	t.Run("bad origin", func(t *testing.T) {
+		dialer := websocket.Dialer{}
+		_, _, _, err := dialer.Dial(wsURL, http.Header{"Origin": []string{"https://evil.com"}})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "bad handshake", err.Error())
+	})
+
+	t.Run("connect request in URL params", func(t *testing.T) {
+		connectReq := `{}`
+		params := url.Values{}
+		params.Set(connectUrlParam, connectReq)
+
+		dialer := websocket.Dialer{}
+		conn, _, _, err := dialer.Dial(wsURL+"?"+params.Encode(), nil)
+		require.NoError(t, err)
+		defer func() { _ = conn.Close() }()
+
+		_, data, err := conn.ReadMessage()
+		require.NoError(t, err)
+		ensureMessageHasClient(t, data)
+	})
+
+	t.Run("invalid connect request in URL params", func(t *testing.T) {
+		params := url.Values{}
+		params.Set(connectUrlParam, "invalid-json")
+
+		dialer := websocket.Dialer{}
+		_, _, _, err := dialer.Dial(wsURL+"?"+params.Encode(), nil)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "bad handshake", err.Error())
+	})
+
+	t.Run("connect request timeout", func(t *testing.T) {
+		t.Parallel()
+		dialer := websocket.Dialer{
+			HandshakeTimeout: 1 * time.Second,
+		}
+		conn, _, _, err := dialer.Dial(wsURL, nil)
+		require.NoError(t, err)
+		defer func() { _ = conn.Close() }()
+
+		err = conn.SetReadDeadline(time.Now().Add(10 * time.Second))
+		require.NoError(t, err)
+		_, _, err = conn.ReadMessage()
+		require.Error(t, err)
+	})
+
+	t.Run("ping pong cycle", func(t *testing.T) {
+		t.Parallel()
+		dialer := websocket.Dialer{}
+		conn, _, _, err := dialer.Dial(wsURL, nil)
+		require.NoError(t, err)
+		defer func() { _ = conn.Close() }()
+
+		err = conn.WriteMessage(websocket.TextMessage, []byte(`{}`))
+		require.NoError(t, err)
+
+		pingReceived := false
+		conn.SetPingHandler(func(appData []byte) error {
+			pingReceived = true
+			t.Log("websocket frame ping received")
+			return conn.WriteMessage(websocket.PongMessage, appData)
+		})
+
+		err = conn.SetReadDeadline(time.Now().Add(10 * time.Second))
+		require.NoError(t, err)
+
+		for {
+			_, data, err := conn.ReadMessage()
+			if err != nil {
+				break
+			}
+			if string(data) == `{}` {
+				t.Logf("centrifugal protocol ping received: %s", string(data))
+			}
+		}
+
+		require.True(t, pingReceived, "Expected to receive ping message")
+	})
+}


### PR DESCRIPTION
This PR improves Centrifugo in the following ways:

* Support `cf_connect` URL param for unidirectional WebSocket, if set – there is no need to send the first connect message over WebSocket. This is similar to the existing `cf_connect` parameter [in uni SSE](https://centrifugal.dev/docs/transports/uni_sse#send-connect-request). The value is a URL-encoded JSON string which represents `ConnectRequest` object.
* Use protocol type for decoding `ConnectRequest` in uni ws case similar to uni sse and uni http stream, slightly reduces allocations
* Add tests for uni websocket, uni SSE, uni HTTP stream implementations

Relates #1032 

Example of using `cf_connect` (with `--client.insecure` flag on server side for demo purposes):

```
❯ wscat --connect "ws://localhost:8000/connection/uni_websocket?cf_connect={}"
Connected (press CTRL+C to quit)
< {"connect":{"client":"c54130bc-de26-4db5-b0de-845f56651b94","version":"0.0.0 OSS","ping":25,"session":"5e574282-06f4-44b8-a631-50069475c1c7"}}
< {}
< {}
```