### PR TITLE
Support Google Cloud ADC auth for OpenTelemetry OTLP export

### DIFF
--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -142,7 +142,7 @@ func Run(cmd *cobra.Command, configFile string) {
 	}
 
 	if cfg.OpenTelemetry.Enabled {
-		_, err := telemetry.SetupTracing(context.Background())
+		_, err := telemetry.SetupTracing(context.Background(), cfg.OpenTelemetry.GoogleCloudAuth)
 		if err != nil {
 			log.Fatal().Err(err).Msg("error setting up opentelemetry tracing")
 		}

--- a/internal/cli/configdoc/schema.json
+++ b/internal/cli/configdoc/schema.json
@@ -13082,6 +13082,16 @@
         "default": "",
         "comment": "",
         "is_complex_type": false
+      },
+      {
+        "field": "opentelemetry.google_cloud_auth",
+        "name": "google_cloud_auth",
+        "go_name": "GoogleCloudAuth",
+        "level": 2,
+        "type": "bool",
+        "default": "",
+        "comment": "GoogleCloudAuth, when true, injects Google Cloud Application Default\nCredentials (ADC) into the OTLP gRPC exporter as per-RPC OAuth2 tokens.\nThis allows exporting directly to Google Cloud's OTLP endpoint\n(telemetry.googleapis.com) without a sidecar collector. Requires the\ngRPC exporter protocol (OTEL_EXPORTER_OTLP_PROTOCOL=grpc); it has no\neffect on the http/protobuf exporter. The endpoint and target project\nare still configured via the standard OTEL_EXPORTER_OTLP_* environment\nvariables (e.g. OTEL_EXPORTER_OTLP_ENDPOINT=https://telemetry.googleapis.com\nand OTEL_RESOURCE_ATTRIBUTES=gcp.project_id=PROJECT_ID).",
+        "is_complex_type": false
       }
     ]
   },

--- a/internal/configtypes/types.go
+++ b/internal/configtypes/types.go
@@ -289,6 +289,16 @@ type OpenTelemetry struct {
 	Enabled   bool `mapstructure:"enabled" json:"enabled" envconfig:"enabled" yaml:"enabled" toml:"enabled"`
 	API       bool `mapstructure:"api" json:"api" envconfig:"api" yaml:"api" toml:"api"`
 	Consuming bool `mapstructure:"consuming" json:"consuming" envconfig:"consuming" yaml:"consuming" toml:"consuming"`
+	// GoogleCloudAuth, when true, injects Google Cloud Application Default
+	// Credentials (ADC) into the OTLP gRPC exporter as per-RPC OAuth2 tokens.
+	// This allows exporting directly to Google Cloud's OTLP endpoint
+	// (telemetry.googleapis.com) without a sidecar collector. Requires the
+	// gRPC exporter protocol (OTEL_EXPORTER_OTLP_PROTOCOL=grpc); it has no
+	// effect on the http/protobuf exporter. The endpoint and target project
+	// are still configured via the standard OTEL_EXPORTER_OTLP_* environment
+	// variables (e.g. OTEL_EXPORTER_OTLP_ENDPOINT=https://telemetry.googleapis.com
+	// and OTEL_RESOURCE_ATTRIBUTES=gcp.project_id=PROJECT_ID).
+	GoogleCloudAuth bool `mapstructure:"google_cloud_auth" json:"google_cloud_auth" envconfig:"google_cloud_auth" yaml:"google_cloud_auth" toml:"google_cloud_auth"`
 }
 
 type HttpAPI struct {

--- a/internal/telemetry/provider.go
+++ b/internal/telemetry/provider.go
@@ -17,15 +17,22 @@ import (
 	"go.opentelemetry.io/otel/sdk/resource"
 	"go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.20.0"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/oauth"
 )
 
-func SetupTracing(ctx context.Context) (*trace.TracerProvider, error) {
+// googleCloudAuthScope is the OAuth2 scope used when authenticating to Google
+// Cloud's OTLP endpoint (telemetry.googleapis.com) with Application Default
+// Credentials.
+const googleCloudAuthScope = "https://www.googleapis.com/auth/cloud-platform"
+
+func SetupTracing(ctx context.Context, googleCloudAuth bool) (*trace.TracerProvider, error) {
 	exporterProtocol := os.Getenv("OTEL_EXPORTER_OTLP_PROTOCOL")
 	if exporterProtocol == "" {
 		exporterProtocol = "http/protobuf"
 	}
 
-	exporter, err := createExporter(ctx, exporterProtocol)
+	exporter, err := createExporter(ctx, exporterProtocol, googleCloudAuth)
 	if err != nil {
 		return nil, err
 	}
@@ -65,14 +72,28 @@ func (e ErrorHandlerImpl) Handle(err error) {
 	log.Err(err).Msg("opentelemetry error")
 }
 
-func createExporter(ctx context.Context, exporterProtocol string) (*otlptrace.Exporter, error) {
+func createExporter(ctx context.Context, exporterProtocol string, googleCloudAuth bool) (*otlptrace.Exporter, error) {
 	if exporterProtocol == "grpc" {
-		return otlptracegrpc.New(
-			ctx,
-		)
+		var opts []otlptracegrpc.Option
+		if googleCloudAuth {
+			// Inject Google Cloud Application Default Credentials as per-RPC
+			// OAuth2 tokens so the exporter can authenticate against Google
+			// Cloud's OTLP endpoint (telemetry.googleapis.com). The token
+			// source refreshes automatically; the metadata server lookup is
+			// lazy and happens on first export, not at startup.
+			creds, err := oauth.NewApplicationDefault(ctx, googleCloudAuthScope)
+			if err != nil {
+				return nil, fmt.Errorf("error creating Google Cloud application default credentials: %w", err)
+			}
+			opts = append(opts, otlptracegrpc.WithDialOption(grpc.WithPerRPCCredentials(creds)))
+		}
+		return otlptracegrpc.New(ctx, opts...)
 	}
 
 	if exporterProtocol == "http/protobuf" {
+		if googleCloudAuth {
+			return nil, fmt.Errorf("opentelemetry google_cloud_auth requires the grpc exporter protocol (OTEL_EXPORTER_OTLP_PROTOCOL=grpc)")
+		}
 		return otlptracehttp.New(
 			ctx,
 		)


### PR DESCRIPTION
Adds an `opentelemetry.google_cloud_auth` boolean option. When enabled, Centrifugo injects Google Cloud Application Default Credentials (ADC) into the OTLP **gRPC** exporter as per-RPC OAuth2 tokens.

This lets Centrifugo export traces (and, in Centrifugo PRO, metrics via the Prometheus bridge) straight to Google Cloud's OTLP endpoint (`telemetry.googleapis.com`) without running a sidecar collector just to attach GCP credentials.

## Why

The standard Go OTLP gRPC exporter doesn't attach ADC, so `telemetry.googleapis.com` rejects requests as unauthenticated. Previously the only options were a sidecar/collector to inject credentials. This flag closes that gap with a single dial option.

## How

- New `GoogleCloudAuth` field on the base `OpenTelemetry` config struct.
- On the gRPC exporter path, the credentials come from `oauth.NewApplicationDefault(ctx, "https://www.googleapis.com/auth/cloud-platform")`, attached via `grpc.WithPerRPCCredentials`.
- The token source is lazy and self-refreshing — the metadata-server lookup happens on the first export, not at startup, so there is no added startup I/O.
- Setting the flag with `http/protobuf` returns a clear error (token refresh only works cleanly over gRPC).
- No new dependencies (`google.golang.org/grpc/credentials/oauth` ships inside grpc).

## Usage

Enable the flag and point the exporter at Google Cloud via the standard OTEL env vars:

```yaml
opentelemetry:
  enabled: true
  google_cloud_auth: true
```

```
OTEL_EXPORTER_OTLP_PROTOCOL=grpc
OTEL_EXPORTER_OTLP_ENDPOINT=https://telemetry.googleapis.com
OTEL_RESOURCE_ATTRIBUTES=gcp.project_id=PROJECT_ID
```

> Note: set the target project via `OTEL_RESOURCE_ATTRIBUTES=gcp.project_id=...`, not via an `x-goog-user-project` header — Google warns the header can produce duplicate values and fail requests.

