### PR TITLE
Support native histograms

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -146,3 +146,5 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260519071638-aa98bba5eb94 // indirect
 	gopkg.in/yaml.v3 v3.0.1
 )
+
+replace github.com/centrifugal/centrifuge => ../centrifuge

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.42.27
 	github.com/aws/aws-sdk-go-v2/service/sts v1.42.1
 	github.com/aws/smithy-go v1.25.1
-	github.com/centrifugal/centrifuge v0.38.1-0.20260520140841-f55b81cbcece
+	github.com/centrifugal/centrifuge v0.38.1-0.20260523153313-5cd046902a38
 	github.com/centrifugal/protocol v0.19.2
 	github.com/cristalhq/jwt/v5 v5.4.0
 	github.com/go-viper/mapstructure/v2 v2.5.0
@@ -146,5 +146,3 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260519071638-aa98bba5eb94 // indirect
 	gopkg.in/yaml.v3 v3.0.1
 )
-
-replace github.com/centrifugal/centrifuge => ../centrifuge

--- a/go.sum
+++ b/go.sum
@@ -73,8 +73,8 @@ github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6r
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/centrifugal/centrifuge v0.38.1-0.20260520140841-f55b81cbcece h1:2QudzvLKn3yvgvQBROkuw7XxqHSehlsL3mKk8oCkx/k=
-github.com/centrifugal/centrifuge v0.38.1-0.20260520140841-f55b81cbcece/go.mod h1:EpRRyI1HBRU0A2RXFv6IEZofIvPTZb9OeUFuXyi5YPA=
+github.com/centrifugal/centrifuge v0.38.1-0.20260523153313-5cd046902a38 h1:irXjnzgUDrPZ5y3Z/iMIbl4t/BtEgbtwNnvdEwJKKhA=
+github.com/centrifugal/centrifuge v0.38.1-0.20260523153313-5cd046902a38/go.mod h1:BKroeyxtsjPHI9ZH7hJw0K4i1Yex/zvncUgJNBSk39Q=
 github.com/centrifugal/protocol v0.19.2 h1:wc1S75EJvX5/KczsqEG74Bt/Jw/XwECDUzWR/vE/E9U=
 github.com/centrifugal/protocol v0.19.2/go.mod h1:zFsp4f1ZRejq1dkyNUbabdPj4dMYOpK8RRXDwHGVpVY=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=

--- a/internal/app/node.go
+++ b/internal/app/node.go
@@ -18,6 +18,7 @@ func centrifugeNodeConfig(version string, edition string, cfgContainer *config.C
 	cfg.Metrics = centrifuge.MetricsConfig{
 		MetricsNamespace:                     "centrifugo",
 		EnableRecoveredPublicationsHistogram: appCfg.Prometheus.RecoveredPublicationsHistogram,
+		EnableNativeHistograms:               appCfg.Prometheus.NativeHistograms,
 	}
 	cfg.Name = nodeName(appCfg)
 	cfg.ChannelMaxLength = appCfg.Channel.MaxLength

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -121,9 +121,10 @@ func Run(cmd *cobra.Command, configFile string) {
 
 	// Initialize centralized metrics registry.
 	err = metrics.Init(metrics.Config{
-		Namespace:   "", // Use default "centrifugo" namespace.
-		ConstLabels: nil, // Can be populated from config in the future.
-		Registerer:  nil, // Use prometheus.DefaultRegisterer.
+		Namespace:        "", // Use default "centrifugo" namespace.
+		ConstLabels:      nil, // Can be populated from config in the future.
+		Registerer:       nil, // Use prometheus.DefaultRegisterer.
+		NativeHistograms: cfg.Prometheus.NativeHistograms,
 	})
 	if err != nil {
 		log.Fatal().Err(err).Msg("error initializing metrics")

--- a/internal/configtypes/types.go
+++ b/internal/configtypes/types.go
@@ -337,6 +337,15 @@ type Prometheus struct {
 	InstrumentHTTPHandlers bool `mapstructure:"instrument_http_handlers" json:"instrument_http_handlers" envconfig:"instrument_http_handlers" yaml:"instrument_http_handlers" toml:"instrument_http_handlers"`
 	// RecoveredPublicationsHistogram enables a histogram to track the distribution of recovered publications number.
 	RecoveredPublicationsHistogram bool `mapstructure:"recovered_publications_histogram" json:"recovered_publications_histogram" envconfig:"recovered_publications_histogram" yaml:"recovered_publications_histogram" toml:"recovered_publications_histogram"`
+	// NativeHistograms switches Centrifugo's Histogram instruments and the
+	// underlying centrifuge library's distribution metrics to Prometheus
+	// native (sparse, exponential) histogram schema with no explicit buckets
+	// exposed. Designed for OpenTelemetry export via the client_golang
+	// Prometheus bridge: native histograms map to OTel ExponentialHistogram.
+	// Text-format scrapes lose _bucket series; only _count and _sum remain
+	// visible — use protobuf scrape format (Prom 2.40+) to get full data.
+	// Experimental in client_golang.
+	NativeHistograms bool `mapstructure:"native_histograms" json:"native_histograms" envconfig:"native_histograms" yaml:"native_histograms" toml:"native_histograms"`
 }
 
 type Health struct {

--- a/internal/metrics/accessors.go
+++ b/internal/metrics/accessors.go
@@ -2,20 +2,36 @@ package metrics
 
 import "github.com/prometheus/client_golang/prometheus"
 
-// Proxy metrics - exported for use by proxy package
+// Proxy metrics - exported for use by proxy package.
+//
+// ProxyCallDurationSummary holds the legacy Summary instrument by default;
+// when prometheus.native_histograms is enabled it is a no-op observer (see
+// internal noopObserverVec), so callers can continue to construct cached
+// observers and call .Observe() without nil-checks. ProxyCallDurationHistogram
+// is the canonical companion — prefer it for new queries and OTel export.
 var (
-	ProxyCallDurationSummary   *prometheus.SummaryVec
+	ProxyCallDurationSummary   prometheus.ObserverVec
 	ProxyCallDurationHistogram *prometheus.HistogramVec
 	ProxyCallErrorCount        *prometheus.CounterVec
 	ProxyCallInflightRequests  *prometheus.GaugeVec
 )
 
-// API metrics - exported for use by api package
+// API metrics - exported for use by api package.
+//
+// APICommandDurationSummary follows the same pattern as ProxyCallDurationSummary
+// (real Summary by default, no-op when native_histograms is enabled).
+// APICommandDurationHistogram is the canonical companion.
+//
+// RPCDurationSummary follows the same pattern. RPCDurationHistogram is the
+// companion Histogram exposed as "rpc_duration_seconds_histogram" —
+// unconditional, with native (sparse, exponential) schema when
+// native_histograms is enabled.
 var (
 	APICommandErrorsTotal       *prometheus.CounterVec
-	APICommandDurationSummary   *prometheus.SummaryVec
+	APICommandDurationSummary   prometheus.ObserverVec
 	APICommandDurationHistogram *prometheus.HistogramVec
-	RPCDurationSummary          *prometheus.SummaryVec
+	RPCDurationSummary          prometheus.ObserverVec
+	RPCDurationHistogram        *prometheus.HistogramVec
 )
 
 // Consumer metrics - exported for use by consuming package

--- a/internal/metrics/helpers.go
+++ b/internal/metrics/helpers.go
@@ -28,6 +28,7 @@ func ObserveAPICommand(started time.Time, protocol string, method string) {
 func ObserveRPC(started time.Time, protocol string, method string) {
 	duration := time.Since(started).Seconds()
 	RPCDurationSummary.WithLabelValues(protocol, method).Observe(duration)
+	RPCDurationHistogram.WithLabelValues(protocol, method).Observe(duration)
 }
 
 // Consumer metric helper functions - these were previously in the consuming package

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"errors"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -17,6 +18,25 @@ type Config struct {
 	ConstLabels map[string]string
 	// Registerer is the prometheus registerer to use. If nil, prometheus.DefaultRegisterer is used.
 	Registerer prometheus.Registerer
+	// NativeHistograms switches Histogram instruments to Prometheus native
+	// (sparse, exponential) schema with no explicit buckets exposed. Designed
+	// for OpenTelemetry export via the client_golang Prometheus bridge.
+	// Text-format scrapes lose _bucket series; use protobuf scrape format.
+	NativeHistograms bool
+}
+
+// nativeHistogramOpts returns opts unchanged when native is false. When true,
+// it enables Prometheus native histogram schema with no explicit buckets —
+// the metric exposes only _count, _sum, and the native histogram chunk.
+func nativeHistogramOpts(opts prometheus.HistogramOpts, native bool) prometheus.HistogramOpts {
+	if !native {
+		return opts
+	}
+	opts.Buckets = nil
+	opts.NativeHistogramBucketFactor = 1.1
+	opts.NativeHistogramMaxBucketNumber = 200
+	opts.NativeHistogramMinResetDuration = time.Hour
+	return opts
 }
 
 // Registry holds all Centrifugo metrics.
@@ -117,14 +137,14 @@ func newRegistry(cfg Config) (*Registry, error) {
 		ConstLabels: constLabels,
 	}, []string{"protocol", "type", "name"})
 
-	m.proxyCallDurationHistogram = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+	m.proxyCallDurationHistogram = prometheus.NewHistogramVec(nativeHistogramOpts(prometheus.HistogramOpts{
 		Namespace:   metricsNamespace,
 		Subsystem:   "proxy",
 		Name:        "duration_seconds_histogram",
 		Buckets:     prometheus.DefBuckets,
 		Help:        "Histogram of duration of proxy call.",
 		ConstLabels: constLabels,
-	}, []string{"protocol", "type", "name"})
+	}, cfg.NativeHistograms), []string{"protocol", "type", "name"})
 
 	m.proxyCallErrorCount = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace:   metricsNamespace,
@@ -160,14 +180,14 @@ func newRegistry(cfg Config) (*Registry, error) {
 		ConstLabels: constLabels,
 	}, []string{"protocol", "method"})
 
-	m.apiCommandDurationHistogram = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+	m.apiCommandDurationHistogram = prometheus.NewHistogramVec(nativeHistogramOpts(prometheus.HistogramOpts{
 		Namespace:   metricsNamespace,
 		Subsystem:   "api",
 		Buckets:     prometheus.DefBuckets,
 		Name:        "command_duration_seconds_histogram",
 		Help:        "Histogram of duration of API per command.",
 		ConstLabels: constLabels,
-	}, []string{"protocol", "method"})
+	}, cfg.NativeHistograms), []string{"protocol", "method"})
 
 	m.rpcDurationSummary = prometheus.NewSummaryVec(prometheus.SummaryOpts{
 		Namespace:   metricsNamespace,
@@ -196,23 +216,23 @@ func newRegistry(cfg Config) (*Registry, error) {
 	}, []string{"consumer_name"})
 
 	// Shared poll proxy metrics
-	m.sharedPollProxyRequestItems = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+	m.sharedPollProxyRequestItems = prometheus.NewHistogramVec(nativeHistogramOpts(prometheus.HistogramOpts{
 		Namespace:   metricsNamespace,
 		Subsystem:   "shared_poll_proxy",
 		Name:        "request_items",
 		Help:        "Number of items per shared poll proxy request.",
 		Buckets:     []float64{1, 5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000},
 		ConstLabels: constLabels,
-	}, []string{"name"})
+	}, cfg.NativeHistograms), []string{"name"})
 
-	m.sharedPollProxyResponseItems = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+	m.sharedPollProxyResponseItems = prometheus.NewHistogramVec(nativeHistogramOpts(prometheus.HistogramOpts{
 		Namespace:   metricsNamespace,
 		Subsystem:   "shared_poll_proxy",
 		Name:        "response_items",
 		Help:        "Number of items per shared poll proxy response.",
 		Buckets:     []float64{1, 5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000},
 		ConstLabels: constLabels,
-	}, []string{"name"})
+	}, cfg.NativeHistograms), []string{"name"})
 
 	// Middleware metrics
 	m.connLimitReached = prometheus.NewCounter(prometheus.CounterOpts{

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -39,21 +39,54 @@ func nativeHistogramOpts(opts prometheus.HistogramOpts, native bool) prometheus.
 	return opts
 }
 
+// noopObserverVec implements prometheus.ObserverVec with all no-op methods.
+// Assigned to Summary accessors when NativeHistograms is true so that
+// callers (proxy handlers, helpers) can still construct cached observers
+// and call .Observe() without nil checks — the calls become no-ops and no
+// metric data is recorded for the disabled Summary instrument.
+type noopObserverVec struct{}
+
+func (noopObserverVec) Describe(chan<- *prometheus.Desc)              {}
+func (noopObserverVec) Collect(chan<- prometheus.Metric)              {}
+func (noopObserverVec) WithLabelValues(...string) prometheus.Observer { return noopObserver{} }
+func (noopObserverVec) With(prometheus.Labels) prometheus.Observer    { return noopObserver{} }
+func (noopObserverVec) GetMetricWith(prometheus.Labels) (prometheus.Observer, error) {
+	return noopObserver{}, nil
+}
+func (noopObserverVec) GetMetricWithLabelValues(...string) (prometheus.Observer, error) {
+	return noopObserver{}, nil
+}
+func (noopObserverVec) CurryWith(prometheus.Labels) (prometheus.ObserverVec, error) {
+	return noopObserverVec{}, nil
+}
+func (noopObserverVec) MustCurryWith(prometheus.Labels) prometheus.ObserverVec {
+	return noopObserverVec{}
+}
+
+type noopObserver struct{}
+
+func (noopObserver) Observe(float64) {}
+
 // Registry holds all Centrifugo metrics.
 type Registry struct {
 	config Config
 
 	// Proxy metrics
-	proxyCallDurationSummary   *prometheus.SummaryVec
+	proxyCallDurationSummary   prometheus.ObserverVec
 	proxyCallDurationHistogram *prometheus.HistogramVec
 	proxyCallErrorCount        *prometheus.CounterVec
 	proxyCallInflightRequests  *prometheus.GaugeVec
 
 	// API metrics
 	apiCommandErrorsTotal       *prometheus.CounterVec
-	apiCommandDurationSummary   *prometheus.SummaryVec
+	apiCommandDurationSummary   prometheus.ObserverVec
 	apiCommandDurationHistogram *prometheus.HistogramVec
-	rpcDurationSummary          *prometheus.SummaryVec
+	// rpcDurationSummary is the legacy Summary by default; no-op when
+	// NativeHistograms is true. rpcDurationHistogram is the new companion
+	// Histogram exposed as "rpc_duration_seconds_histogram" — unconditional,
+	// with native schema when NativeHistograms is true.
+	rpcDurationSummary   prometheus.ObserverVec
+	rpcDurationHistogram *prometheus.HistogramVec
 
 	// Consumer metrics
 	consumerProcessedTotal *prometheus.CounterVec
@@ -93,6 +126,7 @@ func Init(cfg Config) error {
 	APICommandDurationSummary = reg.apiCommandDurationSummary
 	APICommandDurationHistogram = reg.apiCommandDurationHistogram
 	RPCDurationSummary = reg.rpcDurationSummary
+	RPCDurationHistogram = reg.rpcDurationHistogram
 
 	ConsumerProcessedTotal = reg.consumerProcessedTotal
 	ConsumerErrorsTotal = reg.consumerErrorsTotal
@@ -128,14 +162,18 @@ func newRegistry(cfg Config) (*Registry, error) {
 	}
 
 	// Proxy metrics
-	m.proxyCallDurationSummary = prometheus.NewSummaryVec(prometheus.SummaryOpts{
-		Namespace:   metricsNamespace,
-		Subsystem:   "proxy",
-		Name:        "duration_seconds",
-		Objectives:  map[float64]float64{0.5: 0.05, 0.99: 0.001, 0.999: 0.0001},
-		Help:        "Duration of proxy call.",
-		ConstLabels: constLabels,
-	}, []string{"protocol", "type", "name"})
+	if cfg.NativeHistograms {
+		m.proxyCallDurationSummary = noopObserverVec{}
+	} else {
+		m.proxyCallDurationSummary = prometheus.NewSummaryVec(prometheus.SummaryOpts{
+			Namespace:   metricsNamespace,
+			Subsystem:   "proxy",
+			Name:        "duration_seconds",
+			Objectives:  map[float64]float64{0.5: 0.05, 0.99: 0.001, 0.999: 0.0001},
+			Help:        "DEPRECATED — use centrifugo_proxy_duration_seconds_histogram. Will be removed in Centrifugo v7. Duration of proxy call.",
+			ConstLabels: constLabels,
+		}, []string{"protocol", "type", "name"})
+	}
 
 	m.proxyCallDurationHistogram = prometheus.NewHistogramVec(nativeHistogramOpts(prometheus.HistogramOpts{
 		Namespace:   metricsNamespace,
@@ -171,14 +209,18 @@ func newRegistry(cfg Config) (*Registry, error) {
 		ConstLabels: constLabels,
 	}, []string{"protocol", "method", "error"})
 
-	m.apiCommandDurationSummary = prometheus.NewSummaryVec(prometheus.SummaryOpts{
-		Namespace:   metricsNamespace,
-		Subsystem:   "api",
-		Name:        "command_duration_seconds",
-		Objectives:  map[float64]float64{0.5: 0.05, 0.99: 0.001, 0.999: 0.0001},
-		Help:        "Duration of API per command.",
-		ConstLabels: constLabels,
-	}, []string{"protocol", "method"})
+	if cfg.NativeHistograms {
+		m.apiCommandDurationSummary = noopObserverVec{}
+	} else {
+		m.apiCommandDurationSummary = prometheus.NewSummaryVec(prometheus.SummaryOpts{
+			Namespace:   metricsNamespace,
+			Subsystem:   "api",
+			Name:        "command_duration_seconds",
+			Objectives:  map[float64]float64{0.5: 0.05, 0.99: 0.001, 0.999: 0.0001},
+			Help:        "DEPRECATED — use centrifugo_api_command_duration_seconds_histogram. Will be removed in Centrifugo v7. Duration of API per command.",
+			ConstLabels: constLabels,
+		}, []string{"protocol", "method"})
+	}
 
 	m.apiCommandDurationHistogram = prometheus.NewHistogramVec(nativeHistogramOpts(prometheus.HistogramOpts{
 		Namespace:   metricsNamespace,
@@ -189,14 +231,27 @@ func newRegistry(cfg Config) (*Registry, error) {
 		ConstLabels: constLabels,
 	}, cfg.NativeHistograms), []string{"protocol", "method"})
 
-	m.rpcDurationSummary = prometheus.NewSummaryVec(prometheus.SummaryOpts{
+	if cfg.NativeHistograms {
+		m.rpcDurationSummary = noopObserverVec{}
+	} else {
+		m.rpcDurationSummary = prometheus.NewSummaryVec(prometheus.SummaryOpts{
+			Namespace:   metricsNamespace,
+			Subsystem:   "api",
+			Name:        "rpc_duration_seconds",
+			Objectives:  map[float64]float64{0.5: 0.05, 0.99: 0.001, 0.999: 0.0001},
+			Help:        "DEPRECATED — use centrifugo_api_rpc_duration_seconds_histogram. Will be removed in Centrifugo v7. Duration of API per command.",
+			ConstLabels: constLabels,
+		}, []string{"protocol", "method"})
+	}
+
+	m.rpcDurationHistogram = prometheus.NewHistogramVec(nativeHistogramOpts(prometheus.HistogramOpts{
 		Namespace:   metricsNamespace,
 		Subsystem:   "api",
-		Name:        "rpc_duration_seconds",
-		Objectives:  map[float64]float64{0.5: 0.05, 0.99: 0.001, 0.999: 0.0001},
-		Help:        "Duration of API per command.",
+		Name:        "rpc_duration_seconds_histogram",
+		Buckets:     prometheus.DefBuckets,
+		Help:        "Histogram of duration of API per command.",
 		ConstLabels: constLabels,
-	}, []string{"protocol", "method"})
+	}, cfg.NativeHistograms), []string{"protocol", "method"})
 
 	// Consumer metrics
 	m.consumerProcessedTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
@@ -291,6 +346,7 @@ func newRegistry(cfg Config) (*Registry, error) {
 		m.apiCommandDurationSummary,
 		m.apiCommandDurationHistogram,
 		m.rpcDurationSummary,
+		m.rpcDurationHistogram,
 		m.consumerProcessedTotal,
 		m.consumerErrorsTotal,
 		m.sharedPollProxyRequestItems,


### PR DESCRIPTION
Two opt-in flags, both default off. Today's behavior is fully preserved.

## OSS: `prometheus.native_histograms: true`

- New Histogram companion metrics, exposed unconditionally:
  - `centrifugo_api_command_duration_seconds_histogram` (was Summary-only)
  - `centrifugo_proxy_duration_seconds_histogram` (existed already)
  - `centrifugo_api_rpc_duration_seconds_histogram` (new)
  - Centrifuge library companions: `centrifugo_client_command_duration_seconds_histogram`, `centrifugo_node_survey_duration_seconds_histogram`
- When the flag is on:
  - All Summary instruments stop being exposed on `/metrics`.
  - All Histograms (companions and pre-existing) switch to native (sparse, exponential) schema with no explicit buckets.
- Summary instruments are marked deprecated in Help text and will be removed in Centrifugo v7. Use the `_histogram` companions for `histogram_quantile()` queries and OpenTelemetry export.

## Why the deprecation

Summary quantile estimates can't be aggregated across multiple Centrifugo nodes (per-node p99s aren't mathematically combinable into a fleet-wide p99). Histograms aggregate via `histogram_quantile()` over bucket counts, and native histograms map cleanly to OTel `ExponentialHistogram`. The Summary→Histogram migration is the right shape for both multi-node Prometheus deployments and OTel-bound deployments.

## Operational notes

- Text-format Prometheus scrapes lose `_bucket` series when `native_histograms` is on — use protobuf scrape format (Prom 2.40+).
- Native histograms are flagged experimental in `client_golang`.
