### PR TITLE
Fix/nats jetstream recreate on consumer deleted

### DIFF
--- a/internal/consuming/nats_jetstream.go
+++ b/internal/consuming/nats_jetstream.go
@@ -35,7 +35,8 @@ type NatsJetStreamConsumer struct {
 
 // NewNatsJetStreamConsumer creates a new NatsJetStreamConsumer instance.
 // On startup if creating a consumer fails then an error is returned.
-// Later at runtime, if a heartbeat error occurs the consumer is re-created endlessly.
+// Later at runtime, if a heartbeat error occurs or the consumer/stream is
+// deleted on the server side the consumer is re-created endlessly.
 func NewNatsJetStreamConsumer(
 	cfg NatsJetStreamConsumerConfig,
 	dispatcher Dispatcher,
@@ -280,12 +281,20 @@ func publicationTagsFromNatsHeaders(msg jetstream.Msg, prefix string) map[string
 	return tags
 }
 
-// errorHandler returns a jetstream error handler that triggers recreation on heartbeat loss.
+// errorHandler returns a jetstream error handler that triggers recreation on heartbeat loss
+// or when the consumer (or its stream) was deleted on the server side. The latter happens
+// when JetStream state is lost externally – ex. stream removed and re-created by an operator,
+// or in-memory stream lost after NATS restart. Without recreation Centrifugo would keep
+// logging errors without consuming anything until the process is restarted.
 func (c *NatsJetStreamConsumer) errorHandler() jetstream.ConsumeErrHandlerFunc {
 	return func(consumeCtx jetstream.ConsumeContext, err error) {
-		if errors.Is(err, jetstream.ErrNoHeartbeat) {
-			c.common.log.Warn().Msg("no heartbeat detected, triggering consumer recreation")
+		if errors.Is(err, jetstream.ErrNoHeartbeat) ||
+			errors.Is(err, jetstream.ErrConsumerDeleted) ||
+			errors.Is(err, jetstream.ErrConsumerNotFound) ||
+			errors.Is(err, jetstream.ErrStreamNotFound) {
+			c.common.log.Warn().Err(err).Msg("consumer unavailable, triggering consumer recreation")
 			c.triggerRecreation()
+			return
 		}
 		c.common.log.Error().Err(err).Msg("error during consuming")
 	}

--- a/internal/consuming/nats_jetstream.go
+++ b/internal/consuming/nats_jetstream.go
@@ -364,7 +364,7 @@ func (c *NatsJetStreamConsumer) Run(ctx context.Context) error {
 			c.consumeContext.Stop()
 			return ctx.Err()
 		case <-c.recreateCh:
-			c.common.log.Info().Msg("recreating consumer due to heartbeat error")
+			c.common.log.Info().Msg("recreating consumer")
 			c.consumeContext.Stop()
 			// Recreate the consumer.
 		}

--- a/internal/consuming/nats_jetstream_test.go
+++ b/internal/consuming/nats_jetstream_test.go
@@ -121,3 +121,90 @@ func testNatsJetStreamConsumer(t *testing.T, useExistingConsumer bool) {
 	time.Sleep(500 * time.Millisecond) // Give a short delay in case both try to ack
 	require.Equal(t, int64(1), receivedNum.Load(), "only one consumer should have received the message")
 }
+
+// TestNatsJetStreamConsumer_RecreateOnConsumerDeleted verifies that the consumer
+// recovers without a process restart when its JetStream consumer is lost on the
+// server side – ex. the stream is deleted and re-created by an operator, or an
+// in-memory stream is lost after NATS restart.
+func TestNatsJetStreamConsumer_RecreateOnConsumerDeleted(t *testing.T) {
+	t.Parallel()
+
+	url := "nats://localhost:4222"
+	subject := "test.recreate." + uuid.NewString()
+	durableConsumerName := "test-durable-" + uuid.NewString()
+	streamName := "TEST_STREAM_" + uuid.NewString()
+
+	nc, err := nats.Connect(url)
+	require.NoError(t, err)
+	defer nc.Close()
+
+	js, err := nc.JetStream()
+	require.NoError(t, err)
+
+	addStream := func() {
+		_, err := js.AddStream(&nats.StreamConfig{
+			Name:     streamName,
+			Subjects: []string{subject},
+			Storage:  nats.MemoryStorage,
+		})
+		require.NoError(t, err)
+	}
+	addStream()
+
+	var receivedNum atomic.Int64
+	dispatcher := &MockDispatcher{
+		onDispatchCommand: func(ctx context.Context, method string, data []byte) error {
+			receivedNum.Add(1)
+			return nil
+		},
+	}
+
+	cfg := NatsJetStreamConsumerConfig{
+		URL:                 url,
+		StreamName:          streamName,
+		Subjects:            []string{subject},
+		DurableConsumerName: durableConsumerName,
+		DeliverPolicy:       "new",
+		MethodHeader:        "test-method",
+	}
+
+	consumer, err := NewNatsJetStreamConsumer(cfg, dispatcher, testCommon(prometheus.NewRegistry()))
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		if err := consumer.Run(ctx); err != nil && !errors.Is(err, context.Canceled) {
+			t.Errorf("consumer error: %v", err)
+		}
+	}()
+
+	publishAndWaitReceived := func(stage string) {
+		deadline := time.Now().Add(30 * time.Second)
+		before := receivedNum.Load()
+		for time.Now().Before(deadline) {
+			msg := nats.NewMsg(subject)
+			msg.Data = []byte("hello")
+			msg.Header.Set("test-method", "publish")
+			_, _ = js.PublishMsg(msg)
+			time.Sleep(300 * time.Millisecond)
+			if receivedNum.Load() > before {
+				return
+			}
+		}
+		t.Fatalf("timeout waiting for message processing: %s", stage)
+	}
+
+	// Sanity check: consumer works initially.
+	publishAndWaitReceived("initial consume")
+
+	// Delete the stream: the durable consumer is destroyed together with it.
+	require.NoError(t, js.DeleteStream(streamName))
+	// Give the consumer some time to observe the loss.
+	time.Sleep(2 * time.Second)
+
+	// Re-create the stream (as an operator like NACK would do). The consumer
+	// must re-create its durable and resume consuming without a restart.
+	addStream()
+	publishAndWaitReceived("consume after stream re-creation")
+}


### PR DESCRIPTION
Follow-up to our Telegram discussion.

  Problem

  The NATS JetStream async consumer only re-creates itself on ErrNoHeartbeat. When the durable consumer (or its whole stream) is deleted on the server side, pull requests keep failing with nats: consumer deleted, which is only logged:

```
{"level":"error","consumer":"nats_market_quote","error":"nats: consumer deleted","message":"error during consuming"}
```

  Centrifugo then never consumes from that stream again until the process is restarted, while looking perfectly healthy. ErrNoHeartbeat is never triggered in this case: the failure surfaces as ErrConsumerDeleted instead, which was previously only logged and not acted upon.

  This happens in practice when a stream has to be deleted and re-created e.g., to change immutable fields (subjects, storage, limits) or when an in-memory stream is lost after a NATS restart. The stream comes back quickly, but the consumer doesn't, and the only recovery is a manual restart of all Centrifugo nodes.

  Reproducing steps

  1. Run Centrifugo with a nats_jetstream consumer attached to a stream.
  2. nats stream rm <STREAM> - Centrifugo starts logging error during consuming ... nats: consumer deleted forever.
  3. nats stream add <STREAM> (same config) - stream is back, but Centrifugo never consumes again until restarted. Can check by: nats consumer report <STREAM>.

  Fix

  ErrConsumerDeleted, ErrConsumerNotFound and ErrStreamNotFound now also trigger the existing recreation loop (same path as heartbeat loss). The loop already retries with backoff, so while the stream is absent it just keeps retrying; once the stream is back, the durable is re-created with the configured deliver_policy and consuming resumes - same semantics as a process restart, just automatic.

  Added an integration test covering the flow: consume -> delete stream -> re-create stream -> messages flow again without restart. The test is under the existing //go:build integration tag (same as the current NATS test) and passes against a local nats-server -js.