### PR TITLE
Kafka consumer: don't re-init client on retriable fetch errors

### DIFF
--- a/internal/consuming/kafka.go
+++ b/internal/consuming/kafka.go
@@ -21,6 +21,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/rs/zerolog"
+	"github.com/twmb/franz-go/pkg/kerr"
 	"github.com/twmb/franz-go/pkg/kgo"
 	"github.com/twmb/franz-go/pkg/kmsg"
 	mskaws "github.com/twmb/franz-go/pkg/sasl/aws"
@@ -37,6 +38,10 @@ type testOnlyConfig struct {
 	// leaveGroupOnShutdown when true sends a manual LeaveGroup request on shutdown.
 	// Used only in tests to simulate the old behavior with dynamic instance IDs.
 	leaveGroupOnShutdown bool
+	// injectFatalPollErrorCh, when a value is received from this channel (non-blocking
+	// check on each pollUntilFatal entry), causes pollUntilFatal to return it as a fatal
+	// error instead of actually polling — used to exercise the client re-init path in tests.
+	injectFatalPollErrorCh chan error
 }
 
 type topicPartition struct {
@@ -271,8 +276,30 @@ func (c *KafkaConsumer) initClient() (*kgo.Client, error) {
 	return client, nil
 }
 
+// fetchPartitionErrorRequiresClientReinit reports whether a PollRecords fetch error
+// should trigger a full consumer client re-initialization. franz-go classifies Kafka
+// protocol errors with kerr.IsRetriable; broker-level retryability uses
+// kgo.IsRetryableBrokerErr — these differ, so both are consulted. *kgo.ErrDataLoss
+// is handled by offset reset inside the client and does not require restarting it.
+func fetchPartitionErrorRequiresClientReinit(err error) bool {
+	if err == nil {
+		return false
+	}
+	var dataLoss *kgo.ErrDataLoss
+	if errors.As(err, &dataLoss) {
+		return false
+	}
+	if kerr.IsRetriable(err) || kgo.IsRetryableBrokerErr(err) {
+		return false
+	}
+	return true
+}
+
 func (c *KafkaConsumer) Run(ctx context.Context) error {
+	started := time.Now()
 	defer func() {
+		c.common.log.Info().Str("was_running_for", time.Since(started).String()).Msg("stopping Kafka consumer")
+		stopStarted := time.Now()
 		close(c.doneCh)
 		if c.client != nil {
 			// Stop all partition consumers first to ensure all offsets are marked.
@@ -300,25 +327,31 @@ func (c *KafkaConsumer) Run(ctx context.Context) error {
 			// with the same instance ID can take over partitions seamlessly.
 			c.client.CloseAllowingRebalance()
 		}
+		c.common.log.Info().Str("elapsed", time.Since(stopStarted).String()).Msg("stopped Kafka consumer")
 	}()
 	for {
+		pollStarted := time.Now()
 		err := c.pollUntilFatal(ctx)
 		if err != nil {
-			if errors.Is(err, context.Canceled) {
+			// franz-go may return context.DeadlineExceeded instead of context.Canceled on
+			// shutdown, so check the external context to detect shutdown — avoids logging
+			// the unwrapped error as if it were a real polling failure.
+			if ctx.Err() != nil {
 				return ctx.Err()
 			}
-			c.common.log.Error().Err(err).Msg("error polling Kafka")
+			c.common.log.Error().Err(err).Msg("fatal error polling Kafka, need client re-init")
 		}
-		// Upon returning from polling loop we are re-initializing consumer client.
+		// Upon returning from polling loop with fatal error we re-initialize consumer client.
 		c.client.CloseAllowingRebalance()
 		c.client = nil
-		c.common.log.Info().Msg("re-initializing Kafka consumer client")
+		c.common.log.Info().Str("was_polling_for", time.Since(pollStarted).String()).Msg("start re-initializing Kafka consumer client")
+		reInitStarted := time.Now()
 		err = c.reInitClient(ctx)
 		if err != nil {
 			// Only context.Canceled may be returned.
 			return err
 		}
-		c.common.log.Info().Msg("Kafka consumer client re-initialized")
+		c.common.log.Info().Str("elapsed", time.Since(reInitStarted).String()).Msg("Kafka consumer client re-initialized")
 	}
 }
 
@@ -328,22 +361,51 @@ func (c *KafkaConsumer) pollUntilFatal(ctx context.Context) error {
 		case <-ctx.Done():
 			return ctx.Err()
 		default:
+			if ch := c.testOnlyConfig.injectFatalPollErrorCh; ch != nil {
+				select {
+				case err := <-ch:
+					return err
+				default:
+				}
+			}
 			fetches := c.client.PollRecords(ctx, c.config.MaxPollRecords)
 			if fetches.IsClientClosed() {
-				return nil
+				// Defensive check: in our code the client is only closed by Run after this loop
+				// exits, so this should not normally happen. Trigger re-init via Run to recover.
+				c.common.log.Warn().Msg("Kafka client unexpectedly closed during poll, will re-init")
+				return errors.New("client closed during poll")
 			}
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			// Check fetch errors. Only return fatal error if at least one partition error needs a
+			// full client re-init. Kafka-retriable protocol errors (kerr) and retryable broker
+			// errors (kgo) are left to franz-go; ErrDataLoss is handled via offset reset inside the
+			// client. Otherwise we log and continue so EachPartition still processes fetched
+			// records for partitions without errors.
 			fetchErrors := fetches.Errors()
 			if len(fetchErrors) > 0 {
-				// Non-retryable errors returned. We will restart consumer client, but log errors first.
 				var errs []error
+				var fatal bool
 				for _, fetchErr := range fetchErrors {
-					if errors.Is(fetchErr.Err, context.Canceled) {
-						return ctx.Err()
-					}
 					errs = append(errs, fetchErr.Err)
-					c.common.log.Error().Err(fetchErr.Err).Str("topic", fetchErr.Topic).Int32("partition", fetchErr.Partition).Msg("error while polling Kafka")
+					reinit := fetchPartitionErrorRequiresClientReinit(fetchErr.Err)
+					c.common.log.Error().
+						Err(fetchErr.Err).
+						Str("topic", fetchErr.Topic).
+						Int32("partition", fetchErr.Partition).
+						Bool("fatal", reinit).
+						Msg("error while polling topic partition")
+					if reinit {
+						fatal = true
+					}
 				}
-				return fmt.Errorf("poll error: %w", errors.Join(errs...))
+				if fatal {
+					// Client will be re-initialized in Run. This poll returns before EachPartition,
+					// so records from this cycle are not enqueued yet; recovery is at-least-once
+					// via refetch after re-init.
+					return fmt.Errorf("poll error: %w", errors.Join(errs...))
+				}
 			}
 
 			// Track which partitions we've paused in this poll cycle.
@@ -469,7 +531,13 @@ func (c *KafkaConsumer) revoked(ctx context.Context, cl *kgo.Client, revoked map
 	c.killConsumers(revoked)
 	// Always commit marked offsets on revoke.
 	if err := cl.CommitMarkedOffsets(ctx); err != nil {
-		c.common.log.Error().Err(err).Msg("error committing marked offsets on revoke")
+		// On shutdown the app context is already canceled; commit will fail with
+		// context.Canceled. That is expected, not an error — log at info level instead.
+		if errors.Is(err, context.Canceled) {
+			c.common.log.Info().Err(err).Msg("skipping commit on revoke due to context cancellation")
+		} else {
+			c.common.log.Error().Err(err).Msg("error committing marked offsets on revoke")
+		}
 	}
 }
 

--- a/internal/consuming/kafka_test.go
+++ b/internal/consuming/kafka_test.go
@@ -3,12 +3,15 @@
 package consuming
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -18,6 +21,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 	"github.com/twmb/franz-go/pkg/kadm"
 	"github.com/twmb/franz-go/pkg/kgo"
@@ -1333,6 +1337,555 @@ func TestKafkaConsumer_CommitsOffsetsOnShutdown(t *testing.T) {
 	require.True(t, ok, "committed offset not found for topic %s partition 0", testKafkaTopic)
 	require.Equal(t, int64(numMessages), offset.At,
 		"committed offset should equal number of produced messages")
+}
+
+// syncBuffer is a concurrency-safe buffer for capturing zerolog output in tests.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (s *syncBuffer) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.Write(p)
+}
+
+func (s *syncBuffer) String() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.String()
+}
+
+// testCommonWithLogBuf builds a consumerCommon whose zerolog logger writes JSON
+// records into buf so tests can assert on log messages.
+func testCommonWithLogBuf(buf *syncBuffer) *consumerCommon {
+	return &consumerCommon{
+		name:   "test",
+		nodeID: uuid.New().String(),
+		log:    zerolog.New(buf).With().Str("consumer", "test").Logger(),
+	}
+}
+
+// producerState tracks every successfully produced message value.
+type producerState struct {
+	mu     sync.Mutex
+	values []string
+}
+
+func (p *producerState) add(v string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.values = append(p.values, v)
+}
+
+func (p *producerState) snapshot() []string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return slices.Clone(p.values)
+}
+
+// consumedTracker tracks unique consumed message values and total dispatch calls.
+type consumedTracker struct {
+	mu         sync.Mutex
+	values     map[string]struct{}
+	totalCalls int
+}
+
+func newConsumedTracker() *consumedTracker {
+	return &consumedTracker{values: make(map[string]struct{})}
+}
+
+func (c *consumedTracker) add(v string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.values[v] = struct{}{}
+	c.totalCalls++
+}
+
+func (c *consumedTracker) snapshotSet() map[string]struct{} {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make(map[string]struct{}, len(c.values))
+	for v := range c.values {
+		out[v] = struct{}{}
+	}
+	return out
+}
+
+func (c *consumedTracker) uniqueCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.values)
+}
+
+func (c *consumedTracker) totalCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.totalCalls
+}
+
+// runMultiPartitionProducer produces messages "msg_1", "msg_2", ... round-robin
+// across all partitions of the topic. PollRecords blocks until records are
+// available, so a steady traffic stream is required to make the consumer poll
+// loop iterate and pick up an injected fatal error from the test-only channel.
+func runMultiPartitionProducer(
+	t *testing.T,
+	ctx context.Context,
+	topic string,
+	numPartitions int32,
+	interval time.Duration,
+) (*producerState, chan struct{}) {
+	t.Helper()
+	client, err := kgo.NewClient(
+		kgo.SeedBrokers(testKafkaBrokerURL),
+		kgo.RecordPartitioner(kgo.ManualPartitioner()),
+	)
+	require.NoError(t, err)
+
+	state := &producerState{}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		defer client.Close()
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		var seq int
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				seq++
+				value := fmt.Sprintf("msg_%d", seq)
+				partition := int32(seq-1) % numPartitions
+				err := client.ProduceSync(ctx, &kgo.Record{
+					Topic:     topic,
+					Partition: partition,
+					Value:     []byte(value),
+				}).FirstErr()
+				if err != nil {
+					if ctx.Err() != nil {
+						return
+					}
+					t.Logf("produce error: %v", err)
+					return
+				}
+				state.add(value)
+			}
+		}
+	}()
+	return state, done
+}
+
+// assertNoMessageLoss asserts that every successfully produced message was consumed.
+// Allows redeliveries (totalCount >= produced count).
+func assertNoMessageLoss(t *testing.T, prod *producerState, cons *consumedTracker) {
+	t.Helper()
+	producedList := prod.snapshot()
+	producedSet := make(map[string]struct{}, len(producedList))
+	for _, v := range producedList {
+		producedSet[v] = struct{}{}
+	}
+	consumedSet := cons.snapshotSet()
+
+	var missing []string
+	for v := range producedSet {
+		if _, ok := consumedSet[v]; !ok {
+			missing = append(missing, v)
+		}
+	}
+	require.Empty(t, missing, "produced messages were not consumed (message loss): %v", missing)
+
+	require.Equal(t, len(producedSet), len(consumedSet),
+		"unique consumed set size must equal unique produced set size")
+	require.Equal(t, producedSet, consumedSet,
+		"consumed set must equal produced set")
+	require.GreaterOrEqual(t, cons.totalCount(), len(producedList),
+		"total consume calls must be at least produced count")
+}
+
+// runConsumerAsync starts a KafkaConsumer in a goroutine and returns a channel
+// that receives the Run error when it returns.
+func runConsumerAsync(t *testing.T, ctx context.Context, c *KafkaConsumer) chan error {
+	t.Helper()
+	done := make(chan error, 1)
+	go func() {
+		done <- c.Run(ctx)
+	}()
+	return done
+}
+
+// TestKafkaConsumer_NoMessageLossOnReInit verifies that when a fatal poll error
+// triggers client re-initialization, every produced message is eventually
+// consumed and no messages are lost. Uses a multi-partition topic with
+// round-robin distribution so multiple partition consumers are exercised.
+func TestKafkaConsumer_NoMessageLossOnReInit(t *testing.T) {
+	t.Parallel()
+	const numPartitions int32 = 4
+	testKafkaTopic := "centrifugo_consumer_test_" + uuid.New().String()
+	consumerGroup := uuid.New().String()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	require.NoError(t, createTestTopic(ctx, testKafkaTopic, numPartitions, 1))
+
+	producerCtx, producerCancel := context.WithCancel(ctx)
+	defer producerCancel()
+	prod, producerDone := runMultiPartitionProducer(t, producerCtx, testKafkaTopic, numPartitions, 50*time.Millisecond)
+
+	consumed := newConsumedTracker()
+	thresholdReached := make(chan struct{})
+	var thresholdOnce sync.Once
+	const triggerAfter = 10
+
+	mockDispatcher := &MockDispatcher{
+		onDispatchCommand: func(_ context.Context, _ string, data []byte) error {
+			consumed.add(string(data))
+			if consumed.uniqueCount() >= triggerAfter {
+				thresholdOnce.Do(func() { close(thresholdReached) })
+			}
+			return nil
+		},
+	}
+
+	var logBuf syncBuffer
+	fatalErrCh := make(chan error, 1)
+	config := KafkaConfig{
+		Brokers:       []string{testKafkaBrokerURL},
+		Topics:        []string{testKafkaTopic},
+		ConsumerGroup: consumerGroup,
+	}
+
+	consumer, err := NewKafkaConsumer(config, mockDispatcher, testCommonWithLogBuf(&logBuf))
+	require.NoError(t, err)
+	consumer.testOnlyConfig.injectFatalPollErrorCh = fatalErrCh
+
+	consumerCtx, consumerCancel := context.WithCancel(ctx)
+	consumerErr := runConsumerAsync(t, consumerCtx, consumer)
+
+	waitCh(t, thresholdReached, 30*time.Second, "timeout waiting for threshold messages")
+	t.Logf("threshold reached (unique=%d), injecting fatal error", consumed.uniqueCount())
+	consumedAtInjection := consumed.uniqueCount()
+
+	fatalErrCh <- errors.New("injected fatal poll error")
+
+	require.Eventually(t, func() bool {
+		return strings.Contains(logBuf.String(), "Kafka consumer client re-initialized")
+	}, 30*time.Second, 50*time.Millisecond, "expected client re-initialization log entry")
+
+	require.Eventually(t, func() bool {
+		return consumed.uniqueCount() >= consumedAtInjection+3
+	}, 30*time.Second, 50*time.Millisecond, "expected processing to resume after re-init")
+
+	producerCancel()
+	<-producerDone
+
+	produced := prod.snapshot()
+	require.Eventually(t, func() bool {
+		return consumed.uniqueCount() >= len(produced)
+	}, 30*time.Second, 100*time.Millisecond,
+		"expected all produced messages to be consumed")
+
+	assertNoMessageLoss(t, prod, consumed)
+	t.Logf("final: produced=%d, unique=%d, total=%d, redeliveries=%d",
+		len(produced), consumed.uniqueCount(), consumed.totalCount(), consumed.totalCount()-len(produced))
+
+	logs := logBuf.String()
+	require.Contains(t, logs, "fatal error polling Kafka, need client re-init")
+	require.Contains(t, logs, "start re-initializing Kafka consumer client")
+	require.Contains(t, logs, "Kafka consumer client re-initialized")
+
+	consumerCancel()
+	select {
+	case err := <-consumerErr:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(15 * time.Second):
+		t.Fatal("timeout waiting for consumer to close")
+	}
+}
+
+// TestKafkaConsumer_MultipleReInitsNoMessageLoss verifies that the consumer
+// survives multiple consecutive fatal errors, processes all produced messages,
+// and that committed offsets cover the full topic at the end.
+func TestKafkaConsumer_MultipleReInitsNoMessageLoss(t *testing.T) {
+	t.Parallel()
+	const (
+		numPartitions int32 = 4
+		numReInits          = 2
+	)
+	testKafkaTopic := "centrifugo_consumer_test_" + uuid.New().String()
+	consumerGroup := uuid.New().String()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	require.NoError(t, createTestTopic(ctx, testKafkaTopic, numPartitions, 1))
+
+	producerCtx, producerCancel := context.WithCancel(ctx)
+	defer producerCancel()
+	prod, producerDone := runMultiPartitionProducer(t, producerCtx, testKafkaTopic, numPartitions, 50*time.Millisecond)
+
+	consumed := newConsumedTracker()
+	mockDispatcher := &MockDispatcher{
+		onDispatchCommand: func(_ context.Context, _ string, data []byte) error {
+			consumed.add(string(data))
+			return nil
+		},
+	}
+
+	var logBuf syncBuffer
+	fatalErrCh := make(chan error, 1)
+	config := KafkaConfig{
+		Brokers:       []string{testKafkaBrokerURL},
+		Topics:        []string{testKafkaTopic},
+		ConsumerGroup: consumerGroup,
+	}
+	consumer, err := NewKafkaConsumer(config, mockDispatcher, testCommonWithLogBuf(&logBuf))
+	require.NoError(t, err)
+	consumer.testOnlyConfig.injectFatalPollErrorCh = fatalErrCh
+
+	consumerCtx, consumerCancel := context.WithCancel(ctx)
+	consumerErr := runConsumerAsync(t, consumerCtx, consumer)
+
+	require.Eventually(t, func() bool {
+		return consumed.uniqueCount() >= 5
+	}, 30*time.Second, 50*time.Millisecond, "expected initial messages to be consumed")
+
+	for i := range numReInits {
+		fatalErrCh <- fmt.Errorf("injected fatal error #%d", i+1)
+		t.Logf("injected fatal error %d/%d (unique=%d)", i+1, numReInits, consumed.uniqueCount())
+
+		expectedReInits := i + 1
+		require.Eventually(t, func() bool {
+			return strings.Count(logBuf.String(), "Kafka consumer client re-initialized") >= expectedReInits
+		}, 30*time.Second, 50*time.Millisecond,
+			fmt.Sprintf("expected at least %d re-init log entries", expectedReInits))
+
+		baseline := consumed.uniqueCount()
+		require.Eventually(t, func() bool {
+			return consumed.uniqueCount() >= baseline+3
+		}, 30*time.Second, 50*time.Millisecond,
+			"expected processing to resume after re-init before next injection")
+	}
+
+	producerCancel()
+	<-producerDone
+
+	produced := prod.snapshot()
+	require.Eventually(t, func() bool {
+		return consumed.uniqueCount() >= len(produced)
+	}, 30*time.Second, 100*time.Millisecond,
+		"expected all produced messages to be consumed")
+
+	assertNoMessageLoss(t, prod, consumed)
+
+	logs := logBuf.String()
+	require.GreaterOrEqual(t, strings.Count(logs, "fatal error polling Kafka, need client re-init"), numReInits)
+	require.GreaterOrEqual(t, strings.Count(logs, "start re-initializing Kafka consumer client"), numReInits)
+	require.GreaterOrEqual(t, strings.Count(logs, "Kafka consumer client re-initialized"), numReInits)
+
+	t.Logf("after %d re-inits: produced=%d, unique=%d, total=%d, redeliveries=%d",
+		numReInits, len(produced), consumed.uniqueCount(), consumed.totalCount(),
+		consumed.totalCount()-len(produced))
+
+	consumerCancel()
+	select {
+	case err := <-consumerErr:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(15 * time.Second):
+		t.Fatal("timeout waiting for consumer to close")
+	}
+}
+
+// TestKafkaConsumer_ReInitPreservesCommittedOffsets verifies that after a fatal
+// error and client re-initialization, committed offsets eventually cover every
+// partition's full content.
+func TestKafkaConsumer_ReInitPreservesCommittedOffsets(t *testing.T) {
+	t.Parallel()
+	const numPartitions int32 = 4
+	testKafkaTopic := "centrifugo_consumer_test_" + uuid.New().String()
+	consumerGroup := uuid.New().String()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	require.NoError(t, createTestTopic(ctx, testKafkaTopic, numPartitions, 1))
+
+	producerCtx, producerCancel := context.WithCancel(ctx)
+	defer producerCancel()
+	prod, producerDone := runMultiPartitionProducer(t, producerCtx, testKafkaTopic, numPartitions, 50*time.Millisecond)
+
+	consumed := newConsumedTracker()
+	mockDispatcher := &MockDispatcher{
+		onDispatchCommand: func(_ context.Context, _ string, data []byte) error {
+			consumed.add(string(data))
+			return nil
+		},
+	}
+
+	var logBuf syncBuffer
+	fatalErrCh := make(chan error, 1)
+	config := KafkaConfig{
+		Brokers:       []string{testKafkaBrokerURL},
+		Topics:        []string{testKafkaTopic},
+		ConsumerGroup: consumerGroup,
+	}
+	consumer, err := NewKafkaConsumer(config, mockDispatcher, testCommonWithLogBuf(&logBuf))
+	require.NoError(t, err)
+	consumer.testOnlyConfig.injectFatalPollErrorCh = fatalErrCh
+
+	consumerCtx, consumerCancel := context.WithCancel(ctx)
+	consumerErr := runConsumerAsync(t, consumerCtx, consumer)
+
+	require.Eventually(t, func() bool {
+		return consumed.uniqueCount() >= 5
+	}, 30*time.Second, 50*time.Millisecond, "timeout waiting for initial messages")
+
+	fatalErrCh <- errors.New("injected fatal error")
+	require.Eventually(t, func() bool {
+		return strings.Contains(logBuf.String(), "Kafka consumer client re-initialized")
+	}, 30*time.Second, 50*time.Millisecond, "expected re-init completion")
+
+	baseline := consumed.uniqueCount()
+	require.Eventually(t, func() bool {
+		return consumed.uniqueCount() >= baseline+5
+	}, 30*time.Second, 50*time.Millisecond, "expected processing to resume after re-init")
+
+	producerCancel()
+	<-producerDone
+
+	produced := prod.snapshot()
+	require.Eventually(t, func() bool {
+		return consumed.uniqueCount() >= len(produced)
+	}, 30*time.Second, 100*time.Millisecond,
+		"expected all produced messages to be consumed")
+
+	assertNoMessageLoss(t, prod, consumed)
+
+	logs := logBuf.String()
+	require.Contains(t, logs, "fatal error polling Kafka, need client re-init")
+	require.Contains(t, logs, "start re-initializing Kafka consumer client")
+	require.Contains(t, logs, "Kafka consumer client re-initialized")
+
+	// Wait until committed offsets cover every partition's full content.
+	require.Eventually(t, func() bool {
+		cl, err := kgo.NewClient(kgo.SeedBrokers(testKafkaBrokerURL))
+		if err != nil {
+			return false
+		}
+		defer cl.Close()
+		admClient := kadm.NewClient(cl)
+		defer admClient.Close()
+
+		queryCtx, queryCancel := context.WithTimeout(ctx, 5*time.Second)
+		defer queryCancel()
+
+		endOffsets, err := admClient.ListEndOffsets(queryCtx, testKafkaTopic)
+		if err != nil {
+			return false
+		}
+		committed, err := admClient.FetchOffsets(queryCtx, consumerGroup)
+		if err != nil {
+			return false
+		}
+		allMatch := true
+		endOffsets.Each(func(o kadm.ListedOffset) {
+			c, ok := committed.Lookup(testKafkaTopic, o.Partition)
+			if !ok || c.At != o.Offset {
+				allMatch = false
+			}
+		})
+		return allMatch
+	}, 30*time.Second, 200*time.Millisecond,
+		"expected committed offsets to match end offsets on all partitions")
+
+	consumerCancel()
+	select {
+	case err := <-consumerErr:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(15 * time.Second):
+		t.Fatal("timeout waiting for consumer to close")
+	}
+}
+
+// TestKafkaConsumer_GracefulShutdownDuringReInit verifies that cancelling the
+// context after a fatal error has triggered the re-init flow causes Run to
+// return promptly with the context error. The test waits for the "start
+// re-initializing" log entry before cancelling — re-init can occasionally
+// complete before the cancellation lands, in which case we are cancelling
+// the next poll loop iteration rather than mid-re-init proper. Either way,
+// Run must return within the 10s bound.
+func TestKafkaConsumer_GracefulShutdownDuringReInit(t *testing.T) {
+	t.Parallel()
+	const numPartitions int32 = 4
+	testKafkaTopic := "centrifugo_consumer_test_" + uuid.New().String()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	require.NoError(t, createTestTopic(ctx, testKafkaTopic, numPartitions, 1))
+
+	producerCtx, producerCancel := context.WithCancel(ctx)
+	_, producerDone := runMultiPartitionProducer(t, producerCtx, testKafkaTopic, numPartitions, 100*time.Millisecond)
+	defer func() {
+		producerCancel()
+		<-producerDone
+	}()
+
+	eventReceived := make(chan struct{})
+	var eventOnce sync.Once
+	mockDispatcher := &MockDispatcher{
+		onDispatchCommand: func(_ context.Context, _ string, _ []byte) error {
+			eventOnce.Do(func() { close(eventReceived) })
+			return nil
+		},
+	}
+
+	var logBuf syncBuffer
+	fatalErrCh := make(chan error, 1)
+	config := KafkaConfig{
+		Brokers:       []string{testKafkaBrokerURL},
+		Topics:        []string{testKafkaTopic},
+		ConsumerGroup: uuid.New().String(),
+	}
+	consumer, err := NewKafkaConsumer(config, mockDispatcher, testCommonWithLogBuf(&logBuf))
+	require.NoError(t, err)
+	consumer.testOnlyConfig.injectFatalPollErrorCh = fatalErrCh
+
+	consumerCtx, consumerCancel := context.WithCancel(ctx)
+	consumerErr := runConsumerAsync(t, consumerCtx, consumer)
+
+	waitCh(t, eventReceived, 30*time.Second, "timeout waiting for first event")
+
+	fatalErrCh <- errors.New("injected fatal error for shutdown test")
+
+	// Wait until the re-init flow has actually started, so we know we're
+	// cancelling the context mid-re-init.
+	require.Eventually(t, func() bool {
+		s := logBuf.String()
+		return strings.Contains(s, "fatal error polling Kafka, need client re-init") &&
+			strings.Contains(s, "start re-initializing Kafka consumer client")
+	}, 15*time.Second, 25*time.Millisecond, "expected re-init flow to start before context cancellation")
+
+	shutdownStart := time.Now()
+	consumerCancel()
+
+	select {
+	case runErr := <-consumerErr:
+		shutdownDuration := time.Since(shutdownStart)
+		require.ErrorIs(t, runErr, context.Canceled)
+		require.Less(t, shutdownDuration, 10*time.Second,
+			"consumer should shut down promptly when context is cancelled during re-init")
+		t.Logf("consumer shut down in %v after context cancellation", shutdownDuration)
+	case <-time.After(15 * time.Second):
+		t.Fatal("consumer did not shut down in time after context cancellation during re-init")
+	}
+
+	logs := logBuf.String()
+	require.Contains(t, logs, "fatal error polling Kafka, need client re-init")
+	require.Contains(t, logs, "start re-initializing Kafka consumer client")
 }
 
 func BenchmarkKafkaConsumer_ConsumePreLoadedTopic(b *testing.B) {


### PR DESCRIPTION
Changes:

- Classify fetch errors returned by `PollRecords` and only re-initialize the consumer client on errors that actually require it. Errors classified as retriable by `kerr.IsRetriable` or `kgo.IsRetryableBrokerErr`, plus `*kgo.ErrDataLoss` (handled by franz-go via offset reset), are now logged and ignored — records from healthy partitions in the same fetch are still processed.
- Detect shutdown via `ctx.Err()` rather than `errors.Is(err, context.Canceled)`. franz-go can surface `context.DeadlineExceeded` on shutdown when the parent context has a deadline; the old check would have treated that as a real polling failure and triggered a needless re-init.
- Log `context.Canceled` from `CommitMarkedOffsets` in the `OnPartitionsRevoked` callback at info level — it's the expected outcome when the app context is already cancelled during shutdown, not an error.
- Defensive: if `PollRecords` reports `IsClientClosed` unexpectedly, surface a warning and trigger re-init instead of silently treating the poll as a clean exit.
- Add timing fields (`was_running_for`, `was_polling_for`, `elapsed`) to start/stop and re-init log entries so operational logs show how long phases took.
- Add a test seam (`injectFatalPollErrorCh` on the existing `testOnlyConfig`) for exercising the re-init path deterministically.

## Tests

New integration tests (require the Kafka container) covering the re-init flow end-to-end:

- `TestKafkaConsumer_NoMessageLossOnReInit` — one injected fatal poll error → every produced message is eventually consumed.
- `TestKafkaConsumer_MultipleReInitsNoMessageLoss` — two consecutive injected fatal errors → consumer recovers each time and no messages are lost.
- `TestKafkaConsumer_ReInitPreservesCommittedOffsets` — after re-init, committed offsets converge to partition end offsets on every partition.
- `TestKafkaConsumer_GracefulShutdownDuringReInit` — cancelling the context while the consumer is in the re-init flow returns from `Run` within a 10 s bound.

All 12 Kafka tests run in parallel under `-race` and complete in ~11 s wall-clock against a local Kafka container.