### PR TITLE
Hold read lock across token verification to fix verify vs reload race

### DIFF
--- a/internal/jwtverify/token_verifier_jwt.go
+++ b/internal/jwtverify/token_verifier_jwt.go
@@ -448,10 +448,9 @@ func (s *algorithms) verify(token *jwt.Token) error {
 	return verifier.Verify(token)
 }
 
+// verifySignature verifies a token's signature. The caller must hold
+// verifier.mu (at least RLock); it does not lock, to avoid recursive RLock.
 func (verifier *VerifierJWT) verifySignature(token *jwt.Token) error {
-	verifier.mu.RLock()
-	defer verifier.mu.RUnlock()
-
 	err := verifier.algorithms.verify(token)
 	if err != nil && verifier.previousHMACAlgorithms != nil {
 		if validUntil := verifier.hmacPreviousSecretKeyValidUntil; validUntil > 0 && time.Now().Unix() > validUntil {
@@ -464,10 +463,10 @@ func (verifier *VerifierJWT) verifySignature(token *jwt.Token) error {
 	return err
 }
 
+// verifySignatureByJWK verifies a token against the JWKS manager. The caller
+// must hold verifier.mu (at least RLock); it does not lock, to avoid recursive
+// RLock.
 func (verifier *VerifierJWT) verifySignatureByJWK(token *jwt.Token, tokenVars map[string]any) error {
-	verifier.mu.RLock()
-	defer verifier.mu.RUnlock()
-
 	return verifier.jwksManager.verify(token, tokenVars)
 }
 
@@ -535,6 +534,15 @@ func (verifier *VerifierJWT) VerifyConnectToken(t string, skipVerify bool) (Conn
 	if err != nil {
 		return ConnectToken{}, fmt.Errorf("%w: %v", ErrInvalidToken, err)
 	}
+
+	// Hold a read lock across the whole verification so a concurrent Reload (which
+	// rewrites the verifier's signing/config fields under mu.Lock) can't change
+	// them mid-verification - reading them unlocked was a data race and could
+	// nil-deref algorithms/jwksManager when a reload switched auth mode. The
+	// signature helpers assume the caller holds this lock and don't re-acquire it
+	// (recursive RLock can deadlock if a writer is waiting).
+	verifier.mu.RLock()
+	defer verifier.mu.RUnlock()
 
 	tokenVars := map[string]any{}
 
@@ -707,6 +715,11 @@ func (verifier *VerifierJWT) VerifySubscribeToken(t string, skipVerify bool) (Su
 	if err != nil {
 		return SubscribeToken{}, fmt.Errorf("%w: %v", ErrInvalidToken, err)
 	}
+
+	// See VerifyConnectToken: hold a read lock across verification so a concurrent
+	// Reload can't change the signing/config fields mid-verification.
+	verifier.mu.RLock()
+	defer verifier.mu.RUnlock()
 
 	tokenVars := map[string]any{}
 

--- a/internal/jwtverify/token_verifier_jwt_race_test.go
+++ b/internal/jwtverify/token_verifier_jwt_race_test.go
@@ -1,0 +1,61 @@
+package jwtverify
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/centrifugal/centrifugo/v6/internal/config"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestVerifierConcurrentReloadRace guards against a data race between token
+// verification and a concurrent config reload (SIGHUP). VerifyConnectToken /
+// VerifySubscribeToken used to read the verifier's signing/config fields unlocked
+// while Reload rewrites them under mu.Lock - a data race that could also nil-deref
+// algorithms/jwksManager when a reload switched auth mode. Verification now holds
+// verifier.mu.RLock for its whole body. Run with -race.
+func TestVerifierConcurrentReloadRace(t *testing.T) {
+	cfgContainer, err := config.NewContainer(config.DefaultConfig())
+	require.NoError(t, err)
+	verifier, err := NewTokenVerifierJWT(VerifierConfig{HMACSecretKey: "secret"}, cfgContainer)
+	require.NoError(t, err)
+
+	done := make(chan struct{})
+	var writerWg, readersWg sync.WaitGroup
+
+	// Writer reloads the verifier config repeatedly, as a SIGHUP would.
+	writerWg.Add(1)
+	go func() {
+		defer writerWg.Done()
+		configs := []VerifierConfig{
+			{HMACSecretKey: "secret"},
+			{HMACSecretKey: "secret2", HMACPreviousSecretKey: "secret"},
+			{HMACSecretKey: "secret", Audience: "aud", Issuer: "iss"},
+		}
+		for i := 0; ; i++ {
+			select {
+			case <-done:
+				return
+			default:
+			}
+			_ = verifier.Reload(configs[i%len(configs)])
+		}
+	}()
+
+	// Readers verify concurrently; results are irrelevant, only -race matters.
+	for r := 0; r < 4; r++ {
+		readersWg.Add(1)
+		go func() {
+			defer readersWg.Done()
+			for i := 0; i < 3000; i++ {
+				_, _ = verifier.VerifyConnectToken(jwtValid, false)
+				_, _ = verifier.VerifySubscribeToken(subJWTValidCustomUserClaim, false)
+			}
+		}()
+	}
+
+	readersWg.Wait()
+	close(done)
+	writerWg.Wait()
+}


### PR DESCRIPTION
VerifyConnectToken/VerifySubscribeToken read the verifier's signing and config fields (algorithms/jwksManager/audience/issuer/regexes/userIDClaim) without a lock while Reload (SIGHUP) rewrites them under mu.Lock. A reload concurrent with verification was a data race and could nil-deref algorithms/jwksManager when it switched auth mode (crash/DoS).

Take verifier.mu.RLock for the whole verification body (deferring RUnlock) so a reload can't change the fields mid-verification, and drop the now-redundant RLock inside verifySignature/verifySignatureByJWK since the caller holds it (re-locking would risk a recursive-RLock deadlock). Add a -race regression test that reloads concurrently with verification.