### PR TITLE
Fix one more flaky pg test

### DIFF
--- a/internal/pgoutbox/listener.go
+++ b/internal/pgoutbox/listener.go
@@ -40,6 +40,13 @@ type NotificationListener struct {
 	// ErrorFn is called on connection and LISTEN errors. Must be safe for
 	// concurrent use (in practice this listener runs in one goroutine).
 	ErrorFn func(msg string, err error)
+
+	// OnReady, if set, is invoked after each successful LISTEN — i.e., once
+	// the listener is bound and will deliver subsequent NOTIFY signals on
+	// the channel. Fires again after each reconnect. Used by tests that
+	// need to publish only after the listener is bound; the production
+	// path treats early NOTIFYs as benign (PollInterval is the fallback).
+	OnReady func()
 }
 
 // Run starts the listener loop. Returns when ctx is cancelled or closeCh
@@ -83,6 +90,10 @@ func (l *NotificationListener) Run(ctx context.Context, closeCh <-chan struct{})
 		}
 
 		backoff = time.Second
+
+		if l.OnReady != nil {
+			l.OnReady()
+		}
 
 		// Inner notification loop.
 		for {

--- a/internal/pgstreambroker/outbox.go
+++ b/internal/pgstreambroker/outbox.go
@@ -103,6 +103,7 @@ func (e *PostgresStreamBroker) runNotificationListener() {
 		Channel:  e.names.notifyChannel,
 		NotifyCh: e.notifyCh,
 		ErrorFn:  e.logErrorMsg,
+		OnReady:  func() { e.notifyListenerReady.Store(true) },
 	}
 	l.Run(e.cancelCtx, e.closeCh)
 }

--- a/internal/pgstreambroker/pgstreambroker.go
+++ b/internal/pgstreambroker/pgstreambroker.go
@@ -369,6 +369,14 @@ type PostgresStreamBroker struct {
 	cancelFunc   context.CancelFunc
 	notifyCh     chan struct{}
 	sampler      *metricsSampler
+
+	// notifyListenerReady flips true after the LISTEN command succeeds on
+	// the notification listener's connection. Used by tests to publish only
+	// after the listener is bound — a publish whose NOTIFY fires before
+	// LISTEN runs would be dropped, and with a long PollInterval the test
+	// would time out. Production tolerates this race because PollInterval
+	// is the fallback.
+	notifyListenerReady atomic.Bool
 }
 
 var _ centrifuge.Broker = (*PostgresStreamBroker)(nil)

--- a/internal/pgstreambroker/pgstreambroker_test.go
+++ b/internal/pgstreambroker/pgstreambroker_test.go
@@ -1108,6 +1108,13 @@ func TestPostgresStreamBroker_UseNotify_WakesIdleWorker(t *testing.T) {
 		_ = node.Shutdown(ctx)
 	})
 
+	// Wait for the LISTEN to be bound. With PollInterval=30s, a publish whose
+	// NOTIFY fires before LISTEN executes would be dropped and the worker
+	// would idle for 30s — the test's 10s deadline would expire first.
+	require.Eventually(t, e.notifyListenerReady.Load,
+		10*time.Second, 50*time.Millisecond,
+		"notification listener did not bind LISTEN")
+
 	publishAndWait := func(timeout time.Duration, msg string) bool {
 		ch := make(chan struct{}, 1)
 		deliveredPtr.Store(&ch)


### PR DESCRIPTION
```
❯ === RUN   TestPostgresStreamBroker_UseNotify_WakesIdleWorker
      pgstreambroker_test.go:1130:
              Error Trace:    /home/runner/work/centrifugo/centrifugo/internal/pgstreambroker/pgstreambroker_test.go:1130
              Error:          Should be true
              Test:           TestPostgresStreamBroker_UseNotify_WakesIdleWorker
              Messages:       worker did not deliver first publish within 10s
  --- FAIL: TestPostgresStreamBroker_UseNotify_WakesIdleWorker (10.23s)
```
