### PR TITLE
Fix hash(channel) overflow at INT_MIN in Postgres shard routing

### DIFF
--- a/internal/controllers/controller_postgres_schema.sql
+++ b/internal/controllers/controller_postgres_schema.sql
@@ -60,7 +60,7 @@ BEGIN
     IF p_num_shards <= 1 THEN
         v_shard_id := 0;
     ELSIF p_node_id != '' THEN
-        v_shard_id := abs(hashtext(p_node_id)) % p_num_shards;
+        v_shard_id := abs(hashtext(p_node_id)::bigint) % p_num_shards;
     ELSE
         v_shard_id := (txid_current() % p_num_shards)::INTEGER;
     END IF;

--- a/internal/pgmapbroker/internal/sql/schema.sql
+++ b/internal/pgmapbroker/internal/sql/schema.sql
@@ -193,7 +193,7 @@ BEGIN
     END IF;
 
     -- Calculate shard_id from channel hash
-    v_shard_id := abs(hashtext(p_channel)) % p_num_shards;
+    v_shard_id := abs(hashtext(p_channel)::bigint) % p_num_shards;
 
     -- 0. Per-shard serialization lock (lock order: shard → meta → state)
     PERFORM 1 FROM __PREFIX__shard_lock WHERE shard_id = v_shard_id FOR UPDATE;
@@ -472,7 +472,7 @@ BEGIN
     END IF;
 
     -- Calculate shard_id from channel hash
-    v_shard_id := abs(hashtext(p_channel)) % p_num_shards;
+    v_shard_id := abs(hashtext(p_channel)::bigint) % p_num_shards;
 
     -- 0. Per-shard serialization lock (lock order: shard → meta → state)
     PERFORM 1 FROM __PREFIX__shard_lock WHERE shard_id = v_shard_id FOR UPDATE;
@@ -638,7 +638,7 @@ BEGIN
     LOOP
         -- 0. Calculate shard_id and acquire per-shard serialization lock
         --    (lock order: shard → meta → state).
-        v_shard_id := abs(hashtext(v_channel)) % p_num_shards;
+        v_shard_id := abs(hashtext(v_channel)::bigint) % p_num_shards;
         PERFORM 1 FROM __PREFIX__shard_lock WHERE shard_id = v_shard_id FOR UPDATE;
 
         -- 1. Lock meta (same order as publish: shard → meta → state).

--- a/internal/pgmapbroker/pgmapbroker.go
+++ b/internal/pgmapbroker/pgmapbroker.go
@@ -563,29 +563,24 @@ func (e *PostgresMapBroker) getReadPool(channel string, allowCached bool) *pgxpo
 	if !allowCached || len(e.readPools) == 0 {
 		return e.pool
 	}
-	shardID := abs32(hashtext(channel)) % e.conf.NumShards
+	shardID := int(hashtext(channel) % uint32(e.conf.NumShards))
 	replicaIdx := shardID % len(e.readPools)
 	return e.readPools[replicaIdx]
 }
 
-// hashtext is a simple polynomial hash used for shard/replica routing.
-// It does NOT match PostgreSQL's hashtext() (which uses Jenkins lookup3) —
-// values differ for the same input. That is intentional: we only need
-// consistent routing within a single process; the PostgreSQL function is used
-// inside SQL for shard assignment, which is independent of this Go path.
-func hashtext(s string) int32 {
-	var h int32
+// hashtext is a simple polynomial hash used only for in-process read-replica
+// routing. It does NOT match PostgreSQL's hashtext() (which uses Jenkins
+// lookup3) — values differ for the same input, which is fine: replicas are
+// interchangeable, and the PostgreSQL function is used separately inside SQL for
+// shard assignment. It returns uint32 so the result is always non-negative and
+// can be taken modulo NumShards directly (no abs, and no math.MinInt32 overflow
+// edge case).
+func hashtext(s string) uint32 {
+	var h uint32
 	for i := 0; i < len(s); i++ {
-		h = h*31 + int32(s[i])
+		h = h*31 + uint32(s[i])
 	}
 	return h
-}
-
-func abs32(n int32) int {
-	if n < 0 {
-		return int(-n)
-	}
-	return int(n)
 }
 
 // RegisterEventHandler registers the event handler and starts background workers.

--- a/internal/pgstreambroker/internal/sql/schema.sql
+++ b/internal/pgstreambroker/internal/sql/schema.sql
@@ -234,7 +234,7 @@ BEGIN
         RAISE EXCEPTION 'shard_lock table is empty — run EnsureSchema first';
     END IF;
 
-    v_shard_id := abs(hashtext(p_channel)) % p_num_shards;
+    v_shard_id := abs(hashtext(p_channel)::bigint) % p_num_shards;
 
     -- Per-shard serialization lock (lock order: shard → meta).
     PERFORM 1 FROM __PREFIX__shard_lock WHERE shard_id = v_shard_id FOR UPDATE;
@@ -416,7 +416,7 @@ BEGIN
     IF p_num_shards IS NULL THEN
         SELECT COUNT(*)::INTEGER INTO p_num_shards FROM __PREFIX__shard_lock;
     END IF;
-    v_shard_id := abs(hashtext(p_channel)) % p_num_shards;
+    v_shard_id := abs(hashtext(p_channel)::bigint) % p_num_shards;
 
     -- Acquire shard lock so this insert serializes with publications on the
     -- same shard. Without this, the join's id could be committed before an
@@ -451,7 +451,7 @@ BEGIN
     IF p_num_shards IS NULL THEN
         SELECT COUNT(*)::INTEGER INTO p_num_shards FROM __PREFIX__shard_lock;
     END IF;
-    v_shard_id := abs(hashtext(p_channel)) % p_num_shards;
+    v_shard_id := abs(hashtext(p_channel)::bigint) % p_num_shards;
 
     PERFORM 1 FROM __PREFIX__shard_lock WHERE shard_id = v_shard_id FOR UPDATE;
 
@@ -480,7 +480,7 @@ BEGIN
     IF p_num_shards IS NULL THEN
         SELECT COUNT(*)::INTEGER INTO p_num_shards FROM __PREFIX__shard_lock;
     END IF;
-    v_shard_id := abs(hashtext(p_channel)) % p_num_shards;
+    v_shard_id := abs(hashtext(p_channel)::bigint) % p_num_shards;
 
     PERFORM 1 FROM __PREFIX__shard_lock WHERE shard_id = v_shard_id FOR UPDATE;
 

--- a/internal/pgstreambroker/pgstreambroker.go
+++ b/internal/pgstreambroker/pgstreambroker.go
@@ -170,21 +170,18 @@ func durationToIntervalString(d time.Duration) string {
 	return "1 milliseconds"
 }
 
-// hashtext approximates PostgreSQL hashtext() for shard routing. We only need
-// consistency within a process, not cross-process compatibility with PG.
-func hashtext(s string) int32 {
-	var h int32
+// hashtext is a simple polynomial hash used only for in-process read-replica
+// routing. It only needs consistency within a process, not cross-process
+// compatibility with PostgreSQL's hashtext() (which uses Jenkins lookup3 and is
+// used separately inside SQL for shard assignment). It returns uint32 so the
+// result is always non-negative and can be taken modulo NumShards directly (no
+// abs, and no math.MinInt32 overflow edge case).
+func hashtext(s string) uint32 {
+	var h uint32
 	for i := 0; i < len(s); i++ {
-		h = h*31 + int32(s[i])
+		h = h*31 + uint32(s[i])
 	}
 	return h
-}
-
-func abs32(n int32) int {
-	if n < 0 {
-		return int(-n)
-	}
-	return int(n)
 }
 
 // OutboxConfig configures outbox-based delivery.
@@ -599,7 +596,7 @@ func (e *PostgresStreamBroker) getReadPool(channel string, allowCached bool) *pg
 	if !allowCached || len(e.readPools) == 0 {
 		return e.pool
 	}
-	shardID := abs32(hashtext(channel)) % e.conf.NumShards
+	shardID := int(hashtext(channel) % uint32(e.conf.NumShards))
 	replicaIdx := shardID % len(e.readPools)
 	return e.readPools[replicaIdx]
 }


### PR DESCRIPTION
When `hashtext(channel)` returns exactly `INT_MIN`, `abs()` overflows and panics, breaking shard routing for the affected channels.

**Fix**
- Refactor `hashtext` to `uint32` and route via `int(hashtext(channel) % uint32(NumShards))`, removing the `abs32` helper entirely.
- New schema uses `abs(hashtext(x)::bigint)` so the SQL side can no longer overflow (new setups only; existing DBs converge on the next schema bump).