### PR TITLE
Cache recovery for unidirectional clients with server-side subscriptions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.43.2
 	github.com/aws/aws-sdk-go-v2/service/sts v1.43.2
 	github.com/aws/smithy-go v1.27.2
-	github.com/centrifugal/centrifuge v0.38.1-0.20260614052230-24996932b8ed
+	github.com/centrifugal/centrifuge v0.38.1-0.20260615180132-f369d8fe1105
 	github.com/centrifugal/protocol v0.19.2
 	github.com/cristalhq/jwt/v5 v5.4.0
 	github.com/go-viper/mapstructure/v2 v2.5.0

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.43.2
 	github.com/aws/aws-sdk-go-v2/service/sts v1.43.2
 	github.com/aws/smithy-go v1.27.2
-	github.com/centrifugal/centrifuge v0.38.1-0.20260531113025-945c9cce05ad
+	github.com/centrifugal/centrifuge v0.38.1-0.20260614052230-24996932b8ed
 	github.com/centrifugal/protocol v0.19.2
 	github.com/cristalhq/jwt/v5 v5.4.0
 	github.com/go-viper/mapstructure/v2 v2.5.0

--- a/go.sum
+++ b/go.sum
@@ -73,8 +73,8 @@ github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6r
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/centrifugal/centrifuge v0.38.1-0.20260531113025-945c9cce05ad h1:zDNIwtt4f13bkbRZlfbJhKROnEm16mgcmNzF1uoph+c=
-github.com/centrifugal/centrifuge v0.38.1-0.20260531113025-945c9cce05ad/go.mod h1:BKroeyxtsjPHI9ZH7hJw0K4i1Yex/zvncUgJNBSk39Q=
+github.com/centrifugal/centrifuge v0.38.1-0.20260614052230-24996932b8ed h1:7QZ1Y+p/ro6Cs4iOr9djd9/tKBz6U2dytOvHSR0V3gE=
+github.com/centrifugal/centrifuge v0.38.1-0.20260614052230-24996932b8ed/go.mod h1:BKroeyxtsjPHI9ZH7hJw0K4i1Yex/zvncUgJNBSk39Q=
 github.com/centrifugal/protocol v0.19.2 h1:wc1S75EJvX5/KczsqEG74Bt/Jw/XwECDUzWR/vE/E9U=
 github.com/centrifugal/protocol v0.19.2/go.mod h1:zFsp4f1ZRejq1dkyNUbabdPj4dMYOpK8RRXDwHGVpVY=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=

--- a/go.sum
+++ b/go.sum
@@ -73,8 +73,8 @@ github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6r
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/centrifugal/centrifuge v0.38.1-0.20260614052230-24996932b8ed h1:7QZ1Y+p/ro6Cs4iOr9djd9/tKBz6U2dytOvHSR0V3gE=
-github.com/centrifugal/centrifuge v0.38.1-0.20260614052230-24996932b8ed/go.mod h1:BKroeyxtsjPHI9ZH7hJw0K4i1Yex/zvncUgJNBSk39Q=
+github.com/centrifugal/centrifuge v0.38.1-0.20260615180132-f369d8fe1105 h1:aL+lc8cFkJwWIXq2HBJ+tgFSpy628pEtuEltNVJrWRM=
+github.com/centrifugal/centrifuge v0.38.1-0.20260615180132-f369d8fe1105/go.mod h1:BKroeyxtsjPHI9ZH7hJw0K4i1Yex/zvncUgJNBSk39Q=
 github.com/centrifugal/protocol v0.19.2 h1:wc1S75EJvX5/KczsqEG74Bt/Jw/XwECDUzWR/vE/E9U=
 github.com/centrifugal/protocol v0.19.2/go.mod h1:zFsp4f1ZRejq1dkyNUbabdPj4dMYOpK8RRXDwHGVpVY=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=

--- a/internal/client/handler.go
+++ b/internal/client/handler.go
@@ -519,6 +519,25 @@ func (h *Handler) OnClientConnecting(
 		}
 	}
 
+	// Server-side subscribers can't request recovery on their own – especially unidirectional
+	// clients which may not even know channel names. In cache recovery mode auto_cache_recovery
+	// makes Centrifugo deliver the latest publication for such subscriptions automatically on
+	// every (re)connect.
+	for ch, opts := range subscriptions {
+		if opts.Recover || !opts.EnableRecovery {
+			continue
+		}
+		_, _, chOpts, found, err := h.cfgContainer.ChannelOptions(ch)
+		if err != nil {
+			log.Error().Err(err).Str("channel", ch).Msg("error getting channel options")
+			return centrifuge.ConnectReply{}, err
+		}
+		if found && chOpts.AutoCacheRecovery && opts.RecoveryMode == centrifuge.RecoveryModeCache {
+			opts.Recover = true
+			subscriptions[ch] = opts
+		}
+	}
+
 	finalReply := centrifuge.ConnectReply{
 		Storage:           storage,
 		Credentials:       credentials,
@@ -860,6 +879,12 @@ func (h *Handler) OnSubscribe(c Client, e centrifuge.SubscribeEvent, subscribePr
 	// Set subscription type for map subscriptions.
 	if e.Type != centrifuge.SubscriptionTypeStream {
 		options.Type = e.Type
+	}
+
+	// In cache recovery mode auto_cache_recovery makes Centrifugo deliver the latest
+	// publication on subscribe without the client providing an empty "since" itself.
+	if chOpts.AutoCacheRecovery && options.EnableRecovery && options.RecoveryMode == centrifuge.RecoveryModeCache {
+		options.Recover = true
 	}
 
 	return centrifuge.SubscribeReply{

--- a/internal/client/handler.go
+++ b/internal/client/handler.go
@@ -520,11 +520,11 @@ func (h *Handler) OnClientConnecting(
 	}
 
 	// Server-side subscribers can't request recovery on their own – especially unidirectional
-	// clients which may not even know channel names. In cache recovery mode auto_cache_recovery
+	// clients which may not even know channel names. In cache recovery mode auto_cache_recover
 	// makes Centrifugo deliver the latest publication for such subscriptions automatically on
 	// every (re)connect.
 	for ch, opts := range subscriptions {
-		if opts.Recover || !opts.EnableRecovery {
+		if opts.AutoCacheRecover || !opts.EnableRecovery {
 			continue
 		}
 		_, _, chOpts, found, err := h.cfgContainer.ChannelOptions(ch)
@@ -532,8 +532,8 @@ func (h *Handler) OnClientConnecting(
 			log.Error().Err(err).Str("channel", ch).Msg("error getting channel options")
 			return centrifuge.ConnectReply{}, err
 		}
-		if found && chOpts.AutoCacheRecovery && opts.RecoveryMode == centrifuge.RecoveryModeCache {
-			opts.Recover = true
+		if found && chOpts.AutoCacheRecover && opts.RecoveryMode == centrifuge.RecoveryModeCache {
+			opts.AutoCacheRecover = true
 			subscriptions[ch] = opts
 		}
 	}
@@ -881,10 +881,10 @@ func (h *Handler) OnSubscribe(c Client, e centrifuge.SubscribeEvent, subscribePr
 		options.Type = e.Type
 	}
 
-	// In cache recovery mode auto_cache_recovery makes Centrifugo deliver the latest
+	// In cache recovery mode auto_cache_recover makes Centrifugo deliver the latest
 	// publication on subscribe without the client providing an empty "since" itself.
-	if chOpts.AutoCacheRecovery && options.EnableRecovery && options.RecoveryMode == centrifuge.RecoveryModeCache {
-		options.Recover = true
+	if chOpts.AutoCacheRecover && options.EnableRecovery && options.RecoveryMode == centrifuge.RecoveryModeCache {
+		options.AutoCacheRecover = true
 	}
 
 	return centrifuge.SubscribeReply{

--- a/internal/client/handler_test.go
+++ b/internal/client/handler_test.go
@@ -254,7 +254,7 @@ func TestClientConnectWithProxy(t *testing.T) {
 	require.Contains(t, reply.Subscriptions, "channel1")
 }
 
-func TestClientConnectAutoCacheRecoveryServerSubs(t *testing.T) {
+func TestClientConnectAutoCacheRecoverServerSubs(t *testing.T) {
 	node := tools.NodeWithMemoryEngine()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -264,7 +264,7 @@ func TestClientConnectAutoCacheRecoveryServerSubs(t *testing.T) {
 	opts.HistoryTTL = configtypes.Duration(time.Hour)
 	opts.ForceRecovery = true
 	opts.ForceRecoveryMode = "cache"
-	opts.AutoCacheRecovery = true
+	opts.AutoCacheRecover = true
 	cfgContainer, err := config.NewContainer(cfg)
 	require.NoError(t, err)
 	verifier := hmacJWTVerifier(t, cfgContainer)
@@ -282,10 +282,10 @@ func TestClientConnectAutoCacheRecoveryServerSubs(t *testing.T) {
 	reply, err := h.OnClientConnecting(context.Background(), centrifuge.ConnectEvent{}, connectProxyHandler, true)
 	require.NoError(t, err)
 	require.Contains(t, reply.Subscriptions, "channel1")
-	require.True(t, reply.Subscriptions["channel1"].Recover, "auto_cache_recovery must set Recover for server-side subscription")
+	require.True(t, reply.Subscriptions["channel1"].AutoCacheRecover, "auto_cache_recover must set AutoCacheRecover for server-side subscription")
 }
 
-func TestClientConnectNoAutoCacheRecoveryByDefault(t *testing.T) {
+func TestClientConnectNoAutoCacheRecoverByDefault(t *testing.T) {
 	node := tools.NodeWithMemoryEngine()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -312,7 +312,7 @@ func TestClientConnectNoAutoCacheRecoveryByDefault(t *testing.T) {
 	reply, err := h.OnClientConnecting(context.Background(), centrifuge.ConnectEvent{}, connectProxyHandler, true)
 	require.NoError(t, err)
 	require.Contains(t, reply.Subscriptions, "channel1")
-	require.False(t, reply.Subscriptions["channel1"].Recover, "Recover must stay off without auto_cache_recovery")
+	require.False(t, reply.Subscriptions["channel1"].AutoCacheRecover, "AutoCacheRecover must stay off without auto_cache_recover")
 }
 
 func TestClientConnectWithValidTokenRSA(t *testing.T) {

--- a/internal/client/handler_test.go
+++ b/internal/client/handler_test.go
@@ -254,6 +254,67 @@ func TestClientConnectWithProxy(t *testing.T) {
 	require.Contains(t, reply.Subscriptions, "channel1")
 }
 
+func TestClientConnectAutoCacheRecoveryServerSubs(t *testing.T) {
+	node := tools.NodeWithMemoryEngine()
+	defer func() { _ = node.Shutdown(context.Background()) }()
+
+	cfg := config.DefaultConfig()
+	opts := &cfg.Channel.WithoutNamespace
+	opts.HistorySize = 1
+	opts.HistoryTTL = configtypes.Duration(time.Hour)
+	opts.ForceRecovery = true
+	opts.ForceRecoveryMode = "cache"
+	opts.AutoCacheRecovery = true
+	cfgContainer, err := config.NewContainer(cfg)
+	require.NoError(t, err)
+	verifier := hmacJWTVerifier(t, cfgContainer)
+	h := NewHandler(node, cfgContainer, verifier, nil, &ProxyMap{})
+
+	connectProxyHandler := func(context.Context, centrifuge.ConnectEvent) (centrifuge.ConnectReply, proxy.ConnectExtra, error) {
+		return centrifuge.ConnectReply{
+			Credentials: &centrifuge.Credentials{UserID: "34"},
+			Subscriptions: map[string]centrifuge.SubscribeOptions{
+				"channel1": {EnableRecovery: true, RecoveryMode: centrifuge.RecoveryModeCache},
+			},
+		}, proxy.ConnectExtra{}, nil
+	}
+
+	reply, err := h.OnClientConnecting(context.Background(), centrifuge.ConnectEvent{}, connectProxyHandler, true)
+	require.NoError(t, err)
+	require.Contains(t, reply.Subscriptions, "channel1")
+	require.True(t, reply.Subscriptions["channel1"].Recover, "auto_cache_recovery must set Recover for server-side subscription")
+}
+
+func TestClientConnectNoAutoCacheRecoveryByDefault(t *testing.T) {
+	node := tools.NodeWithMemoryEngine()
+	defer func() { _ = node.Shutdown(context.Background()) }()
+
+	cfg := config.DefaultConfig()
+	opts := &cfg.Channel.WithoutNamespace
+	opts.HistorySize = 1
+	opts.HistoryTTL = configtypes.Duration(time.Hour)
+	opts.ForceRecovery = true
+	opts.ForceRecoveryMode = "cache"
+	cfgContainer, err := config.NewContainer(cfg)
+	require.NoError(t, err)
+	verifier := hmacJWTVerifier(t, cfgContainer)
+	h := NewHandler(node, cfgContainer, verifier, nil, &ProxyMap{})
+
+	connectProxyHandler := func(context.Context, centrifuge.ConnectEvent) (centrifuge.ConnectReply, proxy.ConnectExtra, error) {
+		return centrifuge.ConnectReply{
+			Credentials: &centrifuge.Credentials{UserID: "34"},
+			Subscriptions: map[string]centrifuge.SubscribeOptions{
+				"channel1": {EnableRecovery: true, RecoveryMode: centrifuge.RecoveryModeCache},
+			},
+		}, proxy.ConnectExtra{}, nil
+	}
+
+	reply, err := h.OnClientConnecting(context.Background(), centrifuge.ConnectEvent{}, connectProxyHandler, true)
+	require.NoError(t, err)
+	require.Contains(t, reply.Subscriptions, "channel1")
+	require.False(t, reply.Subscriptions["channel1"].Recover, "Recover must stay off without auto_cache_recovery")
+}
+
 func TestClientConnectWithValidTokenRSA(t *testing.T) {
 	privateKey, pubKey := generateTestRSAKeys(t)
 

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -243,8 +243,8 @@ func validateChannelOptions(c configtypes.ChannelOptions, globalHistoryMetaTTL c
 	if c.ForceRecovery && (c.HistorySize == 0 || c.HistoryTTL == 0) {
 		return errors.New("both history size and history ttl required for recovery")
 	}
-	if c.AutoCacheRecovery && (!c.ForceRecovery || c.ForceRecoveryMode != "cache") {
-		return errors.New("auto_cache_recovery requires force_recovery and force_recovery_mode set to cache")
+	if c.AutoCacheRecover && (!c.ForceRecovery || c.ForceRecoveryMode != "cache") {
+		return errors.New("auto_cache_recover requires force_recovery and force_recovery_mode set to cache")
 	}
 	if c.ChannelRegex != "" {
 		if _, err := regexp.Compile(c.ChannelRegex); err != nil {

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -243,6 +243,9 @@ func validateChannelOptions(c configtypes.ChannelOptions, globalHistoryMetaTTL c
 	if c.ForceRecovery && (c.HistorySize == 0 || c.HistoryTTL == 0) {
 		return errors.New("both history size and history ttl required for recovery")
 	}
+	if c.AutoCacheRecovery && (!c.ForceRecovery || c.ForceRecoveryMode != "cache") {
+		return errors.New("auto_cache_recovery requires force_recovery and force_recovery_mode set to cache")
+	}
 	if c.ChannelRegex != "" {
 		if _, err := regexp.Compile(c.ChannelRegex); err != nil {
 			return fmt.Errorf("invalid channel regex %s: %w", c.ChannelRegex, err)

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -228,6 +228,43 @@ func TestValidateMapNamespace_Ephemeral(t *testing.T) {
 	})
 }
 
+func TestValidateAutoCacheRecovery(t *testing.T) {
+	t.Run("valid_with_cache_recovery", func(t *testing.T) {
+		cfg := DefaultConfig()
+		opts := &cfg.Channel.WithoutNamespace
+		opts.HistorySize = 1
+		opts.HistoryTTL = configtypes.Duration(time.Hour)
+		opts.ForceRecovery = true
+		opts.ForceRecoveryMode = "cache"
+		opts.AutoCacheRecovery = true
+		require.NoError(t, cfg.Validate())
+	})
+
+	t.Run("requires_force_recovery", func(t *testing.T) {
+		cfg := DefaultConfig()
+		opts := &cfg.Channel.WithoutNamespace
+		opts.HistorySize = 1
+		opts.HistoryTTL = configtypes.Duration(time.Hour)
+		opts.ForceRecoveryMode = "cache"
+		opts.AutoCacheRecovery = true
+		err := cfg.Validate()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "auto_cache_recovery requires force_recovery")
+	})
+
+	t.Run("requires_cache_mode", func(t *testing.T) {
+		cfg := DefaultConfig()
+		opts := &cfg.Channel.WithoutNamespace
+		opts.HistorySize = 1
+		opts.HistoryTTL = configtypes.Duration(time.Hour)
+		opts.ForceRecovery = true
+		opts.AutoCacheRecovery = true
+		err := cfg.Validate()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "force_recovery_mode set to cache")
+	})
+}
+
 func TestValidateMapNamespace_Recoverable(t *testing.T) {
 	t.Run("valid_minimal_defaults_zero", func(t *testing.T) {
 		// Recoverable with all stream options at zero is valid

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -228,7 +228,7 @@ func TestValidateMapNamespace_Ephemeral(t *testing.T) {
 	})
 }
 
-func TestValidateAutoCacheRecovery(t *testing.T) {
+func TestValidateAutoCacheRecover(t *testing.T) {
 	t.Run("valid_with_cache_recovery", func(t *testing.T) {
 		cfg := DefaultConfig()
 		opts := &cfg.Channel.WithoutNamespace
@@ -236,7 +236,7 @@ func TestValidateAutoCacheRecovery(t *testing.T) {
 		opts.HistoryTTL = configtypes.Duration(time.Hour)
 		opts.ForceRecovery = true
 		opts.ForceRecoveryMode = "cache"
-		opts.AutoCacheRecovery = true
+		opts.AutoCacheRecover = true
 		require.NoError(t, cfg.Validate())
 	})
 
@@ -246,10 +246,10 @@ func TestValidateAutoCacheRecovery(t *testing.T) {
 		opts.HistorySize = 1
 		opts.HistoryTTL = configtypes.Duration(time.Hour)
 		opts.ForceRecoveryMode = "cache"
-		opts.AutoCacheRecovery = true
+		opts.AutoCacheRecover = true
 		err := cfg.Validate()
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "auto_cache_recovery requires force_recovery")
+		require.Contains(t, err.Error(), "auto_cache_recover requires force_recovery")
 	})
 
 	t.Run("requires_cache_mode", func(t *testing.T) {
@@ -258,7 +258,7 @@ func TestValidateAutoCacheRecovery(t *testing.T) {
 		opts.HistorySize = 1
 		opts.HistoryTTL = configtypes.Duration(time.Hour)
 		opts.ForceRecovery = true
-		opts.AutoCacheRecovery = true
+		opts.AutoCacheRecover = true
 		err := cfg.Validate()
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "force_recovery_mode set to cache")

--- a/internal/configtypes/namespace.go
+++ b/internal/configtypes/namespace.go
@@ -112,13 +112,13 @@ type ChannelOptions struct {
 	// ForceRecoveryMode can set the recovery mode for all channel subscribers in the namespace which use recovery.
 	ForceRecoveryMode string `mapstructure:"force_recovery_mode" json:"force_recovery_mode" envconfig:"force_recovery_mode" yaml:"force_recovery_mode" toml:"force_recovery_mode" expose:"full" doc:"Recovery mode for subscribers in this namespace that use recovery. Use <<stream>> (default) or <<cache>> (only the latest publication is recovered)."`
 
-	// AutoCacheRecovery makes Centrifugo automatically recover all subscriptions in the namespace
+	// AutoCacheRecover makes Centrifugo automatically recover all subscriptions in the namespace
 	// on subscribe, without requiring the subscriber to request recovery itself. In cache recovery
 	// mode this means the latest publication is delivered on every (re)subscribe without the need
 	// to provide an empty "since" on the client side, and it also enables this delivery for
 	// server-side subscriptions (e.g. of unidirectional clients which may not even know channel
 	// names). Requires force_recovery and force_recovery_mode set to "cache".
-	AutoCacheRecovery bool `mapstructure:"auto_cache_recovery" json:"auto_cache_recovery" envconfig:"auto_cache_recovery" yaml:"auto_cache_recovery" toml:"auto_cache_recovery" doc:"Automatically recovers all subscriptions in the namespace on subscribe without the subscriber requesting recovery. In cache recovery mode delivers the latest publication on every (re)subscribe (no client-side empty \"since\" needed) and also works for server-side subscriptions of unidirectional clients. Requires force_recovery and force_recovery_mode=cache."`
+	AutoCacheRecover bool `mapstructure:"auto_cache_recover" json:"auto_cache_recover" envconfig:"auto_cache_recover" yaml:"auto_cache_recover" toml:"auto_cache_recover" doc:"Automatically recovers all subscriptions in the namespace on subscribe without the subscriber requesting recovery. In cache recovery mode delivers the latest publication on every (re)subscribe (no client-side empty \"since\" needed) and also works for server-side subscriptions of unidirectional clients. Requires force_recovery and force_recovery_mode=cache."`
 
 	// AllowedDeltaTypes is non-empty contains slice of allowed delta types for subscribers to use.
 	AllowedDeltaTypes []centrifuge.DeltaType `mapstructure:"allowed_delta_types" json:"allowed_delta_types" envconfig:"allowed_delta_types" yaml:"allowed_delta_types" toml:"allowed_delta_types" doc:"Delta types subscribers may request in this namespace, e.g. <<[\"fossil\"]>>. Empty disables delta compression."`

--- a/internal/configtypes/namespace.go
+++ b/internal/configtypes/namespace.go
@@ -112,6 +112,14 @@ type ChannelOptions struct {
 	// ForceRecoveryMode can set the recovery mode for all channel subscribers in the namespace which use recovery.
 	ForceRecoveryMode string `mapstructure:"force_recovery_mode" json:"force_recovery_mode" envconfig:"force_recovery_mode" yaml:"force_recovery_mode" toml:"force_recovery_mode" expose:"full" doc:"Recovery mode for subscribers in this namespace that use recovery. Use <<stream>> (default) or <<cache>> (only the latest publication is recovered)."`
 
+	// AutoCacheRecovery makes Centrifugo automatically recover all subscriptions in the namespace
+	// on subscribe, without requiring the subscriber to request recovery itself. In cache recovery
+	// mode this means the latest publication is delivered on every (re)subscribe without the need
+	// to provide an empty "since" on the client side, and it also enables this delivery for
+	// server-side subscriptions (e.g. of unidirectional clients which may not even know channel
+	// names). Requires force_recovery and force_recovery_mode set to "cache".
+	AutoCacheRecovery bool `mapstructure:"auto_cache_recovery" json:"auto_cache_recovery" envconfig:"auto_cache_recovery" yaml:"auto_cache_recovery" toml:"auto_cache_recovery" doc:"Automatically recovers all subscriptions in the namespace on subscribe without the subscriber requesting recovery. In cache recovery mode delivers the latest publication on every (re)subscribe (no client-side empty \"since\" needed) and also works for server-side subscriptions of unidirectional clients. Requires force_recovery and force_recovery_mode=cache."`
+
 	// AllowedDeltaTypes is non-empty contains slice of allowed delta types for subscribers to use.
 	AllowedDeltaTypes []centrifuge.DeltaType `mapstructure:"allowed_delta_types" json:"allowed_delta_types" envconfig:"allowed_delta_types" yaml:"allowed_delta_types" toml:"allowed_delta_types" doc:"Delta types subscribers may request in this namespace, e.g. <<[\"fossil\"]>>. Empty disables delta compression."`
 

--- a/internal/proxy/connect_handler.go
+++ b/internal/proxy/connect_handler.go
@@ -222,6 +222,7 @@ func (h *ConnectHandler) Handle() ConnectingHandlerFunc {
 					EnableRecovery:    recovery,
 					EnablePositioning: positioning,
 					RecoveryMode:      recoveryMode,
+					Recover:           options.Recover,
 					Data:              chData,
 					Source:            subsource.ConnectProxy,
 					HistoryMetaTTL:    chOpts.HistoryMetaTTL.ToDuration(),

--- a/internal/proxy/connect_handler.go
+++ b/internal/proxy/connect_handler.go
@@ -222,7 +222,7 @@ func (h *ConnectHandler) Handle() ConnectingHandlerFunc {
 					EnableRecovery:    recovery,
 					EnablePositioning: positioning,
 					RecoveryMode:      recoveryMode,
-					Recover:           options.Recover,
+					AutoCacheRecover:  options.CacheRecover,
 					Data:              chData,
 					Source:            subsource.ConnectProxy,
 					HistoryMetaTTL:    chOpts.HistoryMetaTTL.ToDuration(),

--- a/internal/proxy/connect_handler_test.go
+++ b/internal/proxy/connect_handler_test.go
@@ -321,6 +321,30 @@ func TestHandleConnectWithSubscription(t *testing.T) {
 
 }
 
+func TestHandleConnectWithSubscriptionRecover(t *testing.T) {
+	opts := proxyGRPCTestServerOptions{
+		User:     "56",
+		Channels: []string{"test_ch"},
+	}
+	grpcTestCase := newConnHandleGRPCTestCase(context.Background(), newProxyGRPCTestServer("subscription with recover", opts))
+	defer grpcTestCase.Teardown()
+
+	httpTestCase := newConnHandleHTTPTestCase(context.Background(), "/proxy")
+	httpTestCase.Mux.HandleFunc("/proxy", func(w http.ResponseWriter, req *http.Request) {
+		_, _ = w.Write([]byte(`{"result": {"user": "56", "subs": {"test_ch": {"recover": true}}}}`))
+	})
+	defer httpTestCase.Teardown()
+
+	cases := newConnHandleTestCases(httpTestCase, grpcTestCase)
+	for _, c := range cases {
+		reply, err := c.invokeHandle(context.Background())
+		require.NoError(t, err, c.protocol)
+		require.NotNil(t, reply.Subscriptions, c.protocol)
+		require.Contains(t, reply.Subscriptions, "test_ch", c.protocol)
+		require.True(t, reply.Subscriptions["test_ch"].Recover, c.protocol)
+	}
+}
+
 func TestHandleConnectWithSubscriptionError(t *testing.T) {
 	opts := proxyGRPCTestServerOptions{
 		User:     "56",

--- a/internal/proxy/connect_handler_test.go
+++ b/internal/proxy/connect_handler_test.go
@@ -331,7 +331,7 @@ func TestHandleConnectWithSubscriptionRecover(t *testing.T) {
 
 	httpTestCase := newConnHandleHTTPTestCase(context.Background(), "/proxy")
 	httpTestCase.Mux.HandleFunc("/proxy", func(w http.ResponseWriter, req *http.Request) {
-		_, _ = w.Write([]byte(`{"result": {"user": "56", "subs": {"test_ch": {"recover": true}}}}`))
+		_, _ = w.Write([]byte(`{"result": {"user": "56", "subs": {"test_ch": {"cache_recover": true}}}}`))
 	})
 	defer httpTestCase.Teardown()
 
@@ -341,7 +341,7 @@ func TestHandleConnectWithSubscriptionRecover(t *testing.T) {
 		require.NoError(t, err, c.protocol)
 		require.NotNil(t, reply.Subscriptions, c.protocol)
 		require.Contains(t, reply.Subscriptions, "test_ch", c.protocol)
-		require.True(t, reply.Subscriptions["test_ch"].Recover, c.protocol)
+		require.True(t, reply.Subscriptions["test_ch"].AutoCacheRecover, c.protocol)
 	}
 }
 

--- a/internal/proxy/subscribe_handler.go
+++ b/internal/proxy/subscribe_handler.go
@@ -187,6 +187,7 @@ func (h *SubscribeHandler) Handle() SubscribeHandlerFunc {
 				EnableRecovery:    recovery,
 				EnablePositioning: positioning,
 				RecoveryMode:      recoveryMode,
+				Recover:           recovery && chOpts.AutoCacheRecovery && recoveryMode == centrifuge.RecoveryModeCache,
 				AllowedDeltaTypes: chOpts.AllowedDeltaTypes,
 				AllowTagsFilter:   chOpts.AllowTagsFilter,
 				Data:              data,

--- a/internal/proxy/subscribe_handler.go
+++ b/internal/proxy/subscribe_handler.go
@@ -187,7 +187,7 @@ func (h *SubscribeHandler) Handle() SubscribeHandlerFunc {
 				EnableRecovery:    recovery,
 				EnablePositioning: positioning,
 				RecoveryMode:      recoveryMode,
-				Recover:           recovery && chOpts.AutoCacheRecovery && recoveryMode == centrifuge.RecoveryModeCache,
+				AutoCacheRecover:  recovery && chOpts.AutoCacheRecover && recoveryMode == centrifuge.RecoveryModeCache,
 				AllowedDeltaTypes: chOpts.AllowedDeltaTypes,
 				AllowTagsFilter:   chOpts.AllowTagsFilter,
 				Data:              data,

--- a/internal/proxy/test_grpc_server.go
+++ b/internal/proxy/test_grpc_server.go
@@ -52,6 +52,17 @@ func (p proxyGRPCTestServer) Connect(_ context.Context, _ *proxyproto.ConnectReq
 				Channels: p.opts.Channels,
 			},
 		}, nil
+	case "subscription with recover":
+		subs := make(map[string]*proxyproto.SubscribeOptions, len(p.opts.Channels))
+		for _, ch := range p.opts.Channels {
+			subs[ch] = &proxyproto.SubscribeOptions{Recover: true}
+		}
+		return &proxyproto.ConnectResponse{
+			Result: &proxyproto.ConnectResult{
+				User: p.opts.User,
+				Subs: subs,
+			},
+		}, nil
 	case "custom disconnect":
 		return &proxyproto.ConnectResponse{
 			Disconnect: p.newDisconnect(),

--- a/internal/proxy/test_grpc_server.go
+++ b/internal/proxy/test_grpc_server.go
@@ -55,7 +55,7 @@ func (p proxyGRPCTestServer) Connect(_ context.Context, _ *proxyproto.ConnectReq
 	case "subscription with recover":
 		subs := make(map[string]*proxyproto.SubscribeOptions, len(p.opts.Channels))
 		for _, ch := range p.opts.Channels {
-			subs[ch] = &proxyproto.SubscribeOptions{Recover: true}
+			subs[ch] = &proxyproto.SubscribeOptions{CacheRecover: true}
 		}
 		return &proxyproto.ConnectResponse{
 			Result: &proxyproto.ConnectResult{

--- a/internal/proxyproto/proxy.pb.go
+++ b/internal/proxyproto/proxy.pb.go
@@ -334,8 +334,15 @@ type SubscribeOptions struct {
 	B64Data          string                   `protobuf:"bytes,5,opt,name=b64data,proto3" json:"b64data,omitempty"`
 	Override         *SubscribeOptionOverride `protobuf:"bytes,6,opt,name=override,proto3" json:"override,omitempty"`
 	ServerTagsFilter *FilterNode              `protobuf:"bytes,7,opt,name=server_tags_filter,json=serverTagsFilter,proto3" json:"server_tags_filter,omitempty"`
-	unknownFields    protoimpl.UnknownFields
-	sizeCache        protoimpl.SizeCache
+	// recover, when set, makes Centrifugo initiate recovery for the server-side
+	// subscription without requiring the client to provide a recover flag/position
+	// itself. This is the server-side equivalent of subscribing with an empty
+	// `since` on the client. Mostly useful for unidirectional clients which do not
+	// know channel names. Requires recovery to be enabled for the channel; in cache
+	// recovery mode this delivers the latest publication on (re)subscribe.
+	Recover       bool `protobuf:"varint,8,opt,name=recover,proto3" json:"recover,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *SubscribeOptions) Reset() {
@@ -415,6 +422,13 @@ func (x *SubscribeOptions) GetServerTagsFilter() *FilterNode {
 		return x.ServerTagsFilter
 	}
 	return nil
+}
+
+func (x *SubscribeOptions) GetRecover() bool {
+	if x != nil {
+		return x.Recover
+	}
+	return false
 }
 
 type ConnectResult struct {
@@ -3441,7 +3455,7 @@ const file_proxy_proto_rawDesc = "" +
 	"\ab64data\x18\v \x01(\tR\ab64data\x12\x12\n" +
 	"\x04name\x18\f \x01(\tR\x04name\x12\x18\n" +
 	"\aversion\x18\r \x01(\tR\aversion\x12\x1a\n" +
-	"\bchannels\x18\x0e \x03(\tR\bchannels\"\xb6\x02\n" +
+	"\bchannels\x18\x0e \x03(\tR\bchannels\"\xd0\x02\n" +
 	"\x10SubscribeOptions\x12\x1b\n" +
 	"\texpire_at\x18\x01 \x01(\x03R\bexpireAt\x12\x12\n" +
 	"\x04info\x18\x02 \x01(\fR\x04info\x12\x18\n" +
@@ -3449,7 +3463,8 @@ const file_proxy_proto_rawDesc = "" +
 	"\x04data\x18\x04 \x01(\fR\x04data\x12\x18\n" +
 	"\ab64data\x18\x05 \x01(\tR\ab64data\x12Q\n" +
 	"\boverride\x18\x06 \x01(\v25.centrifugal.centrifugo.proxy.SubscribeOptionOverrideR\boverride\x12V\n" +
-	"\x12server_tags_filter\x18\a \x01(\v2(.centrifugal.centrifugo.proxy.FilterNodeR\x10serverTagsFilter\"\xd2\x04\n" +
+	"\x12server_tags_filter\x18\a \x01(\v2(.centrifugal.centrifugo.proxy.FilterNodeR\x10serverTagsFilter\x12\x18\n" +
+	"\arecover\x18\b \x01(\bR\arecover\"\xd2\x04\n" +
 	"\rConnectResult\x12\x12\n" +
 	"\x04user\x18\x01 \x01(\tR\x04user\x12\x1b\n" +
 	"\texpire_at\x18\x02 \x01(\x03R\bexpireAt\x12\x12\n" +

--- a/internal/proxyproto/proxy.pb.go
+++ b/internal/proxyproto/proxy.pb.go
@@ -334,13 +334,14 @@ type SubscribeOptions struct {
 	B64Data          string                   `protobuf:"bytes,5,opt,name=b64data,proto3" json:"b64data,omitempty"`
 	Override         *SubscribeOptionOverride `protobuf:"bytes,6,opt,name=override,proto3" json:"override,omitempty"`
 	ServerTagsFilter *FilterNode              `protobuf:"bytes,7,opt,name=server_tags_filter,json=serverTagsFilter,proto3" json:"server_tags_filter,omitempty"`
-	// recover, when set, makes Centrifugo initiate recovery for the server-side
-	// subscription without requiring the client to provide a recover flag/position
-	// itself. This is the server-side equivalent of subscribing with an empty
-	// `since` on the client. Mostly useful for unidirectional clients which do not
-	// know channel names. Requires recovery to be enabled for the channel; in cache
-	// recovery mode this delivers the latest publication on (re)subscribe.
-	Recover       bool `protobuf:"varint,8,opt,name=recover,proto3" json:"recover,omitempty"`
+	// cache_recover, when set, makes Centrifugo initiate cache recovery for the
+	// server-side subscription without requiring the client to provide a recover
+	// flag/position itself. This is the server-side equivalent of subscribing with an
+	// empty `since` on the client. Mostly useful for unidirectional clients which do
+	// not know channel names. Requires recovery to be enabled for the channel and only
+	// applies in cache recovery mode, where it delivers the latest publication on
+	// (re)subscribe.
+	CacheRecover  bool `protobuf:"varint,8,opt,name=cache_recover,json=cacheRecover,proto3" json:"cache_recover,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -424,9 +425,9 @@ func (x *SubscribeOptions) GetServerTagsFilter() *FilterNode {
 	return nil
 }
 
-func (x *SubscribeOptions) GetRecover() bool {
+func (x *SubscribeOptions) GetCacheRecover() bool {
 	if x != nil {
-		return x.Recover
+		return x.CacheRecover
 	}
 	return false
 }
@@ -3455,7 +3456,7 @@ const file_proxy_proto_rawDesc = "" +
 	"\ab64data\x18\v \x01(\tR\ab64data\x12\x12\n" +
 	"\x04name\x18\f \x01(\tR\x04name\x12\x18\n" +
 	"\aversion\x18\r \x01(\tR\aversion\x12\x1a\n" +
-	"\bchannels\x18\x0e \x03(\tR\bchannels\"\xd0\x02\n" +
+	"\bchannels\x18\x0e \x03(\tR\bchannels\"\xdb\x02\n" +
 	"\x10SubscribeOptions\x12\x1b\n" +
 	"\texpire_at\x18\x01 \x01(\x03R\bexpireAt\x12\x12\n" +
 	"\x04info\x18\x02 \x01(\fR\x04info\x12\x18\n" +
@@ -3463,8 +3464,8 @@ const file_proxy_proto_rawDesc = "" +
 	"\x04data\x18\x04 \x01(\fR\x04data\x12\x18\n" +
 	"\ab64data\x18\x05 \x01(\tR\ab64data\x12Q\n" +
 	"\boverride\x18\x06 \x01(\v25.centrifugal.centrifugo.proxy.SubscribeOptionOverrideR\boverride\x12V\n" +
-	"\x12server_tags_filter\x18\a \x01(\v2(.centrifugal.centrifugo.proxy.FilterNodeR\x10serverTagsFilter\x12\x18\n" +
-	"\arecover\x18\b \x01(\bR\arecover\"\xd2\x04\n" +
+	"\x12server_tags_filter\x18\a \x01(\v2(.centrifugal.centrifugo.proxy.FilterNodeR\x10serverTagsFilter\x12#\n" +
+	"\rcache_recover\x18\b \x01(\bR\fcacheRecover\"\xd2\x04\n" +
 	"\rConnectResult\x12\x12\n" +
 	"\x04user\x18\x01 \x01(\tR\x04user\x12\x1b\n" +
 	"\texpire_at\x18\x02 \x01(\x03R\bexpireAt\x12\x12\n" +

--- a/internal/proxyproto/proxy.proto
+++ b/internal/proxyproto/proxy.proto
@@ -82,6 +82,13 @@ message SubscribeOptions {
   string b64data = 5;
   SubscribeOptionOverride override = 6;
   FilterNode server_tags_filter = 7;
+  // recover, when set, makes Centrifugo initiate recovery for the server-side
+  // subscription without requiring the client to provide a recover flag/position
+  // itself. This is the server-side equivalent of subscribing with an empty
+  // `since` on the client. Mostly useful for unidirectional clients which do not
+  // know channel names. Requires recovery to be enabled for the channel; in cache
+  // recovery mode this delivers the latest publication on (re)subscribe.
+  bool recover = 8;
 }
 
 message ConnectResult {

--- a/internal/proxyproto/proxy.proto
+++ b/internal/proxyproto/proxy.proto
@@ -82,13 +82,14 @@ message SubscribeOptions {
   string b64data = 5;
   SubscribeOptionOverride override = 6;
   FilterNode server_tags_filter = 7;
-  // recover, when set, makes Centrifugo initiate recovery for the server-side
-  // subscription without requiring the client to provide a recover flag/position
-  // itself. This is the server-side equivalent of subscribing with an empty
-  // `since` on the client. Mostly useful for unidirectional clients which do not
-  // know channel names. Requires recovery to be enabled for the channel; in cache
-  // recovery mode this delivers the latest publication on (re)subscribe.
-  bool recover = 8;
+  // cache_recover, when set, makes Centrifugo initiate cache recovery for the
+  // server-side subscription without requiring the client to provide a recover
+  // flag/position itself. This is the server-side equivalent of subscribing with an
+  // empty `since` on the client. Mostly useful for unidirectional clients which do
+  // not know channel names. Requires recovery to be enabled for the channel and only
+  // applies in cache recovery mode, where it delivers the latest publication on
+  // (re)subscribe.
+  bool cache_recover = 8;
 }
 
 message ConnectResult {


### PR DESCRIPTION
Adds a namespace channel option **`auto_cache_recover`** that makes Centrifugo automatically
initiate cache recovery for all subscriptions in the namespace on subscribe, without requiring
the subscriber to request it. In cache recovery mode this delivers the latest publication on
every (re)subscribe — so client-side subscribers no longer need to provide an empty `since`, and
it also works for **server-side subscriptions of unidirectional clients** (SSE, HTTP-streaming,
unidirectional WebSocket) that can't request recovery themselves and may not even know channel
names.

It also adds a per-subscription **`cache_recover`** field to the connect proxy result, so a
connect proxy can enable the same behavior for specific server-side subscriptions instead of
namespace-wide.

## Motivation

Cache recovery mode lets a channel behave like a real-time key-value store: the latest
publication is delivered as the first event on subscribe. Until now this required the client to
opt in by sending an empty `since`. That doesn't work for:

- server-side subscriptions (subscriptions decided by a connect proxy `subs`/`channels` or by a
  JWT), and
- unidirectional clients, which only send a token and may not know channel names.

`auto_cache_recover` covers these cases by letting the server force cache recovery for the
namespace (or, via the proxy, per subscription).

## Changes

- New namespace option `auto_cache_recover` (`configtypes.ChannelOptions.AutoCacheRecover`).
  Validation requires `force_recovery` and `force_recovery_mode: cache`; otherwise config
  validation fails fast.
- Client handler sets the forced-recovery flag on server-side subscriptions (from a connect
  proxy or JWT) and on client subscriptions in the namespace, gated to cache recovery mode.
- Connect proxy: new `cache_recover` field on the per-subscription `SubscribeOptions` message
  (`proxy.proto`, regenerated `proxy.pb.go`). When set, Centrifugo forces cache recovery for
  that server-side subscription — the server-side equivalent of an empty `since`.

### Configuration example

```json title="config.json"
{
  "channel": {
    "namespaces": [
      {
        "name": "example",
        "force_recovery": true,
        "force_recovery_mode": "cache",
        "auto_cache_recover": true,
        "history_size": 1,
        "history_ttl": "1h"
      }
    ]
  }
}
```

A unidirectional listener whose channels are decided server-side then receives the latest
publication per channel on every reconnect, without knowing channel names or stream positions.

## Dependency

Requires the matching Centrifuge change that renames `SubscribeOptions.Recover` →
`AutoCacheRecover` and scopes server-forced recovery to cache recovery mode (ignored in stream
mode). Centrifugo only enables the flag in cache mode, so the two are consistent: the option is
cache-only on both layers.

## Behavior

- Cache recovery mode: with `auto_cache_recover` enabled, every (re)subscribe delivers the
  latest publication (`recovered: true` when a publication exists, `false` on an empty/expired
  cache). Applies to client-side and server-side subscriptions in the namespace.
- The option requires `force_recovery` + `force_recovery_mode: cache`; any other combination is
  rejected at config validation time. It has no effect outside cache recovery mode.
- No behavior change for namespaces that don't set the option.
