### PR TITLE
Set LocalStack image version to 4.14

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       - "8085:8085"
 
   aws-localstack:
-    image: localstack/localstack
+    image: localstack/localstack:4.14
     container_name: localstack
     ports:
       - "4566:4566"   # Edge port for all services.


### PR DESCRIPTION
To use version without required account for now.

See https://blog.localstack.cloud/the-road-ahead-for-localstack