### PR TITLE
Drop linux 386 binary release

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -30,16 +30,9 @@ builds:
   - windows
   goarch:
   - amd64
-  - "386"
-  - arm  
+  - arm
   - arm64
   ignore:
-    - goos: darwin
-      goarch: "386"
-    - goos: windows
-      goarch: "386"
-    - goos: freebsd
-      goarch: "386"
     - goos: darwin
       goarch: arm
     - goos: windows


### PR DESCRIPTION
Seems dead and useless these days.