### PR TITLE
Bound default decompressed WebSocket message size, options to tweak the limit

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -145,3 +145,5 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260615183401-62b3387ff324 // indirect
 	gopkg.in/yaml.v3 v3.0.1
 )
+
+replace github.com/centrifugal/centrifuge => /Users/fz/centrifugal/centrifuge

--- a/go.mod
+++ b/go.mod
@@ -125,10 +125,10 @@ require (
 	github.com/nats-io/nuid v1.0.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_model v0.6.2
-	github.com/prometheus/common v0.68.1 // indirect
-	github.com/prometheus/procfs v0.20.1 // indirect
+	github.com/prometheus/common v0.69.0 // indirect
+	github.com/prometheus/procfs v0.21.0 // indirect
 	github.com/quic-go/qpack v0.6.0 // indirect
-	github.com/redis/rueidis v1.0.75
+	github.com/redis/rueidis v1.0.76
 	github.com/segmentio/asm v1.2.1 // indirect
 	github.com/segmentio/encoding v0.5.4
 	github.com/spf13/cast v1.10.0 // indirect
@@ -145,5 +145,3 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260615183401-62b3387ff324 // indirect
 	gopkg.in/yaml.v3 v3.0.1
 )
-
-replace github.com/centrifugal/centrifuge => /Users/fz/centrifugal/centrifuge

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.44.0
 	github.com/aws/aws-sdk-go-v2/service/sts v1.43.3
 	github.com/aws/smithy-go v1.27.2
-	github.com/centrifugal/centrifuge v0.38.1-0.20260628080247-160e2133061d
+	github.com/centrifugal/centrifuge v0.38.1-0.20260628095811-f8a956294096
 	github.com/centrifugal/protocol v0.19.2
 	github.com/cristalhq/jwt/v5 v5.4.0
 	github.com/go-viper/mapstructure/v2 v2.5.0

--- a/go.sum
+++ b/go.sum
@@ -73,8 +73,8 @@ github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6r
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/centrifugal/centrifuge v0.38.1-0.20260628080247-160e2133061d h1:S4t7OfmDVhuNF9v8YaWouKMGMpVC8KUtFd/oKXSUNVw=
-github.com/centrifugal/centrifuge v0.38.1-0.20260628080247-160e2133061d/go.mod h1:BZxC8CIQt7XEHmWpYejySRT2pFhDQfLLJR71gRRpD0E=
+github.com/centrifugal/centrifuge v0.38.1-0.20260628095811-f8a956294096 h1:vsj+IjcN4YC8pAQwCbnZZ70+2LkbnMs7d/uswxdCzY4=
+github.com/centrifugal/centrifuge v0.38.1-0.20260628095811-f8a956294096/go.mod h1:BZxC8CIQt7XEHmWpYejySRT2pFhDQfLLJR71gRRpD0E=
 github.com/centrifugal/protocol v0.19.2 h1:wc1S75EJvX5/KczsqEG74Bt/Jw/XwECDUzWR/vE/E9U=
 github.com/centrifugal/protocol v0.19.2/go.mod h1:zFsp4f1ZRejq1dkyNUbabdPj4dMYOpK8RRXDwHGVpVY=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=

--- a/go.sum
+++ b/go.sum
@@ -235,10 +235,10 @@ github.com/prometheus/client_golang v1.23.2/go.mod h1:Tb1a6LWHB3/SPIzCoaDXI4I8UH
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/client_model v0.6.2 h1:oBsgwpGs7iVziMvrGhE53c/GrLUsZdHnqNwqPLxwZyk=
 github.com/prometheus/client_model v0.6.2/go.mod h1:y3m2F6Gdpfy6Ut/GBsUqTWZqCUvMVzSfMLjcu6wAwpE=
-github.com/prometheus/common v0.68.1 h1:omjRRl4QP4komogpXuhfeOiisQg7xdy8VM1UY+pStaY=
-github.com/prometheus/common v0.68.1/go.mod h1:ZzL3f6u94qUxh9p+tJTrF+FvBS1XXbbRAZCQkytAL0Y=
-github.com/prometheus/procfs v0.20.1 h1:XwbrGOIplXW/AU3YhIhLODXMJYyC1isLFfYCsTEycfc=
-github.com/prometheus/procfs v0.20.1/go.mod h1:o9EMBZGRyvDrSPH1RqdxhojkuXstoe4UlK79eF5TGGo=
+github.com/prometheus/common v0.69.0 h1:OA85nJQS/T/MaYh/Q2CcgDKSGWqNIgrBDvDH85CuiNk=
+github.com/prometheus/common v0.69.0/go.mod h1:ZzL3f6u94qUxh9p+tJTrF+FvBS1XXbbRAZCQkytAL0Y=
+github.com/prometheus/procfs v0.21.0 h1:Qh/e6TlBjZf+XLLqNCqFGmCU6Kj/2Bu7kj3oAc0UnXc=
+github.com/prometheus/procfs v0.21.0/go.mod h1:aB55Cww9pdSJVHk0hUf0inxWyyjPogFIjmHKYgMKmtY=
 github.com/quagmt/udecimal v1.10.1 h1:h4t88kp/x21hCdhRhzBNW9e7D50l7pLEc1iwIEsCB28=
 github.com/quagmt/udecimal v1.10.1/go.mod h1:ScmJ/xTGZcEoYiyMMzgDLn79PEJHcMBiJ4NNRT3FirA=
 github.com/quic-go/go-ossfuzz-seeds v0.1.0 h1:APacT+iIaNF6fd8AGEiN3bT/Jtkd2jz4v4TzM7MFjy0=
@@ -251,8 +251,8 @@ github.com/quic-go/webtransport-go v0.11.0 h1:3afiZq7MHv3gmKCbMwZ8D5M1u0y/1RdONN
 github.com/quic-go/webtransport-go v0.11.0/go.mod h1:SHgEzUFVyj+9WUSuGB1P6Zd351Pww2leWV3SwlTovkA=
 github.com/rakutentech/jwk-go v1.2.0 h1:vNJwedPkRR+32V5WGNj0JP4COes93BGERvzQLBjLy4c=
 github.com/rakutentech/jwk-go v1.2.0/go.mod h1:pI0bYVntqaJ27RCpaC75MTUacheW0Rk4+8XzWWe1OWM=
-github.com/redis/rueidis v1.0.75 h1:zPlBDvjeMHaNCJT36U9ZKJNddMDXSti7OL2H7v2KYmo=
-github.com/redis/rueidis v1.0.75/go.mod h1:UsfHPSbomB6QAVMk4iiFkzRy0nh9o7scDGa+SitvBY4=
+github.com/redis/rueidis v1.0.76 h1:RdDWuvlYBSp+bTrBvaXqJnNEL3VVzsnjo+0psPFgLc4=
+github.com/redis/rueidis v1.0.76/go.mod h1:UsfHPSbomB6QAVMk4iiFkzRy0nh9o7scDGa+SitvBY4=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/rs/zerolog v1.35.1 h1:m7xQeoiLIiV0BCEY4Hs+j2NG4Gp2o2KPKmhnnLiazKI=

--- a/internal/app/mux.go
+++ b/internal/app/mux.go
@@ -343,6 +343,7 @@ func websocketHandlerConfig(appCfg config.Config) centrifuge.WebsocketConfig {
 	cfg.UseWriteBufferPool = appCfg.WebSocket.UseWriteBufferPool
 	cfg.WriteTimeout = appCfg.WebSocket.WriteTimeout.ToDuration()
 	cfg.MessageSizeLimit = appCfg.WebSocket.MessageSizeLimit
+	cfg.DecompressedMessageSizeLimit = appCfg.WebSocket.DecompressedMessageSizeLimit
 	cfg.CheckOrigin = getCheckOrigin(appCfg)
 	cfg.PingPongConfig = getPingPongConfig(appCfg)
 	return cfg

--- a/internal/configtypes/types.go
+++ b/internal/configtypes/types.go
@@ -97,6 +97,12 @@ type WebSocket struct {
 	WriteBufferSize    int      `mapstructure:"write_buffer_size" json:"write_buffer_size" envconfig:"write_buffer_size" yaml:"write_buffer_size" toml:"write_buffer_size" doc:"WebSocket write buffer size in bytes. Zero uses the default gorilla/websocket buffer size."`
 	WriteTimeout       Duration `mapstructure:"write_timeout" json:"write_timeout" envconfig:"write_timeout" default:"1000ms" yaml:"write_timeout" toml:"write_timeout" doc:"Timeout for a single write operation to a WebSocket connection. Default <<1000ms>>."`
 	MessageSizeLimit   int      `mapstructure:"message_size_limit" json:"message_size_limit" envconfig:"message_size_limit" default:"65536" yaml:"message_size_limit" toml:"message_size_limit" doc:"Maximum allowed WebSocket message size in bytes. Default <<65536>>."`
+	// DecompressedMessageSizeLimit bounds the size of a message after permessage-deflate decompression.
+	// Only effective when Compression is enabled. message_size_limit alone bounds only the compressed bytes
+	// received on the wire, so without this limit a small compressed frame could be inflated into a much
+	// larger amount of memory (a "decompression bomb"). When zero, the limit is derived from
+	// message_size_limit multiplied by the default multiplier (10).
+	DecompressedMessageSizeLimit int `mapstructure:"decompressed_message_size_limit" json:"decompressed_message_size_limit" envconfig:"decompressed_message_size_limit" yaml:"decompressed_message_size_limit" toml:"decompressed_message_size_limit" doc:"Maximum allowed WebSocket message size in bytes after permessage-deflate decompression. Only used when compression is enabled. Zero derives the limit from message_size_limit times the default multiplier (10)."`
 }
 
 // SSE client real-time transport configuration.
@@ -132,6 +138,12 @@ type UniWebSocket struct {
 	WriteBufferSize    int      `mapstructure:"write_buffer_size" json:"write_buffer_size" envconfig:"write_buffer_size" yaml:"write_buffer_size" toml:"write_buffer_size" doc:"Write buffer size in bytes for unidirectional WebSocket connections. Zero uses the default buffer size."`
 	WriteTimeout       Duration `mapstructure:"write_timeout" json:"write_timeout" envconfig:"write_timeout" default:"1000ms" yaml:"write_timeout" toml:"write_timeout" doc:"Timeout for a single write operation on the unidirectional WebSocket transport. Default <<1000ms>>."`
 	MessageSizeLimit   int      `mapstructure:"message_size_limit" json:"message_size_limit" envconfig:"message_size_limit" default:"65536" yaml:"message_size_limit" toml:"message_size_limit" doc:"Maximum allowed message size in bytes for the unidirectional WebSocket transport. Default <<65536>>."`
+	// DecompressedMessageSizeLimit bounds the size of a message after permessage-deflate decompression.
+	// Only effective when Compression is enabled. message_size_limit alone bounds only the compressed bytes
+	// received on the wire, so without this limit a small compressed frame could be inflated into a much
+	// larger amount of memory (a "decompression bomb"). When zero, the limit is derived from
+	// message_size_limit multiplied by DefaultWebsocketDecompressedMessageSizeLimitMultiplier.
+	DecompressedMessageSizeLimit int `mapstructure:"decompressed_message_size_limit" json:"decompressed_message_size_limit" envconfig:"decompressed_message_size_limit" yaml:"decompressed_message_size_limit" toml:"decompressed_message_size_limit" doc:"Maximum allowed message size in bytes after permessage-deflate decompression for the unidirectional WebSocket transport. Only used when compression is enabled. Zero derives the limit from message_size_limit times the default multiplier (10)."`
 	// DisableClosingHandshake disables WebSocket closing handshake. This restores the behavior prior to
 	// Centrifugo v6.5.1 where server never sent a close frame on connection close initiated by server.
 	// Normally closing handshake is recommended to be performed according to WebSocket protocol RFC,

--- a/internal/uniws/config.go
+++ b/internal/uniws/config.go
@@ -18,6 +18,16 @@ const (
 	DefaultWebsocketMessageSizeLimit = 65536 // 64KB
 )
 
+// DefaultWebsocketDecompressedMessageSizeLimitMultiplier is the default factor
+// applied to MessageSizeLimit to derive the maximum allowed decompressed message
+// size when compression is negotiated and DecompressedMessageSizeLimit is not set
+// explicitly. MessageSizeLimit alone only bounds the compressed bytes received on
+// the wire, so a small compressed frame could otherwise be inflated into a much
+// larger amount of memory (a "decompression bomb"). The multiplier leaves
+// generous headroom for legitimately compressible messages while still rejecting
+// extreme expansion ratios.
+const DefaultWebsocketDecompressedMessageSizeLimitMultiplier = 10
+
 type Config = configtypes.UniWebSocket
 
 func sameHostOriginCheck() func(r *http.Request) bool {

--- a/internal/uniws/handler.go
+++ b/internal/uniws/handler.go
@@ -108,9 +108,26 @@ func (s *Handler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	if messageSizeLimit > 0 {
 		conn.SetReadLimit(int64(messageSizeLimit))
 	}
+	if compression {
+		decompressedMessageSizeLimit := s.config.DecompressedMessageSizeLimit
+		if decompressedMessageSizeLimit == 0 {
+			decompressedMessageSizeLimit = messageSizeLimit * DefaultWebsocketDecompressedMessageSizeLimitMultiplier
+		}
+		if decompressedMessageSizeLimit > 0 {
+			conn.SetDecompressedReadLimit(int64(decompressedMessageSizeLimit))
+		}
+	}
 
 	// Separate goroutine for better GC of caller's data.
 	go func() {
+		// Record server-sent (outgoing) close codes for observability. Runs last
+		// (registered first), after any teardown close frame has been written.
+		// Client-supplied codes are skipped to keep metric cardinality bounded.
+		defer func() {
+			if code, incoming := conn.CloseCode(); code != 0 && !incoming {
+				s.node.IncTransportOutgoingClose(transportName, code)
+			}
+		}()
 		opts := websocketTransportOptions{
 			framePingInterval:       framePingInterval,
 			framePongTimeout:        framePongTimeout,

--- a/internal/uniws/handler_test.go
+++ b/internal/uniws/handler_test.go
@@ -194,6 +194,58 @@ func TestUnidirectionalWebSocket(t *testing.T) {
 	})
 }
 
+func TestUnidirectionalWebSocket_DecompressionBombRejected(t *testing.T) {
+	t.Parallel()
+
+	node, err := centrifuge.New(centrifuge.Config{})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = node.Shutdown(context.Background()) })
+
+	node.OnConnecting(func(ctx context.Context, event centrifuge.ConnectEvent) (centrifuge.ConnectReply, error) {
+		return centrifuge.ConnectReply{Credentials: &centrifuge.Credentials{}}, nil
+	})
+
+	// MessageSizeLimit 1024 -> decompressed limit = 1024 * 10 = 10240 bytes.
+	config := configtypes.UniWebSocket{
+		Compression:      true,
+		MessageSizeLimit: 1024,
+	}
+
+	handler := NewHandler(node, config, func(r *http.Request) bool { return true }, centrifuge.PingPongConfig{})
+	server := httptest.NewServer(middleware.LogRequest(handler))
+	t.Cleanup(func() { server.Close() })
+
+	for {
+		resp, err := http.Get(server.URL)
+		if err != nil {
+			time.Sleep(100 * time.Millisecond)
+			continue
+		}
+		_ = resp.Body.Close()
+		break
+	}
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+
+	dialer := websocket.Dialer{EnableCompression: true}
+	conn, _, _, err := dialer.Dial(wsURL, nil)
+	require.NoError(t, err)
+	defer func() { _ = conn.Close() }()
+	require.NoError(t, conn.SetCompressionLevel(9))
+
+	// 64KB of zeros compresses to well under the 1024-byte compressed limit but
+	// inflates far past the 10240-byte decompressed limit, as the first
+	// (pre-auth) frame.
+	bomb := make([]byte, 64*1024)
+	require.NoError(t, conn.WriteMessage(websocket.BinaryMessage, bomb))
+
+	require.NoError(t, conn.SetReadDeadline(time.Now().Add(5*time.Second)))
+	_, _, err = conn.ReadMessage()
+	require.Error(t, err)
+	require.Truef(t, websocket.IsCloseError(err, websocket.CloseMessageTooBig),
+		"expected close %d, got %v", websocket.CloseMessageTooBig, err)
+}
+
 func TestUnidirectionalWebSocket_CloseFrameSent(t *testing.T) {
 	t.Parallel()
 

--- a/internal/websocket/close_code_test.go
+++ b/internal/websocket/close_code_test.go
@@ -1,0 +1,72 @@
+package websocket
+
+import (
+	"bytes"
+	"testing"
+	"time"
+)
+
+// TestCloseCode_Unset returns zero values before any close frame is observed.
+func TestCloseCode_Unset(t *testing.T) {
+	c := newTestConn(nil, &bytes.Buffer{}, true)
+	if code, incoming := c.CloseCode(); code != 0 || incoming {
+		t.Fatalf("CloseCode() = (%d, %v), want (0, false)", code, incoming)
+	}
+}
+
+// TestCloseCode_Outgoing records a close code we write as outgoing.
+func TestCloseCode_Outgoing(t *testing.T) {
+	c := newTestConn(nil, &bytes.Buffer{}, true)
+	_ = c.WriteControl(CloseMessage, FormatCloseMessage(CloseMessageTooBig, ""), time.Now().Add(time.Second))
+	if code, incoming := c.CloseCode(); code != CloseMessageTooBig || incoming {
+		t.Fatalf("CloseCode() = (%d, %v), want (%d, false)", code, incoming, CloseMessageTooBig)
+	}
+}
+
+// TestCloseCode_Incoming records a close code received from the peer as incoming
+// (and the subsequent RFC echo must not flip it to outgoing).
+func TestCloseCode_Incoming(t *testing.T) {
+	var buf bytes.Buffer
+	// Client writes a close frame (masked) into buf.
+	wc := newTestConn(nil, &buf, false)
+	_ = wc.WriteControl(CloseMessage, FormatCloseMessage(CloseGoingAway, ""), time.Now().Add(time.Second))
+
+	// Server reads it; advanceFrame records it as incoming and echoes a close.
+	rc := newTestConn(&buf, &bytes.Buffer{}, true)
+	if _, _, err := rc.NextReader(); !IsCloseError(err, CloseGoingAway) {
+		t.Fatalf("NextReader err = %v, want CloseError(%d)", err, CloseGoingAway)
+	}
+	if code, incoming := rc.CloseCode(); code != CloseGoingAway || !incoming {
+		t.Fatalf("CloseCode() = (%d, %v), want (%d, true)", code, incoming, CloseGoingAway)
+	}
+}
+
+// TestCloseCode_FirstWins keeps the initiating close, ignoring later frames.
+func TestCloseCode_FirstWins(t *testing.T) {
+	c := newTestConn(nil, &bytes.Buffer{}, true)
+	deadline := time.Now().Add(time.Second)
+	_ = c.WriteControl(CloseMessage, FormatCloseMessage(CloseMessageTooBig, ""), deadline)
+	_ = c.WriteControl(CloseMessage, FormatCloseMessage(CloseNormalClosure, ""), deadline)
+	if code, incoming := c.CloseCode(); code != CloseMessageTooBig || incoming {
+		t.Fatalf("CloseCode() = (%d, %v), want (%d, false)", code, incoming, CloseMessageTooBig)
+	}
+}
+
+// TestCloseCode_IncomingAppRangeStillIncoming proves an attacker-supplied
+// application-range close code (3000-4999) is recorded as incoming, so the
+// Centrifuge layer (which only records !incoming) will not turn it into a label.
+func TestCloseCode_IncomingAppRangeStillIncoming(t *testing.T) {
+	const appCode = 4321
+	var buf bytes.Buffer
+	wc := newTestConn(nil, &buf, false)
+	_ = wc.WriteControl(CloseMessage, FormatCloseMessage(appCode, ""), time.Now().Add(time.Second))
+
+	rc := newTestConn(&buf, &bytes.Buffer{}, true)
+	if _, _, err := rc.NextReader(); !IsCloseError(err, appCode) {
+		t.Fatalf("NextReader err = %v, want CloseError(%d)", err, appCode)
+	}
+	code, incoming := rc.CloseCode()
+	if code != appCode || !incoming {
+		t.Fatalf("CloseCode() = (%d, %v), want (%d, true)", code, incoming, appCode)
+	}
+}

--- a/internal/websocket/compression_limit_test.go
+++ b/internal/websocket/compression_limit_test.go
@@ -311,6 +311,47 @@ func TestDecompressedReadLimit_CompressedLimitStillApplies(t *testing.T) {
 	}
 }
 
+// TestDecompressedReadLimit_ErrorIsPermanent proves that once the decompressed
+// limit trips, the error is sticky: subsequent NextReader calls keep returning
+// ErrReadLimit instead of advancing to the next frame. This mirrors the
+// compressed-bytes limit (enforced in advanceFrame, which sets c.readErr via
+// NextReader) and honors the gorilla contract that read errors are permanent.
+func TestDecompressedReadLimit_ErrorIsPermanent(t *testing.T) {
+	const limit = 4096
+
+	// Two back-to-back compressed frames in one stream. The first is a bomb that
+	// trips the decompressed limit; the second is a small legitimate message that
+	// must NOT be delivered once the connection is in its terminal error state.
+	src := writeCompressedFrame(t, bytes.Repeat([]byte{'A'}, 1*1024*1024), 9)
+	next := writeCompressedFrame(t, []byte("should never be read"), 9)
+	src.Write(next.Bytes())
+
+	rc, out := newCompressedReader(src, limit)
+
+	_, r, err := rc.NextReader()
+	if err != nil {
+		t.Fatalf("NextReader: %v", err)
+	}
+	if _, err := io.ReadAll(r); !errors.Is(err, ErrReadLimit) {
+		t.Fatalf("io.ReadAll error = %v, want ErrReadLimit", err)
+	}
+	if !sentTooBig(out) {
+		t.Fatalf("expected CloseMessageTooBig control frame to be sent")
+	}
+
+	// The error must now be permanent: NextReader keeps returning ErrReadLimit
+	// rather than reading the second frame.
+	for i := 0; i < 3; i++ {
+		mt, r, err := rc.NextReader()
+		if !errors.Is(err, ErrReadLimit) {
+			t.Fatalf("NextReader #%d after limit = (%d, %v), want ErrReadLimit", i, mt, err)
+		}
+		if r != nil {
+			t.Fatalf("NextReader #%d returned non-nil reader after permanent error", i)
+		}
+	}
+}
+
 // TestDecompressedReadLimit_StreamingReads proves the limit is enforced on the
 // incremental NextReader path (used by the bidirectional handler's streaming
 // command decoder), not only via io.ReadAll: reading small chunks still trips

--- a/internal/websocket/compression_limit_test.go
+++ b/internal/websocket/compression_limit_test.go
@@ -1,0 +1,350 @@
+package websocket
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"math/rand"
+	"testing"
+)
+
+// writeCompressedFrame returns a buffer holding a single permessage-deflate
+// compressed binary message carrying payload. The frame is written as a client
+// (masked) so it can be consumed by a server-side reader.
+func writeCompressedFrame(t *testing.T, payload []byte, level int) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	wc := newTestConn(nil, &buf, false)
+	wc.newCompressionWriter = compressNoContextTakeover
+	if level != 0 {
+		if err := wc.SetCompressionLevel(level); err != nil {
+			t.Fatalf("SetCompressionLevel: %v", err)
+		}
+	}
+	w, err := wc.NextWriter(BinaryMessage)
+	if err != nil {
+		t.Fatalf("NextWriter: %v", err)
+	}
+	if _, err := w.Write(payload); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	return &buf
+}
+
+// newCompressedReader builds a server-side reader for frames stored in src,
+// with permessage-deflate decompression enabled and the given decompressed read
+// limit. out captures any control frames (e.g. CloseMessageTooBig) the reader
+// writes back to the peer.
+func newCompressedReader(src *bytes.Buffer, decompressedLimit int64) (rc *Conn, out *bytes.Buffer) {
+	out = &bytes.Buffer{}
+	rc = newTestConn(src, out, true)
+	rc.newDecompressionReader = decompressNoContextTakeover
+	rc.SetDecompressedReadLimit(decompressedLimit)
+	return rc, out
+}
+
+func sentTooBig(out *bytes.Buffer) bool {
+	// FormatCloseMessage encodes the 2-byte close code; the server reader does
+	// not mask control frames, so the encoded code appears verbatim in out.
+	return bytes.Contains(out.Bytes(), FormatCloseMessage(CloseMessageTooBig, ""))
+}
+
+// TestDecompressedReadLimit_Bomb proves that a tiny compressed frame that
+// inflates to a huge payload is rejected with ErrReadLimit, that the close
+// frame is sent, and crucially that memory is bounded: io.ReadAll stops after
+// at most limit+1 bytes instead of materializing the whole bomb.
+func TestDecompressedReadLimit_Bomb(t *testing.T) {
+	const limit = 64 * 1024
+	const decompressedSize = 8 * 1024 * 1024 // 8MB inflates from a few KB.
+
+	src := writeCompressedFrame(t, bytes.Repeat([]byte{'A'}, decompressedSize), 9)
+	if src.Len() >= limit {
+		t.Fatalf("compressed frame %d bytes is not under the compressed read limit %d; test would not isolate the decompressed limit", src.Len(), limit)
+	}
+
+	rc, out := newCompressedReader(src, limit)
+
+	mt, r, err := rc.NextReader()
+	if err != nil {
+		t.Fatalf("NextReader: %v", err)
+	}
+	if mt != BinaryMessage {
+		t.Fatalf("message type = %d, want %d", mt, BinaryMessage)
+	}
+
+	data, err := io.ReadAll(r)
+	if !errors.Is(err, ErrReadLimit) {
+		t.Fatalf("io.ReadAll error = %v, want ErrReadLimit", err)
+	}
+	if int64(len(data)) > limit+1 {
+		t.Fatalf("read %d bytes, want at most %d (memory must stay bounded)", len(data), limit+1)
+	}
+	if !sentTooBig(out) {
+		t.Fatalf("expected CloseMessageTooBig control frame to be sent")
+	}
+	// The server-sent 1009 must be observable as an outgoing close code.
+	if code, incoming := rc.CloseCode(); code != CloseMessageTooBig || incoming {
+		t.Fatalf("CloseCode() = (%d, %v), want (%d, false)", code, incoming, CloseMessageTooBig)
+	}
+}
+
+// TestDecompressedReadLimit_Boundary proves the exact accept/reject boundary:
+// a message of exactly limit bytes is accepted, limit+1 is rejected.
+func TestDecompressedReadLimit_Boundary(t *testing.T) {
+	const limit = 4096
+
+	cases := []struct {
+		name       string
+		size       int
+		wantErr    bool
+		wantTooBig bool
+	}{
+		{"under", limit - 1, false, false},
+		{"exact", limit, false, false},
+		{"over_by_one", limit + 1, true, true},
+		{"over_by_many", limit * 4, true, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			payload := bytes.Repeat([]byte{'x'}, tc.size)
+			src := writeCompressedFrame(t, payload, 0)
+			rc, out := newCompressedReader(src, limit)
+
+			_, r, err := rc.NextReader()
+			if err != nil {
+				t.Fatalf("NextReader: %v", err)
+			}
+			data, err := io.ReadAll(r)
+
+			if tc.wantErr {
+				if !errors.Is(err, ErrReadLimit) {
+					t.Fatalf("error = %v, want ErrReadLimit", err)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if !bytes.Equal(data, payload) {
+					t.Fatalf("decompressed payload mismatch: got %d bytes, want %d", len(data), len(payload))
+				}
+			}
+			if got := sentTooBig(out); got != tc.wantTooBig {
+				t.Fatalf("sentTooBig = %v, want %v", got, tc.wantTooBig)
+			}
+		})
+	}
+}
+
+// TestDecompressedReadLimit_LegitCompressible proves the fix does not break the
+// legitimate case the report worried about: a message whose compressed size is
+// small but whose decompressed size is well above the compressed bytes is still
+// accepted, as long as it stays within the (higher) decompressed limit.
+func TestDecompressedReadLimit_LegitCompressible(t *testing.T) {
+	const compressedReadLimit = 8 * 1024    // mimics MessageSizeLimit
+	const decompressedReadLimit = 80 * 1024 // mimics MessageSizeLimit * multiplier
+	const payloadSize = 64 * 1024           // > compressed limit, < decompressed limit
+
+	payload := bytes.Repeat([]byte("centrifuge "), payloadSize/11+1)[:payloadSize]
+	src := writeCompressedFrame(t, payload, 9)
+	if src.Len() >= compressedReadLimit {
+		t.Fatalf("compressed size %d not under compressed read limit %d", src.Len(), compressedReadLimit)
+	}
+
+	rc, out := newCompressedReader(src, decompressedReadLimit)
+	rc.SetReadLimit(compressedReadLimit) // compressed-bytes limit also active
+
+	_, r, err := rc.NextReader()
+	if err != nil {
+		t.Fatalf("NextReader: %v", err)
+	}
+	data, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("legit compressible message rejected: %v", err)
+	}
+	if !bytes.Equal(data, payload) {
+		t.Fatalf("payload mismatch: got %d bytes, want %d", len(data), len(payload))
+	}
+	if sentTooBig(out) {
+		t.Fatalf("unexpected CloseMessageTooBig for a legit message")
+	}
+}
+
+// TestDecompressedReadLimit_ReproducesPreFixVulnerability documents the
+// vulnerability the fix addresses: with only the compressed-bytes limit
+// (SetReadLimit, the protection that existed before this change) and no
+// decompressed limit, a small compressed frame that satisfies the compressed
+// limit still inflates without bound. This is exactly the pre-fix behavior
+// (decompressedReadLimit == 0 is equivalent to the code before the fix).
+func TestDecompressedReadLimit_ReproducesPreFixVulnerability(t *testing.T) {
+	const compressedReadLimit = 64 * 1024    // the old message_size_limit default
+	const decompressedSize = 8 * 1024 * 1024 // 8MB from a few KB on the wire
+
+	src := writeCompressedFrame(t, bytes.Repeat([]byte{'A'}, decompressedSize), 9)
+	compressedLen := src.Len() // capture before reading drains the buffer
+	// The compressed frame is comfortably under the compressed read limit, so
+	// the pre-fix defense does not trigger.
+	if compressedLen >= compressedReadLimit {
+		t.Fatalf("compressed frame %d bytes not under compressed limit %d", compressedLen, compressedReadLimit)
+	}
+
+	rc, out := newCompressedReader(src, 0) // 0 == no decompressed limit (pre-fix)
+	rc.SetReadLimit(compressedReadLimit)   // only the old compressed-bytes defense
+
+	_, r, err := rc.NextReader()
+	if err != nil {
+		t.Fatalf("NextReader: %v", err)
+	}
+	data, err := io.ReadAll(r)
+	// Pre-fix: no error and the full 8MB is materialized despite the compressed
+	// read limit, demonstrating the unbounded amplification (the bug).
+	if err != nil {
+		t.Fatalf("pre-fix path unexpectedly errored: %v", err)
+	}
+	if len(data) != decompressedSize {
+		t.Fatalf("inflated to %d bytes, want full %d (unbounded amplification)", len(data), decompressedSize)
+	}
+	if sentTooBig(out) {
+		t.Fatalf("pre-fix path should not send CloseMessageTooBig")
+	}
+	t.Logf("reproduced: %d compressed wire bytes (<= %d limit) inflated to %d bytes unbounded",
+		compressedLen, compressedReadLimit, len(data))
+}
+
+// TestDecompressedReadLimit_Disabled proves that a zero limit means unlimited
+// (the fork primitive's contract): the bomb fully inflates without error.
+func TestDecompressedReadLimit_Disabled(t *testing.T) {
+	const decompressedSize = 1 * 1024 * 1024
+	payload := bytes.Repeat([]byte{'A'}, decompressedSize)
+	src := writeCompressedFrame(t, payload, 9)
+
+	rc, out := newCompressedReader(src, 0) // 0 == unlimited
+
+	_, r, err := rc.NextReader()
+	if err != nil {
+		t.Fatalf("NextReader: %v", err)
+	}
+	data, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("unexpected error with limit disabled: %v", err)
+	}
+	if len(data) != decompressedSize {
+		t.Fatalf("read %d bytes, want %d", len(data), decompressedSize)
+	}
+	if sentTooBig(out) {
+		t.Fatalf("unexpected CloseMessageTooBig with limit disabled")
+	}
+}
+
+// TestDecompressedReadLimit_IgnoredWithoutCompression proves the decompressed
+// limit only applies to compressed frames: an uncompressed message larger than
+// the decompressed limit (but within the compressed read limit) passes through,
+// because the limit is gated on the RSV1/decompress path.
+func TestDecompressedReadLimit_IgnoredWithoutCompression(t *testing.T) {
+	const decompressedReadLimit = 1024
+	const payloadSize = 8 * 1024
+
+	var src bytes.Buffer
+	wc := newTestConn(nil, &src, false) // no compression writer -> plain frame
+	w, err := wc.NextWriter(BinaryMessage)
+	if err != nil {
+		t.Fatalf("NextWriter: %v", err)
+	}
+	payload := bytes.Repeat([]byte{'y'}, payloadSize)
+	if _, err := w.Write(payload); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	rc, _ := newCompressedReader(&src, decompressedReadLimit)
+	// readLimit (compressed bytes) generous enough to admit the plain frame.
+	rc.SetReadLimit(payloadSize + 1024)
+
+	_, r, err := rc.NextReader()
+	if err != nil {
+		t.Fatalf("NextReader: %v", err)
+	}
+	data, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("uncompressed message wrongly limited: %v", err)
+	}
+	if !bytes.Equal(data, payload) {
+		t.Fatalf("payload mismatch: got %d bytes, want %d", len(data), len(payload))
+	}
+}
+
+// TestDecompressedReadLimit_CompressedLimitStillApplies proves the two limits
+// are independent: with a decompressed limit set, the compressed-bytes limit
+// enforced in advanceFrame still trips for an oversized compressed frame.
+func TestDecompressedReadLimit_CompressedLimitStillApplies(t *testing.T) {
+	const compressedReadLimit = 1024
+	// Incompressible (deterministic pseudo-random) payload so compressed size
+	// stays large and exceeds the compressed read limit before decompression
+	// even matters.
+	payload := make([]byte, 8*1024)
+	rng := rand.New(rand.NewSource(1))
+	_, _ = rng.Read(payload)
+	src := writeCompressedFrame(t, payload, 0)
+	if src.Len() <= compressedReadLimit {
+		t.Fatalf("payload compressed too well (%d bytes) to exceed compressed limit", src.Len())
+	}
+
+	rc, _ := newCompressedReader(src, 10*1024*1024) // generous decompressed limit
+	rc.SetReadLimit(compressedReadLimit)
+
+	_, r, err := rc.NextReader()
+	if err != nil {
+		// Limit may surface from NextReader itself (advanceFrame) ...
+		if !errors.Is(err, ErrReadLimit) {
+			t.Fatalf("NextReader error = %v, want ErrReadLimit", err)
+		}
+		return
+	}
+	// ... or while reading.
+	if _, err := io.ReadAll(r); !errors.Is(err, ErrReadLimit) {
+		t.Fatalf("io.ReadAll error = %v, want ErrReadLimit", err)
+	}
+}
+
+// TestDecompressedReadLimit_StreamingReads proves the limit is enforced on the
+// incremental NextReader path (used by the bidirectional handler's streaming
+// command decoder), not only via io.ReadAll: reading small chunks still trips
+// the limit and keeps total consumed bytes bounded.
+func TestDecompressedReadLimit_StreamingReads(t *testing.T) {
+	const limit = 4096
+	payload := bytes.Repeat([]byte{'z'}, 1*1024*1024)
+	src := writeCompressedFrame(t, payload, 9)
+
+	rc, out := newCompressedReader(src, limit)
+	_, r, err := rc.NextReader()
+	if err != nil {
+		t.Fatalf("NextReader: %v", err)
+	}
+
+	buf := make([]byte, 256)
+	var total int
+	for {
+		n, err := r.Read(buf)
+		total += n
+		if err != nil {
+			if !errors.Is(err, ErrReadLimit) {
+				t.Fatalf("Read error = %v, want ErrReadLimit", err)
+			}
+			break
+		}
+		if total > limit+1 {
+			t.Fatalf("consumed %d bytes without hitting limit %d", total, limit)
+		}
+	}
+	if total > limit+1 {
+		t.Fatalf("consumed %d bytes, want at most %d", total, limit+1)
+	}
+	if !sentTooBig(out) {
+		t.Fatalf("expected CloseMessageTooBig control frame to be sent")
+	}
+}

--- a/internal/websocket/conn.go
+++ b/internal/websocket/conn.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 	"unicode/utf8"
 )
@@ -261,10 +262,14 @@ type Conn struct {
 	writeBuf               []byte // frame is constructed in this buffer.
 	readLength             int64  // Message size.
 	readLimit              int64  // Maximum message size.
-	compressionLevel       int
-	readMaskPos            int
-	writeBufSize           int
-	writeErrMu             sync.Mutex
+	decompressedReadLimit  int64  // Maximum decompressed message size (0 = unlimited).
+	// closeCode holds the first close frame observed on the connection, packed
+	// as bits 0-15 = code, bit 16 = incoming flag; 0 means none observed yet.
+	closeCode        atomic.Int32
+	compressionLevel int
+	readMaskPos      int
+	writeBufSize     int
+	writeErrMu       sync.Mutex
 	// bytes remaining in current frame.
 	// set setReadRemaining to safely update this value and prevent overflow
 	readRemaining          int64
@@ -403,6 +408,14 @@ func (c *Conn) WriteControl(messageType int, data []byte, deadline time.Time) er
 	}
 	if len(data) > maxControlFramePayloadSize {
 		return errInvalidControlFrame
+	}
+
+	if messageType == CloseMessage {
+		code := CloseNoStatusReceived
+		if len(data) >= 2 {
+			code = int(binary.BigEndian.Uint16(data))
+		}
+		c.recordCloseCode(code, false)
 	}
 
 	b0 := byte(messageType) | finalBit
@@ -942,6 +955,7 @@ func (c *Conn) advanceFrame() (int, error) {
 				return noFrame, c.handleProtocolError("invalid utf8 payload in close frame")
 			}
 		}
+		c.recordCloseCode(closeCode, true)
 		if err := c.defaultCloseHandler(closeCode, closeText); err != nil {
 			return noFrame, err
 		}
@@ -992,6 +1006,14 @@ func (c *Conn) NextReader() (messageType int, r io.Reader, err error) {
 			c.reader = c.messageReader
 			if c.readDecompress {
 				c.reader = c.newDecompressionReader(c.reader)
+				if c.decompressedReadLimit > 0 {
+					// readLimit bounds only the compressed bytes counted in
+					// advanceFrame. With permessage-deflate a small compressed
+					// frame can inflate into an unbounded amount of memory
+					// (a "decompression bomb"), so additionally bound the
+					// decompressed output here.
+					c.reader = &limitedReader{c: c, r: c.reader, remaining: c.decompressedReadLimit + 1}
+				}
 			}
 			return frameType, c.reader, nil
 		}
@@ -1053,6 +1075,56 @@ func (r *messageReader) Close() error {
 	return nil
 }
 
+// limitedReader wraps a decompression reader and bounds the number of
+// decompressed bytes that may be read from a single message. Unlike
+// io.LimitedReader it returns ErrReadLimit (and sends a CloseMessageTooBig
+// control frame, mirroring the compressed-bytes limit enforced in
+// advanceFrame) instead of io.EOF when the limit is exceeded, so callers do
+// not mistake a truncated message for a complete one.
+type limitedReader struct {
+	c         *Conn
+	r         io.Reader
+	remaining int64 // decompressed bytes that may still be read (configured limit + 1)
+	tooBig    bool  // whether the close control frame was already sent
+}
+
+func (l *limitedReader) Read(p []byte) (int, error) {
+	if l.remaining <= 0 {
+		return 0, l.limitExceeded()
+	}
+	if int64(len(p)) > l.remaining {
+		// Never read more than one byte past the configured limit: that single
+		// extra byte is enough to prove the decompressed message is too big
+		// while keeping buffered memory bounded.
+		p = p[:l.remaining]
+	}
+	n, err := l.r.Read(p)
+	l.remaining -= int64(n)
+	if l.remaining <= 0 {
+		// Read limit+1 decompressed bytes, so the message exceeds the limit
+		// regardless of whether the underlying reader also reported EOF.
+		return n, l.limitExceeded()
+	}
+	return n, err
+}
+
+func (l *limitedReader) limitExceeded() error {
+	if !l.tooBig {
+		l.tooBig = true
+		// Distinct reason from the compressed-frame limit (which sends an empty
+		// reason) so the peer/operator can tell the decompressed limit was hit.
+		_ = l.c.WriteControl(CloseMessage, FormatCloseMessage(CloseMessageTooBig, "message too big after decompression"), time.Now().Add(writeWait))
+	}
+	return ErrReadLimit
+}
+
+func (l *limitedReader) Close() error {
+	if rc, ok := l.r.(io.Closer); ok {
+		return rc.Close()
+	}
+	return nil
+}
+
 // ReadMessage is a helper method for getting a reader using NextReader and
 // reading from that reader to a buffer.
 func (c *Conn) ReadMessage() (messageType int, p []byte, err error) {
@@ -1078,6 +1150,46 @@ func (c *Conn) SetReadDeadline(t time.Time) error {
 // and returns ErrReadLimit to the application.
 func (c *Conn) SetReadLimit(limit int64) {
 	c.readLimit = limit
+}
+
+// SetDecompressedReadLimit sets the maximum size in bytes for a single
+// decompressed message read from the peer when permessage-deflate compression
+// is negotiated. SetReadLimit only bounds the compressed bytes received on the
+// wire, which allows a small compressed frame to be inflated into a much larger
+// amount of memory (a "decompression bomb"). This limit additionally bounds the
+// decompressed output of each message. If a message exceeds the limit, the
+// connection sends a close message to the peer and reads return ErrReadLimit. A
+// value of zero (the default) disables the decompressed limit.
+func (c *Conn) SetDecompressedReadLimit(limit int64) {
+	c.decompressedReadLimit = limit
+}
+
+const closeCodeIncomingBit = int32(1) << 16
+
+func (c *Conn) recordCloseCode(code int, incoming bool) {
+	if code <= 0 || code > 0xFFFF {
+		return
+	}
+	v := int32(code)
+	if incoming {
+		v |= closeCodeIncomingBit
+	}
+	// The first close frame observed wins, so the initiating close (and its
+	// true direction) is preserved rather than the handshake response or
+	// teardown close that follows it.
+	c.closeCode.CompareAndSwap(0, v)
+}
+
+// CloseCode returns the close code of the first close frame observed on the
+// connection and whether it was received from the peer (incoming) rather than
+// sent locally (outgoing). It returns (0, false) if no close frame has been
+// observed yet.
+func (c *Conn) CloseCode() (code int, incoming bool) {
+	v := c.closeCode.Load()
+	if v == 0 {
+		return 0, false
+	}
+	return int(v & 0xFFFF), v&closeCodeIncomingBit != 0
 }
 
 func (c *Conn) defaultCloseHandler(code int, _ string) error {

--- a/internal/websocket/conn.go
+++ b/internal/websocket/conn.go
@@ -1115,6 +1115,13 @@ func (l *limitedReader) limitExceeded() error {
 		// reason) so the peer/operator can tell the decompressed limit was hit.
 		_ = l.c.WriteControl(CloseMessage, FormatCloseMessage(CloseMessageTooBig, "message too big after decompression"), time.Now().Add(writeWait))
 	}
+	// Make the error permanent, mirroring the compressed-bytes limit enforced in
+	// advanceFrame: that path returns ErrReadLimit through NextReader, which sets
+	// c.readErr. The decompressed limit trips inside this reader (the one handed
+	// to the application), bypassing that assignment, so set it here too. Once set
+	// every subsequent NextReader call returns ErrReadLimit, honoring the gorilla
+	// contract that read errors are permanent.
+	l.c.readErr = ErrReadLimit
 	return ErrReadLimit
 }
 


### PR DESCRIPTION
In bidirectional WebSocket and in unidirectional WebSocket `message_size_limit` only bounds the **compressed** bytes received on the wire. With `permessage-deflate` compression negotiated, a small compressed frame can inflate into a much larger amount of memory — a classic "decompression bomb". This PR adds an independent limit on the **decompressed** size of a single message and wires it through the bidirectional and unidirectional WebSocket transports.

It also adds lightweight observability for server-sent close codes on the unidirectional WebSocket transport.

### Configuration (`internal/configtypes/types.go`, `internal/uniws/config.go`)

- New `decompressed_message_size_limit` option on both `WebSocket` and `UniWebSocket`.
- Only effective when compression is enabled.
- When zero (default), the limit is derived from `message_size_limit` × `10` (const multiplier) — generous headroom for legitimately compressible payloads while still rejecting extreme expansion ratios.

## Tests

- `TestUnidirectionalWebSocket_DecompressionBombRejected`: with `message_size_limit: 1024` (→ 10240-byte decompressed cap), a 64KB zero payload compresses under the compressed limit but inflates past the decompressed cap as the first pre-auth frame, and the server closes with `CloseMessageTooBig`.

## Docs

Documented the new `decompressed_message_size_limit` option (marked "Available since Centrifugo v6.8.4") on both the bidirectional and unidirectional WebSocket transport pages in the `centrifugal.dev` repo.

## Backward compatibility

- Default behavior is preserved: the new limit is opt-in via config, and the derived default (10× `message_size_limit`) only applies when compression is enabled. Connections without compression are unaffected.
