### PR TITLE
Fix outbox flaky test

### DIFF
--- a/internal/pgmapbroker/pgmapbroker.go
+++ b/internal/pgmapbroker/pgmapbroker.go
@@ -216,6 +216,14 @@ type PostgresMapBroker struct {
 	cancelCtx    context.Context
 	cancelFunc   context.CancelFunc
 	notifyCh     chan struct{} // nil when UseNotify is false
+
+	// workersInitialized[i] flips true once shard i's outbox worker completes
+	// its first InitCursor (i.e., has snapshotted MAX(id) and is actively
+	// polling). Used by tests to publish only after the InitCursor snapshot
+	// is taken — otherwise a publish committed between lock acquisition and
+	// the snapshot would be observed by InitCursor and skipped. Only the
+	// LockWorker path sets this; left as nil for the non-fan-out path.
+	workersInitialized []atomic.Bool
 }
 
 var _ centrifuge.MapBroker = (*PostgresMapBroker)(nil)
@@ -460,13 +468,14 @@ func NewPostgresMapBroker(n *centrifuge.Node, conf PostgresMapBrokerConfig) (*Po
 	ctx, cancel := context.WithCancel(context.Background())
 
 	e := &PostgresMapBroker{
-		node:       n,
-		conf:       conf,
-		names:      newPgNames(conf.TablePrefix, conf.BinaryData),
-		pool:       pool,
-		closeCh:    make(chan struct{}),
-		cancelCtx:  ctx,
-		cancelFunc: cancel,
+		node:               n,
+		conf:               conf,
+		names:              newPgNames(conf.TablePrefix, conf.BinaryData),
+		pool:               pool,
+		closeCh:            make(chan struct{}),
+		cancelCtx:          ctx,
+		cancelFunc:         cancel,
+		workersInitialized: make([]atomic.Bool, conf.NumShards),
 	}
 	e.sampler = newMapMetricsSampler(e)
 
@@ -1820,8 +1829,16 @@ func (e *PostgresMapBroker) runOutboxWorkerWithLock(workerIdx int, initialCursor
 		// so we re-query MAX(id) each time. Returning a fixed startup value
 		// is not a correctness bug (subscribers dedup by offset) but would
 		// re-fanout every row already forwarded by a previous lock holder,
-		// growing linearly with broker uptime.
-		InitCursor: e.initOutboxCursor,
+		// growing linearly with broker uptime. The race window between lock
+		// acquisition and this snapshot is recovered subscriber-side via
+		// insufficient_state.
+		InitCursor: func(ctx context.Context, p *pgxpool.Pool) (int64, error) {
+			cursor, err := e.initOutboxCursor(ctx, p)
+			if err == nil {
+				e.workersInitialized[workerIdx].Store(true)
+			}
+			return cursor, err
+		},
 		ProcessBatch: func(ctx context.Context, pool *pgxpool.Pool, cursor int64, shardIDs []int) (int, int64, error) {
 			return e.processOutboxBatch(ctx, pool, cursor, shardIDs, buf)
 		},

--- a/internal/pgmapbroker/pgmapbroker_test.go
+++ b/internal/pgmapbroker/pgmapbroker_test.go
@@ -2568,6 +2568,33 @@ func TestPostgresMapBroker_AllColumnTypes(t *testing.T) {
 // Redis Broker Fan-out Tests (advisory lock mode)
 // ============================================================================
 
+// waitForAllShardLocksHeld blocks until every shard's advisory lock has been
+// acquired by a worker on this broker. Use it before publishing in fan-out
+// tests: runOutboxWorkerWithLock re-queries MAX(id) inside InitCursor on each
+// acquisition, so a publish that lands before the worker's first InitCursor
+// would be observed by the snapshot and silently skipped. In production this
+// race is benign — subscribers recover the gap via insufficient_state — but
+// tests register a raw BrokerEventHandler that bypasses that recovery path.
+func waitForAllShardLocksHeld(tb testing.TB, broker *PostgresMapBroker) {
+	tb.Helper()
+	ctx := context.Background()
+	baseID := broker.conf.Outbox.AdvisoryLockBaseID
+	require.Eventually(tb, func() bool {
+		for i := 0; i < broker.conf.NumShards; i++ {
+			var count int
+			if err := broker.pool.QueryRow(ctx,
+				"SELECT count(*) FROM pg_locks WHERE locktype = 'advisory' AND objid = $1 AND granted = true",
+				baseID+int64(i)).Scan(&count); err != nil {
+				return false
+			}
+			if count < 1 {
+				return false
+			}
+		}
+		return true
+	}, 10*time.Second, 50*time.Millisecond, "all shard advisory locks should be held")
+}
+
 // newTestRedisBrokerForFanout creates a RedisBroker suitable for PG fan-out testing.
 // Does NOT call node.Run() or SetBroker — the PG broker handles registration.
 func newTestRedisBrokerForFanout(tb testing.TB, n *centrifuge.Node) *centrifuge.RedisBroker {
@@ -2657,8 +2684,10 @@ func TestPostgresMapBroker_RedisFanout_Delivery(t *testing.T) {
 	err = broker.Subscribe(channel)
 	require.NoError(t, err)
 
-	// Give workers time to start + subscribe to propagate.
-	time.Sleep(200 * time.Millisecond)
+	// Wait deterministically for all shard locks to be held: the LockWorker
+	// snapshots MAX(id) inside InitCursor on each acquisition, so any publish
+	// that lands before that snapshot would be skipped.
+	waitForAllShardLocksHeld(t, broker)
 
 	// Publish via PG broker.
 	const numMessages = 5
@@ -2764,7 +2793,7 @@ func TestPostgresMapBroker_RedisFanout_Delta(t *testing.T) {
 	err = broker.Subscribe(channel)
 	require.NoError(t, err)
 
-	time.Sleep(200 * time.Millisecond)
+	waitForAllShardLocksHeld(t, broker)
 
 	waitEvent := func(t *testing.T) pubEvent {
 		t.Helper()
@@ -3068,7 +3097,7 @@ func TestPostgresMapBroker_RedisFanout_ClientInfo(t *testing.T) {
 	err = broker.Subscribe(channel)
 	require.NoError(t, err)
 
-	time.Sleep(200 * time.Millisecond)
+	waitForAllShardLocksHeld(t, broker)
 
 	info := &centrifuge.ClientInfo{
 		ClientID: "c1",

--- a/internal/pgmapbroker/pgmapbroker_test.go
+++ b/internal/pgmapbroker/pgmapbroker_test.go
@@ -2568,31 +2568,26 @@ func TestPostgresMapBroker_AllColumnTypes(t *testing.T) {
 // Redis Broker Fan-out Tests (advisory lock mode)
 // ============================================================================
 
-// waitForAllShardLocksHeld blocks until every shard's advisory lock has been
-// acquired by a worker on this broker. Use it before publishing in fan-out
-// tests: runOutboxWorkerWithLock re-queries MAX(id) inside InitCursor on each
-// acquisition, so a publish that lands before the worker's first InitCursor
+// waitForAllShardLocksHeld blocks until every shard's outbox worker has
+// completed its first InitCursor snapshot — i.e., has snapshotted MAX(id) and
+// is actively polling. Use it before publishing in fan-out tests: otherwise a
+// publish committed between lock acquisition and the InitCursor snapshot
 // would be observed by the snapshot and silently skipped. In production this
 // race is benign — subscribers recover the gap via insufficient_state — but
 // tests register a raw BrokerEventHandler that bypasses that recovery path.
+//
+// Waiting on pg_locks is insufficient: the lock is held the moment
+// pg_try_advisory_lock returns, but InitCursor runs strictly after that.
 func waitForAllShardLocksHeld(tb testing.TB, broker *PostgresMapBroker) {
 	tb.Helper()
-	ctx := context.Background()
-	baseID := broker.conf.Outbox.AdvisoryLockBaseID
 	require.Eventually(tb, func() bool {
 		for i := 0; i < broker.conf.NumShards; i++ {
-			var count int
-			if err := broker.pool.QueryRow(ctx,
-				"SELECT count(*) FROM pg_locks WHERE locktype = 'advisory' AND objid = $1 AND granted = true",
-				baseID+int64(i)).Scan(&count); err != nil {
-				return false
-			}
-			if count < 1 {
+			if !broker.workersInitialized[i].Load() {
 				return false
 			}
 		}
 		return true
-	}, 10*time.Second, 50*time.Millisecond, "all shard advisory locks should be held")
+	}, 10*time.Second, 50*time.Millisecond, "all shard workers should have initialized cursors")
 }
 
 // newTestRedisBrokerForFanout creates a RedisBroker suitable for PG fan-out testing.


### PR DESCRIPTION
## Proposed changes

Fixes CI failure:

```
=== RUN   TestPostgresMapBroker_RedisFanout_Delivery
{"level":"info","shard":0,"time":"2026-05-26T04:34:57Z","message":"outbox worker: acquired advisory lock"}
{"level":"info","shard":1,"time":"2026-05-26T04:34:57Z","message":"outbox worker: acquired advisory lock"}
{"level":"info","shard":2,"time":"2026-05-26T04:34:57Z","message":"outbox worker: acquired advisory lock"}
{"level":"info","shard":3,"time":"2026-05-26T04:34:57Z","message":"outbox worker: acquired advisory lock"}
    pgmapbroker_test.go:2682: timeout waiting for publications, received 0/5
--- FAIL: TestPostgresMapBroker_RedisFanout_Delivery (15.61s)
=== RUN   TestPostgresMapBroker_RedisFanout_Delta
{"level":"info","shard":1,"time":"2026-05-26T04:35:12Z","message":"outbox worker: acquired advisory lock"}
{"level":"info","shard":2,"time":"2026-05-26T04:35:13Z","message":"outbox worker: acquired advisory lock"}
{"level":"info","shard":3,"time":"2026-05-26T04:35:13Z","message":"outbox worker: acquired advisory lock"}
{"level":"info","shard":0,"time":"2026-05-26T04:35:13Z","message":"outbox worker: acquired advisory lock"}
--- PASS: TestPostgresMapBroker_RedisFanout_Delta (0.35s)
=== RUN   TestPostgresMapBroker_RedisFanout_AdvisoryLockExclusion
{"level":"info","shard":0,"time":"2026-05-26T04:35:13Z","message":"outbox worker: acquired advisory lock"}
{"level":"info","shard":1,"time":"2026-05-26T04:35:13Z","message":"outbox worker: acquired advisory lock"}
--- PASS: TestPostgresMapBroker_RedisFanout_AdvisoryLockExclusion (0.37s)
=== RUN   TestPostgresMapBroker_RedisFanout_ClientInfo
{"level":"info","shard":1,"time":"2026-05-26T04:35:13Z","message":"outbox worker: acquired advisory lock"}
{"level":"info","shard":2,"time":"2026-05-26T04:35:13Z","message":"outbox worker: acquired advisory lock"}
{"level":"info","shard":0,"time":"2026-05-26T04:35:13Z","message":"outbox worker: acquired advisory lock"}
{"level":"info","shard":3,"time":"2026-05-26T04:35:13Z","message":"outbox worker: acquired advisory lock"}
    pgmapbroker_test.go:3102: timeout waiting for publication event
--- FAIL: TestPostgresMapBroker_RedisFanout_ClientInfo (15.32s)
```
