### PR TITLE
kafka: configurable dial timeout and broker-count-scaled ping timeout

### DIFF
--- a/internal/cli/configdoc/schema.json
+++ b/internal/cli/configdoc/schema.json
@@ -10404,6 +10404,16 @@
             "is_complex_type": false
           },
           {
+            "field": "consumers[].kafka.dial_timeout",
+            "name": "dial_timeout",
+            "go_name": "DialTimeout",
+            "level": 3,
+            "type": "Duration",
+            "default": "3s",
+            "comment": "DialTimeout is the timeout for establishing a TCP connection to a single broker.\nWith many seed brokers, a lower value speeds up initial discovery when some brokers\nare unreachable, because franz-go tries them sequentially. If not set, defaults to 3s.",
+            "is_complex_type": false
+          },
+          {
             "field": "consumers[].kafka.tls",
             "name": "tls",
             "go_name": "TLS",

--- a/internal/configtypes/types.go
+++ b/internal/configtypes/types.go
@@ -853,6 +853,11 @@ type KafkaConsumerConfig struct {
 	// If -1, pausing is done on every poll. If set, pausing only happens when queue size exceeds this threshold.
 	PartitionQueueMaxSize int `mapstructure:"partition_queue_max_size" json:"partition_queue_max_size" envconfig:"partition_queue_max_size" default:"1000" yaml:"partition_queue_max_size" toml:"partition_queue_max_size"`
 
+	// DialTimeout is the timeout for establishing a TCP connection to a single broker.
+	// With many seed brokers, a lower value speeds up initial discovery when some brokers
+	// are unreachable, because franz-go tries them sequentially. If not set, defaults to 3s.
+	DialTimeout Duration `mapstructure:"dial_timeout" json:"dial_timeout" envconfig:"dial_timeout" default:"3s" yaml:"dial_timeout" toml:"dial_timeout"`
+
 	// TLS for the connection to Kafka.
 	TLS TLSConfig `mapstructure:"tls" json:"tls" envconfig:"tls" yaml:"tls" toml:"tls"`
 

--- a/internal/consuming/kafka.go
+++ b/internal/consuming/kafka.go
@@ -217,9 +217,29 @@ func (a *mskAssumeRoleAuth) auth(ctx context.Context) (mskaws.Auth, error) {
 	}, nil
 }
 
+// defaultKafkaDialTimeout is the fallback TCP dial timeout to a single broker.
+const defaultKafkaDialTimeout = 3 * time.Second
+
+func effectiveDialTimeout(d configtypes.Duration) time.Duration {
+	if d <= 0 {
+		return defaultKafkaDialTimeout
+	}
+	return time.Duration(d)
+}
+
+// pingTimeout returns a context deadline long enough for Ping to try every
+// seed broker. franz-go retries each broker's connection once on retryable
+// errors (see broker.handleReq), so each broker may cost up to 2 × dialTimeout.
+func pingTimeout(dialTimeout time.Duration, numBrokers int) time.Duration {
+	const maxAttemptsPerBroker = 2
+	return dialTimeout * time.Duration(numBrokers) * maxAttemptsPerBroker
+}
+
 func (c *KafkaConsumer) initClient() (*kgo.Client, error) {
+	dialTimeout := effectiveDialTimeout(c.config.DialTimeout)
 	opts := []kgo.Opt{
 		kgo.SeedBrokers(c.config.Brokers...),
+		kgo.DialTimeout(dialTimeout),
 		kgo.ConsumeTopics(c.config.Topics...),
 		kgo.ConsumerGroup(c.config.ConsumerGroup),
 		kgo.OnPartitionsAssigned(c.assigned),
@@ -297,7 +317,7 @@ func (c *KafkaConsumer) initClient() (*kgo.Client, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error initializing client: %w", err)
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), pingTimeout(dialTimeout, len(c.config.Brokers)))
 	defer cancel()
 	if err := client.Ping(ctx); err != nil {
 		client.Close()

--- a/internal/consuming/kafka_test.go
+++ b/internal/consuming/kafka_test.go
@@ -1911,3 +1911,41 @@ func BenchmarkKafkaConsumer_ConsumePreLoadedTopic(b *testing.B) {
 		b.Logf("benchmark complete: %d iterations, avg time %v, avg rate %.0f msg/sec", b.N, avgTime, avgRate)
 	}
 }
+
+func TestEffectiveDialTimeout(t *testing.T) {
+	t.Parallel()
+
+	t.Run("zero uses default", func(t *testing.T) {
+		t.Parallel()
+		require.Equal(t, defaultKafkaDialTimeout, effectiveDialTimeout(0))
+	})
+
+	t.Run("negative uses default", func(t *testing.T) {
+		t.Parallel()
+		require.Equal(t, defaultKafkaDialTimeout, effectiveDialTimeout(configtypes.Duration(-1*time.Second)))
+	})
+
+	t.Run("positive value is preserved", func(t *testing.T) {
+		t.Parallel()
+		require.Equal(t, 2*time.Second, effectiveDialTimeout(configtypes.Duration(2*time.Second)))
+	})
+}
+
+func TestPingTimeout(t *testing.T) {
+	t.Parallel()
+
+	t.Run("accounts for 2 attempts per broker", func(t *testing.T) {
+		t.Parallel()
+		require.Equal(t, 54*time.Second, pingTimeout(3*time.Second, 9))
+	})
+
+	t.Run("single broker is 2x dial timeout", func(t *testing.T) {
+		t.Parallel()
+		require.Equal(t, 6*time.Second, pingTimeout(3*time.Second, 1))
+	})
+
+	t.Run("zero brokers returns zero", func(t *testing.T) {
+		t.Parallel()
+		require.Equal(t, time.Duration(0), pingTimeout(3*time.Second, 0))
+	})
+}


### PR DESCRIPTION
Adds a `dial_timeout` option to the Kafka consumer (default `3s`) and passes it to franz-go via `kgo.DialTimeout`. The client ping deadline is now scaled to the number of seed brokers (`dialTimeout × brokers × 2`) instead of a fixed 5s, since franz-go tries brokers sequentially and retries each once — so a low dial timeout speeds up startup when some brokers are unreachable, while the ping still gets enough time to try them all.
