### PR TITLE
Use cloud-sdk emulators image for pubsub emulator in CI

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,7 +66,7 @@ services:
       retries: 10
 
   google-pubsub-emulator:
-    image: google/cloud-sdk:latest
+    image: google/cloud-sdk:572.0.0-alpine
     command: gcloud beta emulators pubsub start --host-port=0.0.0.0:8085
     ports:
       - "8085:8085"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,7 +66,7 @@ services:
       retries: 10
 
   google-pubsub-emulator:
-    image: google/cloud-sdk:572.0.0-alpine
+    image: gcr.io/google.com/cloudsdktool/google-cloud-cli:572.0.0-emulators
     command: gcloud beta emulators pubsub start --host-port=0.0.0.0:8085
     ports:
       - "8085:8085"


### PR DESCRIPTION
## Proposed changes

google/cloud-sdk is not starting anymore, replacing to image which bundles the emulator components and Java
