### PR TITLE
feat(consuming): Kafka MSK IAM support for STS AssumeRole

### DIFF
--- a/internal/cli/configdoc/schema.json
+++ b/internal/cli/configdoc/schema.json
@@ -7330,6 +7330,16 @@
             "is_complex_type": false
           },
           {
+            "field": "consumers[].kafka.assume_role_arn",
+            "name": "assume_role_arn",
+            "go_name": "AssumeRoleARN",
+            "level": 3,
+            "type": "string",
+            "default": "",
+            "comment": "AssumeRoleARN, when set with sasl_mechanism aws-msk-iam, uses AWS STS AssumeRole to obtain\ntemporary credentials for MSK IAM authentication (e.g. cross-account MSK). Base credentials\nand region come from the default AWS SDK chain (AWS_REGION, instance metadata, etc.).\nWhen set, sasl_user and sasl_password are ignored. When empty, static keys from sasl_user/sasl_password are used.",
+            "is_complex_type": false
+          },
+          {
             "field": "consumers[].kafka.instance_id",
             "name": "instance_id",
             "go_name": "InstanceID",

--- a/internal/configtypes/kafka_consumer_test.go
+++ b/internal/configtypes/kafka_consumer_test.go
@@ -1,0 +1,39 @@
+package configtypes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestKafkaConsumerConfigValidate_AssumeRoleARN(t *testing.T) {
+	base := KafkaConsumerConfig{
+		Brokers:       []string{"localhost:9092"},
+		Topics:        []string{"t"},
+		ConsumerGroup: "g",
+	}
+
+	t.Run("assume_role_arn with aws-msk-iam is valid", func(t *testing.T) {
+		c := base
+		c.SASLMechanism = "aws-msk-iam"
+		c.AssumeRoleARN = "arn:aws:iam::123456789012:role/MSKAccess"
+		require.NoError(t, c.Validate())
+	})
+
+	t.Run("assume_role_arn without aws-msk-iam is invalid", func(t *testing.T) {
+		c := base
+		c.SASLMechanism = "plain"
+		c.AssumeRoleARN = "arn:aws:iam::123456789012:role/MSKAccess"
+		err := c.Validate()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "assume_role_arn requires sasl_mechanism aws-msk-iam")
+	})
+
+	t.Run("assume_role_arn with empty sasl_mechanism is invalid", func(t *testing.T) {
+		c := base
+		c.AssumeRoleARN = "arn:aws:iam::123456789012:role/MSKAccess"
+		err := c.Validate()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "assume_role_arn requires sasl_mechanism aws-msk-iam")
+	})
+}

--- a/internal/configtypes/types.go
+++ b/internal/configtypes/types.go
@@ -51,16 +51,16 @@ type Log struct {
 
 // Token common configuration.
 type Token struct {
-	HMACSecretKey                   string `mapstructure:"hmac_secret_key" json:"hmac_secret_key" envconfig:"hmac_secret_key" yaml:"hmac_secret_key" toml:"hmac_secret_key"`
-	HMACPreviousSecretKey           string `mapstructure:"hmac_previous_secret_key" json:"hmac_previous_secret_key" envconfig:"hmac_previous_secret_key" yaml:"hmac_previous_secret_key" toml:"hmac_previous_secret_key"`
-	HMACPreviousSecretKeyValidUntil int64  `mapstructure:"hmac_previous_secret_key_valid_until" json:"hmac_previous_secret_key_valid_until" envconfig:"hmac_previous_secret_key_valid_until" yaml:"hmac_previous_secret_key_valid_until" toml:"hmac_previous_secret_key_valid_until"`
-	RSAPublicKey                    string `mapstructure:"rsa_public_key" json:"rsa_public_key" envconfig:"rsa_public_key" yaml:"rsa_public_key" toml:"rsa_public_key"`
-	ECDSAPublicKey     string `mapstructure:"ecdsa_public_key" json:"ecdsa_public_key" envconfig:"ecdsa_public_key" yaml:"ecdsa_public_key" toml:"ecdsa_public_key"`
-	JWKSPublicEndpoint string `mapstructure:"jwks_public_endpoint" json:"jwks_public_endpoint" envconfig:"jwks_public_endpoint" yaml:"jwks_public_endpoint" toml:"jwks_public_endpoint"`
-	Audience           string `mapstructure:"audience" json:"audience" envconfig:"audience" yaml:"audience" toml:"audience"`
-	AudienceRegex      string `mapstructure:"audience_regex" json:"audience_regex" envconfig:"audience_regex" yaml:"audience_regex" toml:"audience_regex"`
-	Issuer             string `mapstructure:"issuer" json:"issuer" envconfig:"issuer" yaml:"issuer" toml:"issuer"`
-	IssuerRegex        string `mapstructure:"issuer_regex" json:"issuer_regex" envconfig:"issuer_regex" yaml:"issuer_regex" toml:"issuer_regex"`
+	HMACSecretKey                       string `mapstructure:"hmac_secret_key" json:"hmac_secret_key" envconfig:"hmac_secret_key" yaml:"hmac_secret_key" toml:"hmac_secret_key"`
+	HMACPreviousSecretKey               string `mapstructure:"hmac_previous_secret_key" json:"hmac_previous_secret_key" envconfig:"hmac_previous_secret_key" yaml:"hmac_previous_secret_key" toml:"hmac_previous_secret_key"`
+	HMACPreviousSecretKeyValidUntil     int64  `mapstructure:"hmac_previous_secret_key_valid_until" json:"hmac_previous_secret_key_valid_until" envconfig:"hmac_previous_secret_key_valid_until" yaml:"hmac_previous_secret_key_valid_until" toml:"hmac_previous_secret_key_valid_until"`
+	RSAPublicKey                        string `mapstructure:"rsa_public_key" json:"rsa_public_key" envconfig:"rsa_public_key" yaml:"rsa_public_key" toml:"rsa_public_key"`
+	ECDSAPublicKey                      string `mapstructure:"ecdsa_public_key" json:"ecdsa_public_key" envconfig:"ecdsa_public_key" yaml:"ecdsa_public_key" toml:"ecdsa_public_key"`
+	JWKSPublicEndpoint                  string `mapstructure:"jwks_public_endpoint" json:"jwks_public_endpoint" envconfig:"jwks_public_endpoint" yaml:"jwks_public_endpoint" toml:"jwks_public_endpoint"`
+	Audience                            string `mapstructure:"audience" json:"audience" envconfig:"audience" yaml:"audience" toml:"audience"`
+	AudienceRegex                       string `mapstructure:"audience_regex" json:"audience_regex" envconfig:"audience_regex" yaml:"audience_regex" toml:"audience_regex"`
+	Issuer                              string `mapstructure:"issuer" json:"issuer" envconfig:"issuer" yaml:"issuer" toml:"issuer"`
+	IssuerRegex                         string `mapstructure:"issuer_regex" json:"issuer_regex" envconfig:"issuer_regex" yaml:"issuer_regex" toml:"issuer_regex"`
 	UserIDClaim                         string `mapstructure:"user_id_claim" json:"user_id_claim" envconfig:"user_id_claim" yaml:"user_id_claim" toml:"user_id_claim"`
 	InsecureSkipJWKSEndpointSafetyCheck bool   `mapstructure:"insecure_skip_jwks_endpoint_safety_check" json:"insecure_skip_jwks_endpoint_safety_check" envconfig:"insecure_skip_jwks_endpoint_safety_check" yaml:"insecure_skip_jwks_endpoint_safety_check" toml:"insecure_skip_jwks_endpoint_safety_check"`
 }
@@ -813,6 +813,11 @@ type KafkaConsumerConfig struct {
 	SASLMechanism string `mapstructure:"sasl_mechanism" json:"sasl_mechanism" envconfig:"sasl_mechanism" yaml:"sasl_mechanism" toml:"sasl_mechanism"`
 	SASLUser      string `mapstructure:"sasl_user" json:"sasl_user" envconfig:"sasl_user" yaml:"sasl_user" toml:"sasl_user"`
 	SASLPassword  string `mapstructure:"sasl_password" json:"sasl_password" envconfig:"sasl_password" yaml:"sasl_password" toml:"sasl_password"`
+	// AssumeRoleARN, when set with sasl_mechanism aws-msk-iam, uses AWS STS AssumeRole to obtain
+	// temporary credentials for MSK IAM authentication (e.g. cross-account MSK). Base credentials
+	// and region come from the default AWS SDK chain (AWS_REGION, instance metadata, etc.).
+	// When set, sasl_user and sasl_password are ignored. When empty, static keys from sasl_user/sasl_password are used.
+	AssumeRoleARN string `mapstructure:"assume_role_arn" json:"assume_role_arn" envconfig:"assume_role_arn" yaml:"assume_role_arn" toml:"assume_role_arn"`
 
 	// InstanceID sets a stable consumer group instance ID for Kafka static membership.
 	// When set, enables the static membership protocol: during rolling restarts, a replacement
@@ -842,6 +847,9 @@ func (c KafkaConsumerConfig) Validate() error {
 	}
 	if c.PublicationDataMode.Enabled && c.PublicationDataMode.ChannelsHeader == "" {
 		return errors.New("no Kafka channels_header_name provided for publication data mode")
+	}
+	if c.AssumeRoleARN != "" && c.SASLMechanism != "aws-msk-iam" {
+		return errors.New("assume_role_arn requires sasl_mechanism aws-msk-iam")
 	}
 	return nil
 }

--- a/internal/configtypes/types.go
+++ b/internal/configtypes/types.go
@@ -51,16 +51,16 @@ type Log struct {
 
 // Token common configuration.
 type Token struct {
-	HMACSecretKey                       string `mapstructure:"hmac_secret_key" json:"hmac_secret_key" envconfig:"hmac_secret_key" yaml:"hmac_secret_key" toml:"hmac_secret_key"`
-	HMACPreviousSecretKey               string `mapstructure:"hmac_previous_secret_key" json:"hmac_previous_secret_key" envconfig:"hmac_previous_secret_key" yaml:"hmac_previous_secret_key" toml:"hmac_previous_secret_key"`
-	HMACPreviousSecretKeyValidUntil     int64  `mapstructure:"hmac_previous_secret_key_valid_until" json:"hmac_previous_secret_key_valid_until" envconfig:"hmac_previous_secret_key_valid_until" yaml:"hmac_previous_secret_key_valid_until" toml:"hmac_previous_secret_key_valid_until"`
-	RSAPublicKey                        string `mapstructure:"rsa_public_key" json:"rsa_public_key" envconfig:"rsa_public_key" yaml:"rsa_public_key" toml:"rsa_public_key"`
-	ECDSAPublicKey                      string `mapstructure:"ecdsa_public_key" json:"ecdsa_public_key" envconfig:"ecdsa_public_key" yaml:"ecdsa_public_key" toml:"ecdsa_public_key"`
-	JWKSPublicEndpoint                  string `mapstructure:"jwks_public_endpoint" json:"jwks_public_endpoint" envconfig:"jwks_public_endpoint" yaml:"jwks_public_endpoint" toml:"jwks_public_endpoint"`
-	Audience                            string `mapstructure:"audience" json:"audience" envconfig:"audience" yaml:"audience" toml:"audience"`
-	AudienceRegex                       string `mapstructure:"audience_regex" json:"audience_regex" envconfig:"audience_regex" yaml:"audience_regex" toml:"audience_regex"`
-	Issuer                              string `mapstructure:"issuer" json:"issuer" envconfig:"issuer" yaml:"issuer" toml:"issuer"`
-	IssuerRegex                         string `mapstructure:"issuer_regex" json:"issuer_regex" envconfig:"issuer_regex" yaml:"issuer_regex" toml:"issuer_regex"`
+	HMACSecretKey                   string `mapstructure:"hmac_secret_key" json:"hmac_secret_key" envconfig:"hmac_secret_key" yaml:"hmac_secret_key" toml:"hmac_secret_key"`
+	HMACPreviousSecretKey           string `mapstructure:"hmac_previous_secret_key" json:"hmac_previous_secret_key" envconfig:"hmac_previous_secret_key" yaml:"hmac_previous_secret_key" toml:"hmac_previous_secret_key"`
+	HMACPreviousSecretKeyValidUntil int64  `mapstructure:"hmac_previous_secret_key_valid_until" json:"hmac_previous_secret_key_valid_until" envconfig:"hmac_previous_secret_key_valid_until" yaml:"hmac_previous_secret_key_valid_until" toml:"hmac_previous_secret_key_valid_until"`
+	RSAPublicKey                    string `mapstructure:"rsa_public_key" json:"rsa_public_key" envconfig:"rsa_public_key" yaml:"rsa_public_key" toml:"rsa_public_key"`
+	ECDSAPublicKey     string `mapstructure:"ecdsa_public_key" json:"ecdsa_public_key" envconfig:"ecdsa_public_key" yaml:"ecdsa_public_key" toml:"ecdsa_public_key"`
+	JWKSPublicEndpoint string `mapstructure:"jwks_public_endpoint" json:"jwks_public_endpoint" envconfig:"jwks_public_endpoint" yaml:"jwks_public_endpoint" toml:"jwks_public_endpoint"`
+	Audience           string `mapstructure:"audience" json:"audience" envconfig:"audience" yaml:"audience" toml:"audience"`
+	AudienceRegex      string `mapstructure:"audience_regex" json:"audience_regex" envconfig:"audience_regex" yaml:"audience_regex" toml:"audience_regex"`
+	Issuer             string `mapstructure:"issuer" json:"issuer" envconfig:"issuer" yaml:"issuer" toml:"issuer"`
+	IssuerRegex        string `mapstructure:"issuer_regex" json:"issuer_regex" envconfig:"issuer_regex" yaml:"issuer_regex" toml:"issuer_regex"`
 	UserIDClaim                         string `mapstructure:"user_id_claim" json:"user_id_claim" envconfig:"user_id_claim" yaml:"user_id_claim" toml:"user_id_claim"`
 	InsecureSkipJWKSEndpointSafetyCheck bool   `mapstructure:"insecure_skip_jwks_endpoint_safety_check" json:"insecure_skip_jwks_endpoint_safety_check" envconfig:"insecure_skip_jwks_endpoint_safety_check" yaml:"insecure_skip_jwks_endpoint_safety_check" toml:"insecure_skip_jwks_endpoint_safety_check"`
 }

--- a/internal/consuming/kafka.go
+++ b/internal/consuming/kafka.go
@@ -16,10 +16,14 @@ import (
 	"github.com/centrifugal/centrifugo/v6/internal/logging"
 	"github.com/centrifugal/centrifugo/v6/internal/metrics"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsv2cfg "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/rs/zerolog"
 	"github.com/twmb/franz-go/pkg/kgo"
 	"github.com/twmb/franz-go/pkg/kmsg"
-	"github.com/twmb/franz-go/pkg/sasl/aws"
+	mskaws "github.com/twmb/franz-go/pkg/sasl/aws"
 	"github.com/twmb/franz-go/pkg/sasl/plain"
 	"github.com/twmb/franz-go/pkg/sasl/scram"
 )
@@ -159,6 +163,17 @@ func (c *KafkaConsumer) leaveGroup(ctx context.Context, client *kgo.Client) erro
 	return err
 }
 
+func loadAWSConfigForKafkaAssumeRole(ctx context.Context, roleARN string) (aws.Config, error) {
+	awsCfg, err := awsv2cfg.LoadDefaultConfig(ctx)
+	if err != nil {
+		return aws.Config{}, err
+	}
+	stsClient := sts.NewFromConfig(awsCfg)
+	assumeRoleProvider := stscreds.NewAssumeRoleProvider(stsClient, roleARN)
+	awsCfg.Credentials = aws.NewCredentialsCache(assumeRoleProvider)
+	return awsCfg, nil
+}
+
 func (c *KafkaConsumer) initClient() (*kgo.Client, error) {
 	opts := []kgo.Opt{
 		kgo.SeedBrokers(c.config.Brokers...),
@@ -214,10 +229,30 @@ func (c *KafkaConsumer) initClient() (*kgo.Client, error) {
 				Pass: c.config.SASLPassword,
 			}.AsSha512Mechanism()))
 		case "aws-msk-iam":
-			opts = append(opts, kgo.SASL(aws.Auth{
-				AccessKey: c.config.SASLUser,
-				SecretKey: c.config.SASLPassword,
-			}.AsManagedStreamingIAMMechanism()))
+			if c.config.AssumeRoleARN != "" {
+				ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+				awsCfg, err := loadAWSConfigForKafkaAssumeRole(ctx, c.config.AssumeRoleARN)
+				cancel()
+				if err != nil {
+					return nil, fmt.Errorf("load AWS config for MSK IAM assume role: %w", err)
+				}
+				opts = append(opts, kgo.SASL(mskaws.ManagedStreamingIAM(func(ctx context.Context) (mskaws.Auth, error) {
+					v, err := awsCfg.Credentials.Retrieve(ctx)
+					if err != nil {
+						return mskaws.Auth{}, err
+					}
+					return mskaws.Auth{
+						AccessKey:    v.AccessKeyID,
+						SecretKey:    v.SecretAccessKey,
+						SessionToken: v.SessionToken,
+					}, nil
+				})))
+			} else {
+				opts = append(opts, kgo.SASL(mskaws.Auth{
+					AccessKey: c.config.SASLUser,
+					SecretKey: c.config.SASLPassword,
+				}.AsManagedStreamingIAMMechanism()))
+			}
 		default:
 			return nil, fmt.Errorf("unsupported SASL mechanism: %s", c.config.SASLMechanism)
 		}


### PR DESCRIPTION
Add consumers[].kafka.assume_role_arn. When set with sasl_mechanism aws-msk-iam, load credentials via AWS SDK default chain + STS AssumeRole and use franz-go ManagedStreamingIAM for refreshed session tokens.

Static sasl_user/sasl_password remain the default when assume_role_arn is empty. Validates assume_role_arn is only used with aws-msk-iam.

Closes centrifugal/centrifugo#1126 (assume-role scope).

Made-with: Cursor

## Proposed changes

Adds support for assume-role for kafka aws-msk-iam.
Fixes issue: https://github.com/centrifugal/centrifugo/issues/1126

It was tested in AWS env. Connects successfully on setting env variable: CENTRIFUGO_CONSUMERS_KAFKA_CONSUMER_KAFKA_ASSUME_ROLE_ARN
