### PR TITLE
metrics: split PG broker metrics into broker_/map_broker_ subsystems

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.44.0
 	github.com/aws/aws-sdk-go-v2/service/sts v1.43.3
 	github.com/aws/smithy-go v1.27.2
-	github.com/centrifugal/centrifuge v0.38.1-0.20260628075351-447901fa5929
+	github.com/centrifugal/centrifuge v0.38.1-0.20260628080247-160e2133061d
 	github.com/centrifugal/protocol v0.19.2
 	github.com/cristalhq/jwt/v5 v5.4.0
 	github.com/go-viper/mapstructure/v2 v2.5.0
@@ -125,10 +125,10 @@ require (
 	github.com/nats-io/nuid v1.0.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_model v0.6.2
-	github.com/prometheus/common v0.68.1 // indirect
-	github.com/prometheus/procfs v0.20.1 // indirect
+	github.com/prometheus/common v0.69.0 // indirect
+	github.com/prometheus/procfs v0.21.0 // indirect
 	github.com/quic-go/qpack v0.6.0 // indirect
-	github.com/redis/rueidis v1.0.75
+	github.com/redis/rueidis v1.0.76
 	github.com/segmentio/asm v1.2.1 // indirect
 	github.com/segmentio/encoding v0.5.4
 	github.com/spf13/cast v1.10.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.44.0
 	github.com/aws/aws-sdk-go-v2/service/sts v1.43.3
 	github.com/aws/smithy-go v1.27.2
-	github.com/centrifugal/centrifuge v0.38.1-0.20260615180132-f369d8fe1105
+	github.com/centrifugal/centrifuge v0.38.1-0.20260628075351-447901fa5929
 	github.com/centrifugal/protocol v0.19.2
 	github.com/cristalhq/jwt/v5 v5.4.0
 	github.com/go-viper/mapstructure/v2 v2.5.0

--- a/go.sum
+++ b/go.sum
@@ -73,8 +73,8 @@ github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6r
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/centrifugal/centrifuge v0.38.1-0.20260628075351-447901fa5929 h1:uBzTdVDqsbDHwilxsFCCxAEPrarntzHLsvCTvuV7kCs=
-github.com/centrifugal/centrifuge v0.38.1-0.20260628075351-447901fa5929/go.mod h1:BKroeyxtsjPHI9ZH7hJw0K4i1Yex/zvncUgJNBSk39Q=
+github.com/centrifugal/centrifuge v0.38.1-0.20260628080247-160e2133061d h1:S4t7OfmDVhuNF9v8YaWouKMGMpVC8KUtFd/oKXSUNVw=
+github.com/centrifugal/centrifuge v0.38.1-0.20260628080247-160e2133061d/go.mod h1:BZxC8CIQt7XEHmWpYejySRT2pFhDQfLLJR71gRRpD0E=
 github.com/centrifugal/protocol v0.19.2 h1:wc1S75EJvX5/KczsqEG74Bt/Jw/XwECDUzWR/vE/E9U=
 github.com/centrifugal/protocol v0.19.2/go.mod h1:zFsp4f1ZRejq1dkyNUbabdPj4dMYOpK8RRXDwHGVpVY=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
@@ -235,10 +235,10 @@ github.com/prometheus/client_golang v1.23.2/go.mod h1:Tb1a6LWHB3/SPIzCoaDXI4I8UH
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/client_model v0.6.2 h1:oBsgwpGs7iVziMvrGhE53c/GrLUsZdHnqNwqPLxwZyk=
 github.com/prometheus/client_model v0.6.2/go.mod h1:y3m2F6Gdpfy6Ut/GBsUqTWZqCUvMVzSfMLjcu6wAwpE=
-github.com/prometheus/common v0.68.1 h1:omjRRl4QP4komogpXuhfeOiisQg7xdy8VM1UY+pStaY=
-github.com/prometheus/common v0.68.1/go.mod h1:ZzL3f6u94qUxh9p+tJTrF+FvBS1XXbbRAZCQkytAL0Y=
-github.com/prometheus/procfs v0.20.1 h1:XwbrGOIplXW/AU3YhIhLODXMJYyC1isLFfYCsTEycfc=
-github.com/prometheus/procfs v0.20.1/go.mod h1:o9EMBZGRyvDrSPH1RqdxhojkuXstoe4UlK79eF5TGGo=
+github.com/prometheus/common v0.69.0 h1:OA85nJQS/T/MaYh/Q2CcgDKSGWqNIgrBDvDH85CuiNk=
+github.com/prometheus/common v0.69.0/go.mod h1:ZzL3f6u94qUxh9p+tJTrF+FvBS1XXbbRAZCQkytAL0Y=
+github.com/prometheus/procfs v0.21.0 h1:Qh/e6TlBjZf+XLLqNCqFGmCU6Kj/2Bu7kj3oAc0UnXc=
+github.com/prometheus/procfs v0.21.0/go.mod h1:aB55Cww9pdSJVHk0hUf0inxWyyjPogFIjmHKYgMKmtY=
 github.com/quagmt/udecimal v1.10.1 h1:h4t88kp/x21hCdhRhzBNW9e7D50l7pLEc1iwIEsCB28=
 github.com/quagmt/udecimal v1.10.1/go.mod h1:ScmJ/xTGZcEoYiyMMzgDLn79PEJHcMBiJ4NNRT3FirA=
 github.com/quic-go/go-ossfuzz-seeds v0.1.0 h1:APacT+iIaNF6fd8AGEiN3bT/Jtkd2jz4v4TzM7MFjy0=
@@ -251,8 +251,8 @@ github.com/quic-go/webtransport-go v0.11.0 h1:3afiZq7MHv3gmKCbMwZ8D5M1u0y/1RdONN
 github.com/quic-go/webtransport-go v0.11.0/go.mod h1:SHgEzUFVyj+9WUSuGB1P6Zd351Pww2leWV3SwlTovkA=
 github.com/rakutentech/jwk-go v1.2.0 h1:vNJwedPkRR+32V5WGNj0JP4COes93BGERvzQLBjLy4c=
 github.com/rakutentech/jwk-go v1.2.0/go.mod h1:pI0bYVntqaJ27RCpaC75MTUacheW0Rk4+8XzWWe1OWM=
-github.com/redis/rueidis v1.0.75 h1:zPlBDvjeMHaNCJT36U9ZKJNddMDXSti7OL2H7v2KYmo=
-github.com/redis/rueidis v1.0.75/go.mod h1:UsfHPSbomB6QAVMk4iiFkzRy0nh9o7scDGa+SitvBY4=
+github.com/redis/rueidis v1.0.76 h1:RdDWuvlYBSp+bTrBvaXqJnNEL3VVzsnjo+0psPFgLc4=
+github.com/redis/rueidis v1.0.76/go.mod h1:UsfHPSbomB6QAVMk4iiFkzRy0nh9o7scDGa+SitvBY4=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/rs/zerolog v1.35.1 h1:m7xQeoiLIiV0BCEY4Hs+j2NG4Gp2o2KPKmhnnLiazKI=

--- a/go.sum
+++ b/go.sum
@@ -73,8 +73,8 @@ github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6r
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/centrifugal/centrifuge v0.38.1-0.20260615180132-f369d8fe1105 h1:aL+lc8cFkJwWIXq2HBJ+tgFSpy628pEtuEltNVJrWRM=
-github.com/centrifugal/centrifuge v0.38.1-0.20260615180132-f369d8fe1105/go.mod h1:BKroeyxtsjPHI9ZH7hJw0K4i1Yex/zvncUgJNBSk39Q=
+github.com/centrifugal/centrifuge v0.38.1-0.20260628075351-447901fa5929 h1:uBzTdVDqsbDHwilxsFCCxAEPrarntzHLsvCTvuV7kCs=
+github.com/centrifugal/centrifuge v0.38.1-0.20260628075351-447901fa5929/go.mod h1:BKroeyxtsjPHI9ZH7hJw0K4i1Yex/zvncUgJNBSk39Q=
 github.com/centrifugal/protocol v0.19.2 h1:wc1S75EJvX5/KczsqEG74Bt/Jw/XwECDUzWR/vE/E9U=
 github.com/centrifugal/protocol v0.19.2/go.mod h1:zFsp4f1ZRejq1dkyNUbabdPj4dMYOpK8RRXDwHGVpVY=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=

--- a/internal/metrics/accessors.go
+++ b/internal/metrics/accessors.go
@@ -52,10 +52,17 @@ var (
 	HTTPRequestsTotal *prometheus.CounterVec
 )
 
-// PostgreSQL broker metrics - exported for use by pgmapbroker and pgstreambroker.
-// Shared subsystem "pg_broker" with a "broker" label to distinguish map vs stream.
+// Postgres broker metrics exported for use by pgmapbroker and pgstreambroker.
+//
+// All carry a postgres_ name prefix: these are Postgres-specific (outbox,
+// partitions, row cleanup), not generic broker concepts. Metrics emitted by both
+// PG brokers are split per kind (broker_* for stream, map_broker_* for map) so
+// the two never share a series. Cleanup is stream-only today.
 var (
-	PGBrokerCleanupRowsDeletedTotal *prometheus.CounterVec
-	PGBrokerOutboxCursorLagSeconds  *prometheus.GaugeVec
-	PGBrokerPartitions              *prometheus.GaugeVec
+	BrokerPostgresCleanupRemovedTotal *prometheus.CounterVec
+
+	BrokerPostgresOutboxCursorLagSeconds    *prometheus.GaugeVec
+	MapBrokerPostgresOutboxCursorLagSeconds *prometheus.GaugeVec
+	BrokerPostgresPartitions                *prometheus.GaugeVec
+	MapBrokerPostgresPartitions             *prometheus.GaugeVec
 )

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -100,10 +100,15 @@ type Registry struct {
 	connLimitReached  prometheus.Counter
 	httpRequestsTotal *prometheus.CounterVec
 
-	// PostgreSQL broker metrics (shared by both map and stream PG brokers)
-	pgBrokerCleanupRowsDeletedTotal *prometheus.CounterVec
-	pgBrokerOutboxCursorLagSeconds  *prometheus.GaugeVec
-	pgBrokerPartitions              *prometheus.GaugeVec
+	// PostgreSQL-specific broker metrics. Cleanup is Postgres-specific here (only
+	// the PG stream broker prunes rows, with PG table names in the "pass" label),
+	// so it carries the postgres_ prefix like the rest. Metrics emitted by both
+	// PG brokers are split per kind so stream and map never share a series.
+	brokerPostgresCleanupRemovedTotal       *prometheus.CounterVec
+	brokerPostgresOutboxCursorLagSeconds    *prometheus.GaugeVec
+	mapBrokerPostgresOutboxCursorLagSeconds *prometheus.GaugeVec
+	brokerPostgresPartitions                *prometheus.GaugeVec
+	mapBrokerPostgresPartitions             *prometheus.GaugeVec
 }
 
 // Init initializes the metrics registry with the provided configuration.
@@ -137,9 +142,11 @@ func Init(cfg Config) error {
 	ConnLimitReached = reg.connLimitReached
 	HTTPRequestsTotal = reg.httpRequestsTotal
 
-	PGBrokerCleanupRowsDeletedTotal = reg.pgBrokerCleanupRowsDeletedTotal
-	PGBrokerOutboxCursorLagSeconds = reg.pgBrokerOutboxCursorLagSeconds
-	PGBrokerPartitions = reg.pgBrokerPartitions
+	BrokerPostgresCleanupRemovedTotal = reg.brokerPostgresCleanupRemovedTotal
+	BrokerPostgresOutboxCursorLagSeconds = reg.brokerPostgresOutboxCursorLagSeconds
+	MapBrokerPostgresOutboxCursorLagSeconds = reg.mapBrokerPostgresOutboxCursorLagSeconds
+	BrokerPostgresPartitions = reg.brokerPostgresPartitions
+	MapBrokerPostgresPartitions = reg.mapBrokerPostgresPartitions
 
 	return nil
 }
@@ -309,30 +316,49 @@ func newRegistry(cfg Config) (*Registry, error) {
 		[]string{"path", "method", "status"},
 	)
 
-	// PostgreSQL broker metrics (shared by both pg_map_broker and pg_stream_broker).
-	m.pgBrokerCleanupRowsDeletedTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+	// Postgres-specific broker metrics carry a postgres_ name prefix. Cleanup is
+	// Postgres-specific here: only the PG stream broker prunes rows (the "pass"
+	// label is the PG table being cleaned), so it is not the generic cleanup
+	// metric. Metrics emitted by both PG brokers are split per kind below.
+	m.brokerPostgresCleanupRemovedTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace:   metricsNamespace,
-		Subsystem:   "pg_broker",
-		Name:        "cleanup_rows_deleted_total",
-		Help:        "Total rows deleted by each cleanup pass.",
+		Subsystem:   "broker",
+		Name:        "postgres_cleanup_removed_total",
+		Help:        "Total rows removed by each Postgres cleanup pass.",
 		ConstLabels: constLabels,
-	}, []string{"broker", "pass"})
+	}, []string{"broker_name", "pass"})
 
-	m.pgBrokerOutboxCursorLagSeconds = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	m.brokerPostgresOutboxCursorLagSeconds = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace:   metricsNamespace,
-		Subsystem:   "pg_broker",
-		Name:        "outbox_cursor_lag_seconds",
+		Subsystem:   "broker",
+		Name:        "postgres_outbox_cursor_lag_seconds",
 		Help:        "Time between the outbox cursor's row created_at and now, per shard.",
 		ConstLabels: constLabels,
-	}, []string{"broker", "shard"})
+	}, []string{"broker_name", "shard"})
 
-	m.pgBrokerPartitions = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	m.mapBrokerPostgresOutboxCursorLagSeconds = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace:   metricsNamespace,
-		Subsystem:   "pg_broker",
-		Name:        "partitions",
+		Subsystem:   "map_broker",
+		Name:        "postgres_outbox_cursor_lag_seconds",
+		Help:        "Time between the outbox cursor's row created_at and now, per shard.",
+		ConstLabels: constLabels,
+	}, []string{"broker_name", "shard"})
+
+	m.brokerPostgresPartitions = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace:   metricsNamespace,
+		Subsystem:   "broker",
+		Name:        "postgres_partitions",
 		Help:        "Count of stream/history table partitions.",
 		ConstLabels: constLabels,
-	}, []string{"broker"})
+	}, []string{"broker_name"})
+
+	m.mapBrokerPostgresPartitions = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace:   metricsNamespace,
+		Subsystem:   "map_broker",
+		Name:        "postgres_partitions",
+		Help:        "Count of stream/history table partitions.",
+		ConstLabels: constLabels,
+	}, []string{"broker_name"})
 
 	// Register all metrics
 	var alreadyRegistered prometheus.AlreadyRegisteredError
@@ -353,9 +379,11 @@ func newRegistry(cfg Config) (*Registry, error) {
 		m.sharedPollProxyResponseItems,
 		m.connLimitReached,
 		m.httpRequestsTotal,
-		m.pgBrokerCleanupRowsDeletedTotal,
-		m.pgBrokerOutboxCursorLagSeconds,
-		m.pgBrokerPartitions,
+		m.brokerPostgresCleanupRemovedTotal,
+		m.brokerPostgresOutboxCursorLagSeconds,
+		m.mapBrokerPostgresOutboxCursorLagSeconds,
+		m.brokerPostgresPartitions,
+		m.mapBrokerPostgresPartitions,
 	}
 
 	for _, collector := range collectors {

--- a/internal/pgmapbroker/pgmapbroker.go
+++ b/internal/pgmapbroker/pgmapbroker.go
@@ -2122,7 +2122,7 @@ func (e *PostgresMapBroker) expireKeys(ctx context.Context) {
 		}
 		rows.Close()
 		if removedCount > 0 {
-			e.node.AddMapBrokerCleanupKeysRemoved(e.conf.Name, removedCount)
+			e.node.AddMapBrokerCleanupRemoved(e.conf.Name, removedCount)
 		}
 	}
 }

--- a/internal/pgmapbroker/pgmapbroker_test.go
+++ b/internal/pgmapbroker/pgmapbroker_test.go
@@ -598,14 +598,14 @@ func TestPostgresMapBroker_CleanupMetrics(t *testing.T) {
 		}
 		var removedCount float64
 		for _, f := range families {
-			if f.GetName() == "centrifuge_map_broker_cleanup_keys_removed_count" {
+			if f.GetName() == "centrifuge_map_broker_cleanup_removed_count" {
 				for _, m := range f.GetMetric() {
 					removedCount += m.GetCounter().GetValue()
 				}
 			}
 		}
 		return removedCount >= 2
-	}, 10*time.Second, 200*time.Millisecond, "cleanup_keys_removed_count should reach >= 2")
+	}, 10*time.Second, 200*time.Millisecond, "cleanup_removed_count should reach >= 2")
 }
 
 // TestPostgresMapBroker_KeyTTL tests key TTL (this is a slower test).

--- a/internal/pgmapbroker/sampler.go
+++ b/internal/pgmapbroker/sampler.go
@@ -31,7 +31,7 @@ func (s *mapMetricsSampler) storeCursor(shard int, cursor int64) {
 }
 
 func (s *mapMetricsSampler) sample(ctx context.Context) {
-	if metrics.PGBrokerPartitions == nil {
+	if metrics.MapBrokerPostgresPartitions == nil {
 		return
 	}
 	brokerName := s.broker.conf.Name
@@ -44,7 +44,7 @@ func (s *mapMetricsSampler) sample(ctx context.Context) {
 		 WHERE c.relname = $1
 	`, s.broker.names.stream).Scan(&partitionCount)
 	if err == nil {
-		metrics.PGBrokerPartitions.WithLabelValues(brokerName).Set(float64(partitionCount))
+		metrics.MapBrokerPostgresPartitions.WithLabelValues(brokerName).Set(float64(partitionCount))
 	}
 
 	// Sample cursor lag per shard.
@@ -61,13 +61,13 @@ func (s *mapMetricsSampler) sample(ctx context.Context) {
 			s.broker.names.stream,
 		), cursor).Scan(&createdAt)
 		if err != nil {
-			metrics.PGBrokerOutboxCursorLagSeconds.WithLabelValues(brokerName, fmt.Sprintf("%d", shard)).Set(0)
+			metrics.MapBrokerPostgresOutboxCursorLagSeconds.WithLabelValues(brokerName, fmt.Sprintf("%d", shard)).Set(0)
 			continue
 		}
 		lag := time.Since(createdAt).Seconds()
 		if lag < 0 {
 			lag = 0
 		}
-		metrics.PGBrokerOutboxCursorLagSeconds.WithLabelValues(brokerName, fmt.Sprintf("%d", shard)).Set(lag)
+		metrics.MapBrokerPostgresOutboxCursorLagSeconds.WithLabelValues(brokerName, fmt.Sprintf("%d", shard)).Set(lag)
 	}
 }

--- a/internal/pgstreambroker/partition.go
+++ b/internal/pgstreambroker/partition.go
@@ -57,8 +57,8 @@ func (e *PostgresStreamBroker) runCleanupWorker() {
 }
 
 func addCleanupRows(broker, pass string, n int64) {
-	if metrics.PGBrokerCleanupRowsDeletedTotal != nil {
-		metrics.PGBrokerCleanupRowsDeletedTotal.WithLabelValues(broker, pass).Add(float64(n))
+	if metrics.BrokerPostgresCleanupRemovedTotal != nil {
+		metrics.BrokerPostgresCleanupRemovedTotal.WithLabelValues(broker, pass).Add(float64(n))
 	}
 }
 

--- a/internal/pgstreambroker/pgstreambroker_test.go
+++ b/internal/pgstreambroker/pgstreambroker_test.go
@@ -23,7 +23,7 @@ import (
 func TestMain(m *testing.M) {
 	// Initialize metrics with a custom registry for tests to avoid conflicts
 	// with prometheus.DefaultRegisterer. This populates the package-level vars
-	// (metrics.PGBrokerOrphanRows, etc.) that the sampler and tests use.
+	// (metrics.BrokerPostgresPartitions, etc.) that the sampler and tests use.
 	registry := prometheus.NewRegistry()
 	_ = metrics.Init(metrics.Config{
 		Registerer: registry,
@@ -1404,7 +1404,7 @@ func TestPostgresStreamBroker_Metrics(t *testing.T) {
 	time.Sleep(300 * time.Millisecond)
 
 	// Verify PG-specific gauges are populated (initialized by TestMain).
-	require.NotNil(t, metrics.PGBrokerPartitions)
+	require.NotNil(t, metrics.BrokerPostgresPartitions)
 }
 
 // TestPostgresStreamBroker_OutboxCursorLag verifies the outbox cursor lag
@@ -1424,7 +1424,7 @@ func TestPostgresStreamBroker_OutboxCursorLag(t *testing.T) {
 	// Wait for sampler to run. The main assertion is that the sampler
 	// doesn't panic when computing cursor lag.
 	time.Sleep(300 * time.Millisecond)
-	require.NotNil(t, metrics.PGBrokerOutboxCursorLagSeconds)
+	require.NotNil(t, metrics.BrokerPostgresOutboxCursorLagSeconds)
 }
 
 // testutilGaugeValue extracts a GaugeVec value for the given labels.

--- a/internal/pgstreambroker/sampler.go
+++ b/internal/pgstreambroker/sampler.go
@@ -32,7 +32,7 @@ func (s *metricsSampler) storeCursor(shard int, cursor int64) {
 }
 
 func (s *metricsSampler) sample(ctx context.Context) {
-	if metrics.PGBrokerPartitions == nil {
+	if metrics.BrokerPostgresPartitions == nil {
 		return
 	}
 	brokerName := s.broker.conf.Name
@@ -45,7 +45,7 @@ func (s *metricsSampler) sample(ctx context.Context) {
 		 WHERE c.relname = $1
 	`, s.broker.names.stream).Scan(&partitionCount)
 	if err == nil {
-		metrics.PGBrokerPartitions.WithLabelValues(brokerName).Set(float64(partitionCount))
+		metrics.BrokerPostgresPartitions.WithLabelValues(brokerName).Set(float64(partitionCount))
 	}
 
 	// Sample cursor lag per shard.
@@ -62,13 +62,13 @@ func (s *metricsSampler) sample(ctx context.Context) {
 			s.broker.names.stream,
 		), cursor).Scan(&createdAt)
 		if err != nil {
-			metrics.PGBrokerOutboxCursorLagSeconds.WithLabelValues(brokerName, fmt.Sprintf("%d", shard)).Set(0)
+			metrics.BrokerPostgresOutboxCursorLagSeconds.WithLabelValues(brokerName, fmt.Sprintf("%d", shard)).Set(0)
 			continue
 		}
 		lag := time.Since(createdAt).Seconds()
 		if lag < 0 {
 			lag = 0
 		}
-		metrics.PGBrokerOutboxCursorLagSeconds.WithLabelValues(brokerName, fmt.Sprintf("%d", shard)).Set(lag)
+		metrics.BrokerPostgresOutboxCursorLagSeconds.WithLabelValues(brokerName, fmt.Sprintf("%d", shard)).Set(lag)
 	}
 }


### PR DESCRIPTION
## What

Restructure the PostgreSQL broker metrics to follow the broker metric taxonomy: generic concepts under `broker_*` / `map_broker_*`, and a `postgres_` name prefix for Postgres-specific ones.

## Why

All PG broker metrics lived under a single `pg_broker` subsystem, shared by the stream and map PG brokers and distinguished only by a `broker` label. So a stream and a map PG broker running with the same (or default) name merged into the same series — and `pg_broker` doesn't fit the `broker_*` / `map_broker_*` model used elsewhere (mirrors the same fix done for the Redis brokers in the centrifuge library).

## Changes

| Before | After |
|---|---|
| `pg_broker_cleanup_rows_deleted_total` | `broker_postgres_cleanup_removed_total` |
| `pg_broker_outbox_cursor_lag_seconds` | `broker_postgres_outbox_cursor_lag_seconds` + `map_broker_postgres_outbox_cursor_lag_seconds` |
| `pg_broker_partitions` | `broker_postgres_partitions` + `map_broker_postgres_partitions` |

All three are **Postgres-specific** — transactional outbox cursor, table partitions, and row cleanup (the `pass` label is the PG table being cleaned). A metric is generic only if every broker implementation fills it; PG cleanup is emitted only by the PG stream broker and in a PG-specific shape, so it carries the `postgres_` prefix rather than masquerading as a generic `broker_cleanup_*`.

- `outbox` and `partitions` are emitted by both PG brokers → split per kind (`broker_*` + `map_broker_*`).
- `cleanup` is stream-only today → `broker_postgres_*` only.
- Label `broker` → `broker_name`, matching the rest of the metrics.

## Backward compatibility

Metrics rename (these were experimental): all `pg_broker_*` series are renamed as above. Dashboards/alerts referencing `pg_broker_*` need updating. No bundled dashboards/docs referenced them.

## Testing

- `go build ./...`, `go vet ./...` (whole repo) pass.
