### PR TITLE
Fix nil-request crashes and Azure message loss on failure

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -59,6 +59,14 @@ func (h *Executor) SetRPCExtension(method string, handler RPCHandler) {
 }
 
 func (h *Executor) processCmd(ctx context.Context, cmd *Command, i int, replies []*Reply) {
+	if cmd == nil {
+		// A batch can carry a nil command (e.g. a JSON `null` array element). In
+		// parallel mode processCmd runs in its own goroutine, so a nil-deref here
+		// would escape net/http's per-request recover and crash the whole process;
+		// reject it as a bad request instead.
+		replies[i].Error = ErrorBadRequest
+		return
+	}
 	var method string
 	if cmd.Publish != nil {
 		method = "publish"

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -68,6 +68,31 @@ func TestPublishAPI(t *testing.T) {
 	require.Equal(t, ErrorUnknownChannel, resp.Error)
 }
 
+// TestBatchAPINilCommand guards against a crash on a nil batch command (e.g. a
+// JSON `null` array element). In parallel mode each command runs in its own
+// goroutine, so a nil-deref would escape net/http's recover and crash the node.
+func TestBatchAPINilCommand(t *testing.T) {
+	node := nodeWithMemoryEngine()
+	cfg := config.DefaultConfig()
+	cfgContainer, err := config.NewContainer(cfg)
+	require.NoError(t, err)
+
+	api := NewExecutor(node, cfgContainer, &testSurveyCaller{}, ExecutorConfig{Protocol: "test", UseOpenTelemetry: false})
+
+	for _, parallel := range []bool{false, true} {
+		resp := api.Batch(context.Background(), &BatchRequest{
+			Parallel: parallel,
+			Commands: []*Command{
+				nil,
+				{Publish: &PublishRequest{Channel: "test", Data: []byte("x")}},
+			},
+		})
+		require.Len(t, resp.Replies, 2)
+		require.Equal(t, ErrorBadRequest, resp.Replies[0].Error)
+		require.Nil(t, resp.Replies[1].Error)
+	}
+}
+
 func TestBroadcastAPI(t *testing.T) {
 	node := nodeWithMemoryEngine()
 	cfg := config.DefaultConfig()

--- a/internal/consuming/azure_service_bus.go
+++ b/internal/consuming/azure_service_bus.go
@@ -9,10 +9,10 @@ import (
 	"sync"
 	"time"
 
-	"github.com/centrifugal/centrifugo/v6/internal/metrics"
 	"github.com/centrifugal/centrifugo/v6/internal/api"
 	"github.com/centrifugal/centrifugo/v6/internal/configtypes"
 	"github.com/centrifugal/centrifugo/v6/internal/logging"
+	"github.com/centrifugal/centrifugo/v6/internal/metrics"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus"
@@ -253,6 +253,7 @@ func (c *AzureServiceBusConsumer) runNonSessionMode(ctx context.Context) error {
 // azureCompleter defines an interface for completing messages.
 type azureCompleter interface {
 	CompleteMessage(context.Context, *azservicebus.ReceivedMessage, *azservicebus.CompleteMessageOptions) error
+	AbandonMessage(context.Context, *azservicebus.ReceivedMessage, *azservicebus.AbandonMessageOptions) error
 }
 
 // processMessage processes a single message with a retry mechanism.
@@ -262,14 +263,14 @@ func (c *AzureServiceBusConsumer) processMessage(ctx context.Context, msg *azser
 	data := msg.Body
 	const maxRetries = 5
 
+	var processErr error
 	for {
-		var err error
 		if c.config.PublicationDataMode.Enabled {
-			err = c.processPublicationDataMessage(ctx, msg, data)
+			processErr = c.processPublicationDataMessage(ctx, msg, data)
 		} else {
-			err = c.processCommandMessage(ctx, msg, data)
+			processErr = c.processCommandMessage(ctx, msg, data)
 		}
-		if err == nil {
+		if processErr == nil {
 			if retries > 0 {
 				c.common.log.Info().Msg("message processed successfully after retries")
 			}
@@ -277,17 +278,28 @@ func (c *AzureServiceBusConsumer) processMessage(ctx context.Context, msg *azser
 		}
 		// Stop retrying if context is canceled or maximum attempts reached.
 		if ctx.Err() != nil || retries >= maxRetries {
-			c.common.log.Error().Err(err).Msg("max retries reached or context canceled; abandoning message")
+			c.common.log.Error().Err(processErr).Msg("max retries reached or context canceled; abandoning message")
 			break
 		}
 		retries++
 		backoffDuration = getNextBackoffDuration(backoffDuration, retries)
-		c.common.log.Error().Err(err).Msgf("error processing message, retrying in %v", backoffDuration)
+		c.common.log.Error().Err(processErr).Msgf("error processing message, retrying in %v", backoffDuration)
 		select {
 		case <-time.After(backoffDuration):
 		case <-ctx.Done():
 			return
 		}
+	}
+
+	if processErr != nil {
+		// Processing failed after retries: abandon the message so the broker
+		// redelivers it (and eventually dead-letters at MaxDeliveryCount) instead
+		// of completing it, which settles it as successful and permanently drops it.
+		if err := completer.AbandonMessage(ctx, msg, nil); err != nil {
+			c.common.log.Error().Err(err).Msg("failed to abandon message")
+			metrics.ConsumerErrorsTotal.WithLabelValues(c.common.name).Inc()
+		}
+		return
 	}
 
 	// Complete the message (or log an error on failure).

--- a/internal/unihttpstream/handler.go
+++ b/internal/unihttpstream/handler.go
@@ -68,6 +68,13 @@ func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if req == nil {
+		// A literal `null` connect request decodes to a nil request with no error;
+		// treat it as an empty request rather than passing nil to the connect
+		// handler, which would nil-deref.
+		req = &protocol.ConnectRequest{}
+	}
+
 	ack := make(chan struct{})
 	transport := newStreamTransport(r, h.pingPong, ack)
 	c, closeFn, err := centrifuge.NewClient(r.Context(), h.node, transport)

--- a/internal/unisse/handler.go
+++ b/internal/unisse/handler.go
@@ -80,6 +80,13 @@ func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if req == nil {
+		// A literal `null` connect request decodes to a nil request with no error;
+		// treat it as an empty request rather than passing nil to the connect
+		// handler, which would nil-deref.
+		req = &protocol.ConnectRequest{}
+	}
+
 	ack := make(chan struct{})
 	transport := newEventsourceTransport(r, h.pingPong, ack)
 	c, closeFn, err := centrifuge.NewClient(r.Context(), h.node, transport)

--- a/internal/uniws/handler.go
+++ b/internal/uniws/handler.go
@@ -218,6 +218,14 @@ func (s *Handler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 			}
 		}
 
+		if req == nil {
+			// A literal `null` connect frame decodes to a nil request with no error;
+			// treat it as an empty connect request. Passing nil to the connect
+			// handler nil-derefs, and this runs in a bare goroutine (ServeHTTP has
+			// already returned), so the panic would crash the whole process.
+			req = &protocol.ConnectRequest{}
+		}
+
 		c.ProtocolConnect(req)
 
 		for {


### PR DESCRIPTION
Crash and message-loss fixes.

**Fixes**
- Guard against a nil `ConnectRequest` over uni WebSocket/SSE/HTTP-stream transports (null connect command panicked the node).
- Guard against a nil command inside a batch server-API request.
- Abandon (not Complete) an Azure Service Bus message when processing fails, so it is redelivered instead of silently dropped.