### PR TITLE
Otel: use node ID as instance ID

### DIFF
--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -142,7 +142,7 @@ func Run(cmd *cobra.Command, configFile string) {
 	}
 
 	if cfg.OpenTelemetry.Enabled {
-		_, err := telemetry.SetupTracing(context.Background(), cfg.OpenTelemetry.GoogleCloudADCAuth)
+		_, err := telemetry.SetupTracing(context.Background(), cfg.OpenTelemetry, node.ID())
 		if err != nil {
 			log.Fatal().Err(err).Msg("error setting up opentelemetry tracing")
 		}

--- a/internal/telemetry/detectors.go
+++ b/internal/telemetry/detectors.go
@@ -1,0 +1,13 @@
+package telemetry
+
+import (
+	"github.com/centrifugal/centrifugo/v6/internal/configtypes"
+
+	"go.opentelemetry.io/otel/sdk/resource"
+)
+
+// resourceDetectors returns extra resource detectors to attach to the
+// telemetry resource based on the OpenTelemetry configuration.
+func resourceDetectors(cfg configtypes.OpenTelemetry) ([]resource.Detector, error) {
+	return nil, nil
+}

--- a/internal/telemetry/provider.go
+++ b/internal/telemetry/provider.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"github.com/centrifugal/centrifugo/v6/internal/build"
+	"github.com/centrifugal/centrifugo/v6/internal/configtypes"
 
 	"github.com/rs/zerolog/log"
 	"go.opentelemetry.io/otel"
@@ -29,28 +30,64 @@ import (
 // Credentials.
 const googleCloudAuthScope = "https://www.googleapis.com/auth/cloud-platform"
 
-func SetupTracing(ctx context.Context, googleCloudADCAuth bool) (*trace.TracerProvider, error) {
+// newResource builds the OTel resource attached to telemetry providers.
+// instanceID (Centrifugo node ID) becomes the default service.instance.id —
+// backends that require points of a time series to arrive in order (notably
+// Google Cloud Managed Service for Prometheus) reject or collapse metrics when
+// several instances report under the same identity, so every process must
+// carry a distinct one. Optional detectors run first, so both Centrifugo
+// defaults and environment values override what they detect.
+// OTEL_RESOURCE_ATTRIBUTES / OTEL_SERVICE_NAME are merged with precedence over
+// Centrifugo defaults; the SDK's WithResource merges environment attributes
+// too, but with the opposite precedence (explicitly passed attributes win
+// there), so the env override must happen here.
+func newResource(ctx context.Context, instanceID string, detectors ...resource.Detector) (*resource.Resource, error) {
+	serviceName := os.Getenv("OTEL_SERVICE_NAME")
+	if serviceName == "" {
+		serviceName = "centrifugo"
+	}
+	rs, err := resource.New(ctx,
+		resource.WithSchemaURL(semconv.SchemaURL),
+		resource.WithDetectors(detectors...),
+		resource.WithAttributes(
+			semconv.ServiceNameKey.String(serviceName),
+			semconv.ServiceInstanceIDKey.String(instanceID),
+			attribute.String("version", build.Version),
+		),
+		resource.WithFromEnv(),
+	)
+	if err != nil {
+		// resource.New returns a usable partial resource together with the
+		// error (malformed OTEL_RESOURCE_ATTRIBUTES, failed detector), but
+		// exporting telemetry under a wrong or incomplete identity is worse
+		// than failing startup: both causes are actionable, and orchestrator
+		// restarts cover transient ones (e.g. metadata server not ready yet).
+		return nil, fmt.Errorf("error building opentelemetry resource: %w", err)
+	}
+	return rs, nil
+}
+
+func SetupTracing(ctx context.Context, cfg configtypes.OpenTelemetry, instanceID string) (*trace.TracerProvider, error) {
 	exporterProtocol := os.Getenv("OTEL_EXPORTER_OTLP_PROTOCOL")
 	if exporterProtocol == "" {
 		exporterProtocol = "http/protobuf"
 	}
 
-	exporter, err := createExporter(ctx, exporterProtocol, googleCloudADCAuth)
+	exporter, err := createExporter(ctx, exporterProtocol, cfg.GoogleCloudADCAuth)
 	if err != nil {
 		return nil, err
 	}
 
-	serviceName := os.Getenv("OTEL_SERVICE_NAME")
-	if serviceName == "" {
-		serviceName = "centrifugo"
+	detectors, err := resourceDetectors(cfg)
+	if err != nil {
+		return nil, err
 	}
 
 	// labels/tags/resources that are common to all traces.
-	rs := resource.NewWithAttributes(
-		semconv.SchemaURL,
-		semconv.ServiceNameKey.String(serviceName),
-		attribute.String("version", build.Version),
-	)
+	rs, err := newResource(ctx, instanceID, detectors...)
+	if err != nil {
+		return nil, err
+	}
 
 	provider := trace.NewTracerProvider(
 		trace.WithBatcher(exporter),

--- a/internal/telemetry/provider_test.go
+++ b/internal/telemetry/provider_test.go
@@ -1,0 +1,121 @@
+package telemetry
+
+import (
+	"context"
+	"testing"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/resource"
+	semconv "go.opentelemetry.io/otel/semconv/v1.20.0"
+)
+
+func resourceAttr(t *testing.T, attrs []attribute.KeyValue, key attribute.Key) (string, bool) {
+	t.Helper()
+	for _, kv := range attrs {
+		if kv.Key == key {
+			return kv.Value.AsString(), true
+		}
+	}
+	return "", false
+}
+
+func TestNewResourceDefaults(t *testing.T) {
+	t.Setenv("OTEL_RESOURCE_ATTRIBUTES", "")
+	t.Setenv("OTEL_SERVICE_NAME", "")
+
+	rs, err := newResource(context.Background(), "node-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	attrs := rs.Attributes()
+
+	if v, _ := resourceAttr(t, attrs, semconv.ServiceNameKey); v != "centrifugo" {
+		t.Fatalf("unexpected service.name: %q", v)
+	}
+	if v, _ := resourceAttr(t, attrs, semconv.ServiceInstanceIDKey); v != "node-1" {
+		t.Fatalf("unexpected service.instance.id: %q", v)
+	}
+}
+
+func TestNewResourceEnvOverridesAndMerges(t *testing.T) {
+	t.Setenv("OTEL_RESOURCE_ATTRIBUTES", "gcp.project_id=my-project,service.instance.id=custom-id")
+	t.Setenv("OTEL_SERVICE_NAME", "my-centrifugo")
+
+	rs, err := newResource(context.Background(), "node-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	attrs := rs.Attributes()
+
+	if v, _ := resourceAttr(t, attrs, semconv.ServiceNameKey); v != "my-centrifugo" {
+		t.Fatalf("unexpected service.name: %q", v)
+	}
+	if v, _ := resourceAttr(t, attrs, semconv.ServiceInstanceIDKey); v != "custom-id" {
+		t.Fatalf("env must override default service.instance.id, got: %q", v)
+	}
+	if v, ok := resourceAttr(t, attrs, "gcp.project_id"); !ok || v != "my-project" {
+		t.Fatalf("OTEL_RESOURCE_ATTRIBUTES not merged into resource, gcp.project_id: %q (present: %v)", v, ok)
+	}
+	if v, ok := resourceAttr(t, attrs, "version"); !ok || v == "" {
+		t.Fatalf("version attribute missing: %q (present: %v)", v, ok)
+	}
+}
+
+func TestNewResourceMalformedEnv(t *testing.T) {
+	t.Setenv("OTEL_RESOURCE_ATTRIBUTES", "missing-equals-sign")
+	t.Setenv("OTEL_SERVICE_NAME", "")
+
+	if _, err := newResource(context.Background(), "node-1"); err == nil {
+		t.Fatal("expected error for malformed OTEL_RESOURCE_ATTRIBUTES")
+	}
+}
+
+type errorDetector struct{}
+
+func (errorDetector) Detect(context.Context) (*resource.Resource, error) {
+	return nil, context.DeadlineExceeded
+}
+
+func TestNewResourceDetectorError(t *testing.T) {
+	t.Setenv("OTEL_RESOURCE_ATTRIBUTES", "")
+	t.Setenv("OTEL_SERVICE_NAME", "")
+
+	if _, err := newResource(context.Background(), "node-1", errorDetector{}); err == nil {
+		t.Fatal("expected error when detector fails")
+	}
+}
+
+type staticDetector []attribute.KeyValue
+
+func (d staticDetector) Detect(context.Context) (*resource.Resource, error) {
+	return resource.NewSchemaless(d...), nil
+}
+
+func TestNewResourceDetectorPrecedence(t *testing.T) {
+	t.Setenv("OTEL_RESOURCE_ATTRIBUTES", "cloud.region=env-region")
+	t.Setenv("OTEL_SERVICE_NAME", "")
+
+	det := staticDetector{
+		attribute.String("cloud.region", "detected-region"),
+		attribute.String("k8s.cluster.name", "detected-cluster"),
+		semconv.ServiceNameKey.String("detected-name"),
+	}
+	rs, err := newResource(context.Background(), "node-1", det)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	attrs := rs.Attributes()
+
+	if v, _ := resourceAttr(t, attrs, "cloud.region"); v != "env-region" {
+		t.Fatalf("env must override detector, cloud.region: %q", v)
+	}
+	if v, _ := resourceAttr(t, attrs, "k8s.cluster.name"); v != "detected-cluster" {
+		t.Fatalf("detector attribute lost, k8s.cluster.name: %q", v)
+	}
+	if v, _ := resourceAttr(t, attrs, semconv.ServiceNameKey); v != "centrifugo" {
+		t.Fatalf("Centrifugo defaults must override detector, service.name: %q", v)
+	}
+	if v, _ := resourceAttr(t, attrs, semconv.ServiceInstanceIDKey); v != "node-1" {
+		t.Fatalf("unexpected service.instance.id: %q", v)
+	}
+}


### PR DESCRIPTION
Start using node ID as instance ID for opentelemetry. It still can be overriden over `OTEL_RESOURCE_ATTRIBUTES` env var.
