### PR TITLE
Azure property panic, broadcast error label, outbox lock liveness

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -376,7 +376,7 @@ func (h *Executor) Broadcast(ctx context.Context, cmd *BroadcastRequest) *Broadc
 				}
 			} else {
 				respError := ErrorInternal
-				metrics.IncAPIError(h.config.Protocol, "publish", respError.Code)
+				metrics.IncAPIError(h.config.Protocol, "broadcast_publish", respError.Code)
 				log.Error().Err(err).Str("channel", ch).Msg("error publishing data to channel during broadcast")
 				resp.Error = respError
 			}

--- a/internal/consuming/azure_service_bus.go
+++ b/internal/consuming/azure_service_bus.go
@@ -9,10 +9,10 @@ import (
 	"sync"
 	"time"
 
-	"github.com/centrifugal/centrifugo/v6/internal/metrics"
 	"github.com/centrifugal/centrifugo/v6/internal/api"
 	"github.com/centrifugal/centrifugo/v6/internal/configtypes"
 	"github.com/centrifugal/centrifugo/v6/internal/logging"
+	"github.com/centrifugal/centrifugo/v6/internal/metrics"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus"
@@ -363,7 +363,11 @@ func getAzureBoolProperty(msg *azservicebus.ReceivedMessage, key string) (bool, 
 	if !ok {
 		return false, nil
 	}
-	b, err := strconv.ParseBool(val.(string))
+	strVal, ok := val.(string)
+	if !ok {
+		return false, fmt.Errorf("property %q is not a string", key)
+	}
+	b, err := strconv.ParseBool(strVal)
 	if err != nil {
 		return false, fmt.Errorf("error parsing bool property %q: %w", key, err)
 	}

--- a/internal/pgoutbox/lock_worker.go
+++ b/internal/pgoutbox/lock_worker.go
@@ -13,6 +13,12 @@ import (
 // spikes — otherwise we spuriously release and re-acquire the lock.
 const lockPingMinTimeout = 2 * time.Second
 
+// lockLivenessInterval bounds how often the lock-holding connection is pinged
+// for liveness, whether the worker is busy or idle. It caps how long a silently
+// dropped lock connection — and therefore a dual-leader window — can go
+// undetected under a sustained backlog (where the worker never goes idle).
+const lockLivenessInterval = 5 * time.Second
+
 // LockWorker runs the advisory-lock variant of the outbox poll loop.
 //
 // Unlike Worker, LockWorker holds a session-scoped PostgreSQL advisory
@@ -170,6 +176,7 @@ func (lw *LockWorker) runLockedSession(ctx context.Context, closeCh <-chan struc
 		return false
 	}
 
+	lastLockPing := time.Now()
 	for {
 		select {
 		case <-closeCh:
@@ -207,41 +214,31 @@ func (lw *LockWorker) runLockedSession(ctx context.Context, closeCh <-chan struc
 			return false
 		}
 
+		// Ping the lock-holding connection on a time bound, whether the worker is
+		// busy or idle. Postgres releases the advisory lock when this session dies,
+		// so a silently reaped lock conn (pgbouncer reaping it, kernel TCP timeout,
+		// a network partition affecting only this conn) lets another node acquire
+		// the lock and dual-process. The lock conn is TCP-idle while queries run on
+		// PollPool, and under a sustained backlog the worker never reaches the idle
+		// wait below — so this liveness ping must run here, not only when idle. On
+		// failure, drop the session and re-acquire, restoring single-writer
+		// semantics.
+		if time.Since(lastLockPing) >= lockLivenessInterval {
+			alive, ctxDone := lw.pingLockConn(ctx, lockConn)
+			if ctxDone {
+				return true
+			}
+			if !alive {
+				return false
+			}
+			lastLockPing = time.Now()
+		}
+
 		if !idle {
 			continue
 		}
 
-		// Idle wait. While waiting, periodically ping the lock-holding
-		// connection so we detect silent session loss (pgbouncer reaping the
-		// idle conn, kernel TCP timeout, transient network partition
-		// affecting only this conn). If the lock conn dies, Postgres
-		// releases the advisory lock automatically on session end and
-		// another node could acquire it — leading to dual-leader processing
-		// of the same outbox region. The ping turns that into an explicit
-		// "lock lost" → release and re-acquire, restoring single-writer
-		// semantics. Cost is one round-trip per PollInterval during idle
-		// periods; during active batching the PollPool path already
-		// exercises the broader connection state.
-		//
-		// The ping timeout is decoupled from PollInterval: PollInterval
-		// controls idle cadence (often sub-second), but a ping is a TCP
-		// RTT liveness probe that must tolerate transient latency spikes
-		// without spuriously dropping the lock.
-		pingTimeout := lw.PollInterval
-		if pingTimeout < lockPingMinTimeout {
-			pingTimeout = lockPingMinTimeout
-		}
-		pingCtx, cancel := context.WithTimeout(ctx, pingTimeout)
-		err := lockConn.Conn().Ping(pingCtx)
-		cancel()
-		if err != nil {
-			if ctx.Err() != nil {
-				return true
-			}
-			lw.ErrorFn("outbox worker: lock connection ping failed — releasing lock", err)
-			return false
-		}
-
+		// Idle wait.
 		select {
 		case <-closeCh:
 			return true
@@ -250,6 +247,30 @@ func (lw *LockWorker) runLockedSession(ctx context.Context, closeCh <-chan struc
 		case <-time.After(lw.PollInterval):
 		}
 	}
+}
+
+// pingLockConn checks the lock-holding connection is still alive. Returns
+// (alive, ctxDone): alive=false means the connection is dead — Postgres has (or
+// will) release the advisory lock, so the caller must drop the session and
+// re-acquire; ctxDone=true means the worker is shutting down. The ping timeout
+// is decoupled from PollInterval (which can be sub-second) with a floor so a
+// transient latency spike doesn't spuriously drop the lock.
+func (lw *LockWorker) pingLockConn(ctx context.Context, lockConn *pgxpool.Conn) (alive bool, ctxDone bool) {
+	pingTimeout := lw.PollInterval
+	if pingTimeout < lockPingMinTimeout {
+		pingTimeout = lockPingMinTimeout
+	}
+	pingCtx, cancel := context.WithTimeout(ctx, pingTimeout)
+	err := lockConn.Conn().Ping(pingCtx)
+	cancel()
+	if err != nil {
+		if ctx.Err() != nil {
+			return false, true
+		}
+		lw.ErrorFn("outbox worker: lock connection ping failed — releasing lock", err)
+		return false, false
+	}
+	return true, false
 }
 
 // releaseAdvisoryLock explicitly releases an advisory lock held on conn.

--- a/internal/pgoutbox/lock_worker_test.go
+++ b/internal/pgoutbox/lock_worker_test.go
@@ -64,9 +64,10 @@ func findLockHolderPID(t *testing.T, pool *pgxpool.Pool, lockID int64) int32 {
 // TestLockWorker_LockConnTerminationDetected is the regression test for the
 // advisory-lock health-check ping. Once the worker has acquired the advisory
 // lock, an external session terminates the lock-holding backend; Postgres
-// then auto-releases the advisory lock. The ping during the next idle wait
-// must detect the dead session and surface it via ErrorFn so the worker
-// releases the (already-gone) lock and re-acquires it via the outer loop.
+// then auto-releases the advisory lock. The time-gated liveness ping (fires
+// every lockLivenessInterval, whether the worker is idle or busy) must detect
+// the dead session and surface it via ErrorFn so the worker releases the
+// (already-gone) lock and re-acquires it via the outer loop.
 //
 // Without the ping, the worker would happily continue polling on a healthy
 // PollPool connection while another node could have already acquired the
@@ -147,7 +148,7 @@ func TestLockWorker_LockConnTerminationDetected(t *testing.T) {
 			}
 		}
 		return false
-	}, 3*time.Second, 100*time.Millisecond, "ping failure was not surfaced via ErrorFn")
+	}, lockLivenessInterval+3*time.Second, 100*time.Millisecond, "ping failure was not surfaced via ErrorFn")
 
 	// And the worker should be able to re-acquire the lock under a fresh
 	// connection on its next cycle. We don't assert specific PIDs because


### PR DESCRIPTION
Three independent fixes.

**Fixes**
- Guard the Azure Service Bus bool-property type assertion (`val.(string)` comma-ok) against a panic on non-string application properties.
- Label per-channel Broadcast publish failures as `broadcast_publish` instead of reusing the `publish` label.

**Improvements**
- Ping the outbox advisory-lock connection while busy too (time-gated), not only during idle waits, so silent session loss is detected sooner.