### PR TITLE
Rename option to google_cloud_adc_auth, support http

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -52,6 +52,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.43.0
 	go.uber.org/automaxprocs v1.6.0
 	golang.org/x/crypto v0.52.0
+	golang.org/x/oauth2 v0.36.0
 	golang.org/x/sync v0.20.0
 	golang.org/x/time v0.15.0
 	google.golang.org/api v0.280.0
@@ -104,7 +105,6 @@ require (
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
-	golang.org/x/oauth2 v0.36.0 // indirect
 	google.golang.org/genproto v0.0.0-20260523011958-0a33c5d7ca68 // indirect
 )
 

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -121,7 +121,7 @@ func Run(cmd *cobra.Command, configFile string) {
 
 	// Initialize centralized metrics registry.
 	err = metrics.Init(metrics.Config{
-		Namespace:        "", // Use default "centrifugo" namespace.
+		Namespace:        "",  // Use default "centrifugo" namespace.
 		ConstLabels:      nil, // Can be populated from config in the future.
 		Registerer:       nil, // Use prometheus.DefaultRegisterer.
 		NativeHistograms: cfg.Prometheus.NativeHistograms,
@@ -142,7 +142,7 @@ func Run(cmd *cobra.Command, configFile string) {
 	}
 
 	if cfg.OpenTelemetry.Enabled {
-		_, err := telemetry.SetupTracing(context.Background(), cfg.OpenTelemetry.GoogleCloudAuth)
+		_, err := telemetry.SetupTracing(context.Background(), cfg.OpenTelemetry.GoogleCloudADCAuth)
 		if err != nil {
 			log.Fatal().Err(err).Msg("error setting up opentelemetry tracing")
 		}

--- a/internal/cli/configdoc/schema.json
+++ b/internal/cli/configdoc/schema.json
@@ -13084,13 +13084,13 @@
         "is_complex_type": false
       },
       {
-        "field": "opentelemetry.google_cloud_auth",
-        "name": "google_cloud_auth",
-        "go_name": "GoogleCloudAuth",
+        "field": "opentelemetry.google_cloud_adc_auth",
+        "name": "google_cloud_adc_auth",
+        "go_name": "GoogleCloudADCAuth",
         "level": 2,
         "type": "bool",
         "default": "",
-        "comment": "GoogleCloudAuth, when true, injects Google Cloud Application Default\nCredentials (ADC) into the OTLP gRPC exporter as per-RPC OAuth2 tokens.\nThis allows exporting directly to Google Cloud's OTLP endpoint\n(telemetry.googleapis.com) without a sidecar collector. Requires the\ngRPC exporter protocol (OTEL_EXPORTER_OTLP_PROTOCOL=grpc); it has no\neffect on the http/protobuf exporter. The endpoint and target project\nare still configured via the standard OTEL_EXPORTER_OTLP_* environment\nvariables (e.g. OTEL_EXPORTER_OTLP_ENDPOINT=https://telemetry.googleapis.com\nand OTEL_RESOURCE_ATTRIBUTES=gcp.project_id=PROJECT_ID).",
+        "comment": "GoogleCloudADCAuth, when true, authenticates the OTLP exporter with\nGoogle Cloud Application Default Credentials (ADC). This allows exporting\ndirectly to Google Cloud's OTLP endpoint (telemetry.googleapis.com)\nwithout a sidecar collector. Works with both exporter protocols: over\ngrpc the ADC token is attached as a per-RPC credential, over http/protobuf\nvia an OAuth2 http.Client transport; in both cases the token refreshes\nautomatically. The endpoint and target project are still configured via\nthe standard OTEL_EXPORTER_OTLP_* environment variables (e.g.\nOTEL_EXPORTER_OTLP_ENDPOINT=https://telemetry.googleapis.com and\nOTEL_RESOURCE_ATTRIBUTES=gcp.project_id=PROJECT_ID).",
         "is_complex_type": false
       }
     ]

--- a/internal/configtypes/types.go
+++ b/internal/configtypes/types.go
@@ -51,16 +51,16 @@ type Log struct {
 
 // Token common configuration.
 type Token struct {
-	HMACSecretKey                   string `mapstructure:"hmac_secret_key" json:"hmac_secret_key" envconfig:"hmac_secret_key" yaml:"hmac_secret_key" toml:"hmac_secret_key"`
-	HMACPreviousSecretKey           string `mapstructure:"hmac_previous_secret_key" json:"hmac_previous_secret_key" envconfig:"hmac_previous_secret_key" yaml:"hmac_previous_secret_key" toml:"hmac_previous_secret_key"`
-	HMACPreviousSecretKeyValidUntil int64  `mapstructure:"hmac_previous_secret_key_valid_until" json:"hmac_previous_secret_key_valid_until" envconfig:"hmac_previous_secret_key_valid_until" yaml:"hmac_previous_secret_key_valid_until" toml:"hmac_previous_secret_key_valid_until"`
-	RSAPublicKey                    string `mapstructure:"rsa_public_key" json:"rsa_public_key" envconfig:"rsa_public_key" yaml:"rsa_public_key" toml:"rsa_public_key"`
-	ECDSAPublicKey     string `mapstructure:"ecdsa_public_key" json:"ecdsa_public_key" envconfig:"ecdsa_public_key" yaml:"ecdsa_public_key" toml:"ecdsa_public_key"`
-	JWKSPublicEndpoint string `mapstructure:"jwks_public_endpoint" json:"jwks_public_endpoint" envconfig:"jwks_public_endpoint" yaml:"jwks_public_endpoint" toml:"jwks_public_endpoint"`
-	Audience           string `mapstructure:"audience" json:"audience" envconfig:"audience" yaml:"audience" toml:"audience"`
-	AudienceRegex      string `mapstructure:"audience_regex" json:"audience_regex" envconfig:"audience_regex" yaml:"audience_regex" toml:"audience_regex"`
-	Issuer             string `mapstructure:"issuer" json:"issuer" envconfig:"issuer" yaml:"issuer" toml:"issuer"`
-	IssuerRegex        string `mapstructure:"issuer_regex" json:"issuer_regex" envconfig:"issuer_regex" yaml:"issuer_regex" toml:"issuer_regex"`
+	HMACSecretKey                       string `mapstructure:"hmac_secret_key" json:"hmac_secret_key" envconfig:"hmac_secret_key" yaml:"hmac_secret_key" toml:"hmac_secret_key"`
+	HMACPreviousSecretKey               string `mapstructure:"hmac_previous_secret_key" json:"hmac_previous_secret_key" envconfig:"hmac_previous_secret_key" yaml:"hmac_previous_secret_key" toml:"hmac_previous_secret_key"`
+	HMACPreviousSecretKeyValidUntil     int64  `mapstructure:"hmac_previous_secret_key_valid_until" json:"hmac_previous_secret_key_valid_until" envconfig:"hmac_previous_secret_key_valid_until" yaml:"hmac_previous_secret_key_valid_until" toml:"hmac_previous_secret_key_valid_until"`
+	RSAPublicKey                        string `mapstructure:"rsa_public_key" json:"rsa_public_key" envconfig:"rsa_public_key" yaml:"rsa_public_key" toml:"rsa_public_key"`
+	ECDSAPublicKey                      string `mapstructure:"ecdsa_public_key" json:"ecdsa_public_key" envconfig:"ecdsa_public_key" yaml:"ecdsa_public_key" toml:"ecdsa_public_key"`
+	JWKSPublicEndpoint                  string `mapstructure:"jwks_public_endpoint" json:"jwks_public_endpoint" envconfig:"jwks_public_endpoint" yaml:"jwks_public_endpoint" toml:"jwks_public_endpoint"`
+	Audience                            string `mapstructure:"audience" json:"audience" envconfig:"audience" yaml:"audience" toml:"audience"`
+	AudienceRegex                       string `mapstructure:"audience_regex" json:"audience_regex" envconfig:"audience_regex" yaml:"audience_regex" toml:"audience_regex"`
+	Issuer                              string `mapstructure:"issuer" json:"issuer" envconfig:"issuer" yaml:"issuer" toml:"issuer"`
+	IssuerRegex                         string `mapstructure:"issuer_regex" json:"issuer_regex" envconfig:"issuer_regex" yaml:"issuer_regex" toml:"issuer_regex"`
 	UserIDClaim                         string `mapstructure:"user_id_claim" json:"user_id_claim" envconfig:"user_id_claim" yaml:"user_id_claim" toml:"user_id_claim"`
 	InsecureSkipJWKSEndpointSafetyCheck bool   `mapstructure:"insecure_skip_jwks_endpoint_safety_check" json:"insecure_skip_jwks_endpoint_safety_check" envconfig:"insecure_skip_jwks_endpoint_safety_check" yaml:"insecure_skip_jwks_endpoint_safety_check" toml:"insecure_skip_jwks_endpoint_safety_check"`
 }
@@ -289,16 +289,17 @@ type OpenTelemetry struct {
 	Enabled   bool `mapstructure:"enabled" json:"enabled" envconfig:"enabled" yaml:"enabled" toml:"enabled"`
 	API       bool `mapstructure:"api" json:"api" envconfig:"api" yaml:"api" toml:"api"`
 	Consuming bool `mapstructure:"consuming" json:"consuming" envconfig:"consuming" yaml:"consuming" toml:"consuming"`
-	// GoogleCloudAuth, when true, injects Google Cloud Application Default
-	// Credentials (ADC) into the OTLP gRPC exporter as per-RPC OAuth2 tokens.
-	// This allows exporting directly to Google Cloud's OTLP endpoint
-	// (telemetry.googleapis.com) without a sidecar collector. Requires the
-	// gRPC exporter protocol (OTEL_EXPORTER_OTLP_PROTOCOL=grpc); it has no
-	// effect on the http/protobuf exporter. The endpoint and target project
-	// are still configured via the standard OTEL_EXPORTER_OTLP_* environment
-	// variables (e.g. OTEL_EXPORTER_OTLP_ENDPOINT=https://telemetry.googleapis.com
-	// and OTEL_RESOURCE_ATTRIBUTES=gcp.project_id=PROJECT_ID).
-	GoogleCloudAuth bool `mapstructure:"google_cloud_auth" json:"google_cloud_auth" envconfig:"google_cloud_auth" yaml:"google_cloud_auth" toml:"google_cloud_auth"`
+	// GoogleCloudADCAuth, when true, authenticates the OTLP exporter with
+	// Google Cloud Application Default Credentials (ADC). This allows exporting
+	// directly to Google Cloud's OTLP endpoint (telemetry.googleapis.com)
+	// without a sidecar collector. Works with both exporter protocols: over
+	// grpc the ADC token is attached as a per-RPC credential, over http/protobuf
+	// via an OAuth2 http.Client transport; in both cases the token refreshes
+	// automatically. The endpoint and target project are still configured via
+	// the standard OTEL_EXPORTER_OTLP_* environment variables (e.g.
+	// OTEL_EXPORTER_OTLP_ENDPOINT=https://telemetry.googleapis.com and
+	// OTEL_RESOURCE_ATTRIBUTES=gcp.project_id=PROJECT_ID).
+	GoogleCloudADCAuth bool `mapstructure:"google_cloud_adc_auth" json:"google_cloud_adc_auth" envconfig:"google_cloud_adc_auth" yaml:"google_cloud_adc_auth" toml:"google_cloud_adc_auth"`
 }
 
 type HttpAPI struct {
@@ -806,19 +807,19 @@ func (d *Consumers) Decode(value string) error {
 
 // PostgresConsumerConfig is a configuration for Postgres async outbox table consumer.
 type PostgresConsumerConfig struct {
-	DSN                          string    `mapstructure:"dsn" json:"dsn" envconfig:"dsn" yaml:"dsn" toml:"dsn"`
-	OutboxTableName              string    `mapstructure:"outbox_table_name" json:"outbox_table_name" envconfig:"outbox_table_name" yaml:"outbox_table_name" toml:"outbox_table_name"`
-	NumPartitions                int       `mapstructure:"num_partitions" json:"num_partitions" envconfig:"num_partitions" default:"1" yaml:"num_partitions" toml:"num_partitions"`
-	PartitionSelectLimit         int       `mapstructure:"partition_select_limit" json:"partition_select_limit" envconfig:"partition_select_limit" default:"100" yaml:"partition_select_limit" toml:"partition_select_limit"`
-	PartitionPollInterval        Duration  `mapstructure:"partition_poll_interval" json:"partition_poll_interval" envconfig:"partition_poll_interval" default:"300ms" yaml:"partition_poll_interval" toml:"partition_poll_interval"`
-	PartitionNotificationChannel string    `mapstructure:"partition_notification_channel" json:"partition_notification_channel" envconfig:"partition_notification_channel" yaml:"partition_notification_channel" toml:"partition_notification_channel"`
+	DSN                          string   `mapstructure:"dsn" json:"dsn" envconfig:"dsn" yaml:"dsn" toml:"dsn"`
+	OutboxTableName              string   `mapstructure:"outbox_table_name" json:"outbox_table_name" envconfig:"outbox_table_name" yaml:"outbox_table_name" toml:"outbox_table_name"`
+	NumPartitions                int      `mapstructure:"num_partitions" json:"num_partitions" envconfig:"num_partitions" default:"1" yaml:"num_partitions" toml:"num_partitions"`
+	PartitionSelectLimit         int      `mapstructure:"partition_select_limit" json:"partition_select_limit" envconfig:"partition_select_limit" default:"100" yaml:"partition_select_limit" toml:"partition_select_limit"`
+	PartitionPollInterval        Duration `mapstructure:"partition_poll_interval" json:"partition_poll_interval" envconfig:"partition_poll_interval" default:"300ms" yaml:"partition_poll_interval" toml:"partition_poll_interval"`
+	PartitionNotificationChannel string   `mapstructure:"partition_notification_channel" json:"partition_notification_channel" envconfig:"partition_notification_channel" yaml:"partition_notification_channel" toml:"partition_notification_channel"`
 	// PartitionNotificationDSN is an optional separate DSN used exclusively for
 	// the LISTEN connection. Set this to a direct PostgreSQL URL (bypassing
 	// PGBouncer) when DSN points at a PGBouncer endpoint — PGBouncer transaction
 	// pooling mode is incompatible with LISTEN/NOTIFY. If empty, the primary
 	// DSN pool is used (fine for direct PostgreSQL connections).
-	PartitionNotificationDSN string `mapstructure:"partition_notification_dsn" json:"partition_notification_dsn" envconfig:"partition_notification_dsn" yaml:"partition_notification_dsn" toml:"partition_notification_dsn"`
-	TLS                          TLSConfig `mapstructure:"tls" json:"tls" envconfig:"tls" yaml:"tls" toml:"tls"`
+	PartitionNotificationDSN string    `mapstructure:"partition_notification_dsn" json:"partition_notification_dsn" envconfig:"partition_notification_dsn" yaml:"partition_notification_dsn" toml:"partition_notification_dsn"`
+	TLS                      TLSConfig `mapstructure:"tls" json:"tls" envconfig:"tls" yaml:"tls" toml:"tls"`
 	// UseTryLock when enabled tells Centrifugo to use pg_try_advisory_xact_lock instead of pg_advisory_xact_lock.
 	UseTryLock bool `mapstructure:"use_try_lock" json:"use_try_lock" envconfig:"use_try_lock" default:"false" yaml:"use_try_lock" toml:"use_try_lock"`
 }

--- a/internal/telemetry/provider.go
+++ b/internal/telemetry/provider.go
@@ -3,6 +3,7 @@ package telemetry
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"os"
 
 	"github.com/centrifugal/centrifugo/v6/internal/build"
@@ -17,6 +18,8 @@ import (
 	"go.opentelemetry.io/otel/sdk/resource"
 	"go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.20.0"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/oauth"
 )
@@ -26,13 +29,13 @@ import (
 // Credentials.
 const googleCloudAuthScope = "https://www.googleapis.com/auth/cloud-platform"
 
-func SetupTracing(ctx context.Context, googleCloudAuth bool) (*trace.TracerProvider, error) {
+func SetupTracing(ctx context.Context, googleCloudADCAuth bool) (*trace.TracerProvider, error) {
 	exporterProtocol := os.Getenv("OTEL_EXPORTER_OTLP_PROTOCOL")
 	if exporterProtocol == "" {
 		exporterProtocol = "http/protobuf"
 	}
 
-	exporter, err := createExporter(ctx, exporterProtocol, googleCloudAuth)
+	exporter, err := createExporter(ctx, exporterProtocol, googleCloudADCAuth)
 	if err != nil {
 		return nil, err
 	}
@@ -72,15 +75,17 @@ func (e ErrorHandlerImpl) Handle(err error) {
 	log.Err(err).Msg("opentelemetry error")
 }
 
-func createExporter(ctx context.Context, exporterProtocol string, googleCloudAuth bool) (*otlptrace.Exporter, error) {
+func createExporter(ctx context.Context, exporterProtocol string, googleCloudADCAuth bool) (*otlptrace.Exporter, error) {
 	if exporterProtocol == "grpc" {
 		var opts []otlptracegrpc.Option
-		if googleCloudAuth {
+		if googleCloudADCAuth {
 			// Inject Google Cloud Application Default Credentials as per-RPC
 			// OAuth2 tokens so the exporter can authenticate against Google
-			// Cloud's OTLP endpoint (telemetry.googleapis.com). The token
-			// source refreshes automatically; the metadata server lookup is
-			// lazy and happens on first export, not at startup.
+			// Cloud's OTLP endpoint (telemetry.googleapis.com). The access
+			// token is minted lazily on first export and then cached and
+			// auto-refreshed. Note: resolving ADC here (at startup) may do a
+			// one-time metadata-server probe when running on GCE without an
+			// explicit credentials file.
 			creds, err := oauth.NewApplicationDefault(ctx, googleCloudAuthScope)
 			if err != nil {
 				return nil, fmt.Errorf("error creating Google Cloud application default credentials: %w", err)
@@ -91,13 +96,32 @@ func createExporter(ctx context.Context, exporterProtocol string, googleCloudAut
 	}
 
 	if exporterProtocol == "http/protobuf" {
-		if googleCloudAuth {
-			return nil, fmt.Errorf("opentelemetry google_cloud_auth requires the grpc exporter protocol (OTEL_EXPORTER_OTLP_PROTOCOL=grpc)")
+		var opts []otlptracehttp.Option
+		if googleCloudADCAuth {
+			// Same as the gRPC path, but ADC tokens are attached by an OAuth2
+			// http.Client transport (which also refreshes them automatically)
+			// since the HTTP exporter has no per-RPC credentials concept.
+			client, err := googleCloudADCHTTPClient(ctx)
+			if err != nil {
+				return nil, err
+			}
+			opts = append(opts, otlptracehttp.WithHTTPClient(client))
 		}
-		return otlptracehttp.New(
-			ctx,
-		)
+		return otlptracehttp.New(ctx, opts...)
 	}
 
 	return nil, fmt.Errorf("unsupported exporter protocol: %s", exporterProtocol)
+}
+
+// googleCloudADCHTTPClient returns an *http.Client that authenticates outgoing
+// requests with Google Cloud Application Default Credentials. The OAuth2
+// transport mints the access token lazily on first request and then caches and
+// auto-refreshes it. Resolving ADC (here, at startup) may perform a one-time
+// metadata-server probe when running on GCE without an explicit credentials file.
+func googleCloudADCHTTPClient(ctx context.Context) (*http.Client, error) {
+	ts, err := google.DefaultTokenSource(ctx, googleCloudAuthScope)
+	if err != nil {
+		return nil, fmt.Errorf("error creating Google Cloud application default credentials: %w", err)
+	}
+	return oauth2.NewClient(ctx, ts), nil
 }


### PR DESCRIPTION
## Proposed changes

Follow up to #1143 , rename option to `google_cloud_adc_auth` and support HTTP export protocol
