### PR TITLE
Closing handshake for unidirectional websocket

### DIFF
--- a/internal/configtypes/types.go
+++ b/internal/configtypes/types.go
@@ -121,7 +121,15 @@ type UniWebSocket struct {
 	WriteBufferSize    int      `mapstructure:"write_buffer_size" json:"write_buffer_size" envconfig:"write_buffer_size" yaml:"write_buffer_size" toml:"write_buffer_size"`
 	WriteTimeout       Duration `mapstructure:"write_timeout" json:"write_timeout" envconfig:"write_timeout" default:"1000ms" yaml:"write_timeout" toml:"write_timeout"`
 	MessageSizeLimit   int      `mapstructure:"message_size_limit" json:"message_size_limit" envconfig:"message_size_limit" default:"65536" yaml:"message_size_limit" toml:"message_size_limit"`
-
+	// DisableClosingHandshake disables WebSocket closing handshake. This restores the behavior prior to
+	// Centrifugo v6.5.1 where server never sent a close frame on connection close initiated by server.
+	// Normally closing handshake is recommended to be performed according to WebSocket protocol RFC,
+	// so this option is useful only in some specific cases when you need to restore the previous behavior.
+	DisableClosingHandshake bool `mapstructure:"disable_closing_handshake" json:"disable_closing_handshake" envconfig:"disable_closing_handshake" yaml:"disable_closing_handshake" toml:"disable_closing_handshake"`
+	// DisableDisconnectPush disables sending disconnect push messages to clients. It's sent by default to make
+	// unidirectional transports similar, but since uni_websocket transport also sends close frame to the client
+	// with the same code/reason – some users may want to disable disconnect push to avoid ambiguity.
+	DisableDisconnectPush bool `mapstructure:"disable_disconnect_push" json:"disable_disconnect_push" envconfig:"disable_disconnect_push" yaml:"disable_disconnect_push" toml:"disable_disconnect_push"`
 	// JoinPushMessages when enabled allow uni_websocket transport to join messages together into
 	// one frame using Centrifugal client protocol delimiters: new line for JSON protocol and
 	// length-prefixed format for Protobuf protocol. This can be useful to reduce system call

--- a/internal/timers/pool.go
+++ b/internal/timers/pool.go
@@ -1,0 +1,34 @@
+package timers
+
+import (
+	"sync"
+	"time"
+)
+
+var timerPool sync.Pool
+
+// AcquireTimer from pool.
+func AcquireTimer(d time.Duration) *time.Timer {
+	v := timerPool.Get()
+	if v == nil {
+		return time.NewTimer(d)
+	}
+	tm := v.(*time.Timer)
+	if tm.Reset(d) {
+		panic("Received an active timer from the pool!")
+	}
+	return tm
+}
+
+// ReleaseTimer to pool.
+func ReleaseTimer(tm *time.Timer) {
+	if !tm.Stop() {
+		// Collect possibly added time from the channel
+		// If timer has been stopped and nobody collected its value.
+		select {
+		case <-tm.C:
+		default:
+		}
+	}
+	timerPool.Put(tm)
+}

--- a/internal/timers/pool_test.go
+++ b/internal/timers/pool_test.go
@@ -1,0 +1,99 @@
+package timers
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// waitTimer waits for a timer to fire or a timeout, returning true if fired.
+func waitTimer(tm *time.Timer, timeout time.Duration) bool {
+	select {
+	case <-tm.C:
+		return true
+	case <-time.After(timeout):
+		return false
+	}
+}
+
+func TestTimersReliable(t *testing.T) {
+	t.Run("acquire timer does not fire immediately", func(t *testing.T) {
+		tm := AcquireTimer(50 * time.Millisecond)
+		require.NotNil(t, tm)
+
+		fired := waitTimer(tm, 10*time.Millisecond)
+		require.False(t, fired, "timer should not have fired immediately")
+
+		ReleaseTimer(tm)
+	})
+
+	t.Run("timer fires after duration", func(t *testing.T) {
+		tm := AcquireTimer(20 * time.Millisecond)
+		require.NotNil(t, tm)
+
+		fired := waitTimer(tm, 100*time.Millisecond)
+		require.True(t, fired, "timer did not fire as expected")
+
+		ReleaseTimer(tm)
+	})
+
+	t.Run("release stops timer", func(t *testing.T) {
+		tm := AcquireTimer(50 * time.Millisecond)
+		require.NotNil(t, tm)
+
+		ReleaseTimer(tm)
+
+		fired := waitTimer(tm, 60*time.Millisecond)
+		require.False(t, fired, "timer should have been stopped")
+	})
+
+	t.Run("reuse timer from pool", func(t *testing.T) {
+		// Acquire and release a timer to populate the pool
+		tm1 := AcquireTimer(50 * time.Millisecond)
+		ReleaseTimer(tm1)
+
+		// Acquire again from pool
+		tm2 := AcquireTimer(20 * time.Millisecond)
+		require.NotNil(t, tm2)
+
+		fired := waitTimer(tm2, 100*time.Millisecond)
+		require.True(t, fired, "reused timer should have fired")
+
+		ReleaseTimer(tm2)
+	})
+
+	t.Run("concurrent acquire and release", func(t *testing.T) {
+		var wg sync.WaitGroup
+		numGoroutines := 50
+
+		wg.Add(numGoroutines)
+		for i := 0; i < numGoroutines; i++ {
+			go func() {
+				defer wg.Done()
+				tm := AcquireTimer(10 * time.Millisecond)
+				// deterministically wait for timer to fire or grace period
+				waitTimer(tm, 20*time.Millisecond)
+				ReleaseTimer(tm)
+			}()
+		}
+
+		wg.Wait()
+	})
+
+	t.Run("release timer that already fired", func(t *testing.T) {
+		tm := AcquireTimer(10 * time.Millisecond)
+		require.NotNil(t, tm)
+
+		fired := waitTimer(tm, 50*time.Millisecond)
+		require.True(t, fired, "timer should have fired")
+
+		ReleaseTimer(tm)
+
+		// Acquire again to ensure pool is working
+		tm2 := AcquireTimer(20 * time.Millisecond)
+		require.NotNil(t, tm2)
+		ReleaseTimer(tm2)
+	})
+}


### PR DESCRIPTION
Relates #1069 

Unidirectional WebSocket now uses closing handshake for server-initiated disconnects.

Two new options for `uni_websocket` section:

* `disable_closing_handshake` disables WebSocket closing handshake. This restores the behavior prior to Centrifugo v6.5.1 where server never sent a close frame on connection close initiated by server. Normally closing handshake is recommended to be performed according to WebSocket protocol RFC, so this option is useful only in some specific cases when you need to restore the previous behavior.
* `disable_disconnect_push` disables sending disconnect push messages to clients. It's sent by default to make unidirectional transports similar, but since uni_websocket transport also sends close frame to the client with the same code/reason – some users may want to disable disconnect push to avoid ambiguity.