### PR TITLE
Fix publication timestamps, Nats epoch tag, rate limit, redisqueue signals

### DIFF
--- a/internal/app/mux.go
+++ b/internal/app/mux.go
@@ -148,8 +148,10 @@ func Mux(
 	}
 
 	connMiddlewares := append([]alice.Constructor{}, commonMiddlewares...)
-	connLimit := cfg.Client.ConnectionLimit
-	if connLimit > 0 {
+	// The ConnLimit middleware enforces both the total connection cap and the
+	// connection rate limit, so install it when either is configured - otherwise
+	// connection_rate_limit is silently ignored when connection_limit is 0.
+	if cfg.Client.ConnectionLimit > 0 || cfg.Client.ConnectionRateLimit > 0 {
 		connLimitMW := middleware.NewConnLimit(n, cfgContainer)
 		connMiddlewares = append(connMiddlewares, connLimitMW.Middleware)
 	}

--- a/internal/natsbroker/broker.go
+++ b/internal/natsbroker/broker.go
@@ -319,6 +319,9 @@ func (b *NatsBroker) handleClientMessage(subject string, data []byte, sub *nats.
 			sp.Offset = push.Pub.Offset
 			sp.Epoch = push.Pub.Tags[epochTagsKey]
 		}
+		// Strip the internal epoch tag so it isn't delivered to clients as if it
+		// were an application tag (no-op when absent).
+		delete(push.Pub.Tags, epochTagsKey)
 		delta := push.Pub.Delta
 		push.Pub.Delta = false
 		_ = b.eventHandler.HandlePublication(subChannel, pubFromProto(push.Pub, specificChannel), sp, delta, nil)

--- a/internal/pgmapbroker/pgx_helpers.go
+++ b/internal/pgmapbroker/pgx_helpers.go
@@ -168,12 +168,22 @@ func pgRawTimestampMillis(b []byte, format int16) int64 {
 		return 0
 	}
 	if format == pgTextFormat {
-		// PostgreSQL text format for timestamptz, e.g. "2025-06-15 12:34:56.123456+00"
-		t, err := time.Parse("2006-01-02 15:04:05.999999Z07:00:00", convert.BytesToString(b))
-		if err != nil {
-			return 0
+		// PostgreSQL renders timestamptz with a variable-width zone offset - hour
+		// only ("+00"), hour:minute ("+05:30"), or the rare hour:minute:second - so
+		// no single Go layout matches all of them (the previous "Z07:00:00" layout
+		// parsed none of PostgreSQL's actual output, zeroing every timestamp under
+		// the simple-query protocol). Try the three offset widths.
+		s := convert.BytesToString(b)
+		for _, layout := range []string{
+			"2006-01-02 15:04:05.999999-07",
+			"2006-01-02 15:04:05.999999-07:00",
+			"2006-01-02 15:04:05.999999-07:00:00",
+		} {
+			if t, err := time.Parse(layout, s); err == nil {
+				return t.UnixMilli()
+			}
 		}
-		return t.UnixMilli()
+		return 0
 	}
 	usec := int64(binary.BigEndian.Uint64(b))
 	return (usec + pgEpochDeltaUsec) / 1000

--- a/internal/redisqueue/consumer.go
+++ b/internal/redisqueue/consumer.go
@@ -149,11 +149,12 @@ func (c *Consumer) Run() {
 		c.poll()
 	}()
 
-	stop := newSignalHandler()
-	go func() {
-		<-stop
-		c.Shutdown()
-	}()
+	// NOTE: the upstream library installed its own process-global SIGINT/SIGTERM
+	// handler here that os.Exit(1)s on a second signal. That hijacks the embedding
+	// server's graceful shutdown (a second signal aborts it, skipping cleanup) and
+	// leaks goroutines. Centrifugo drives shutdown via Shutdown() on context
+	// cancellation (see consuming.RedisStreamConsumer.Run), so no signal handler
+	// is installed here.
 
 	var workerWg sync.WaitGroup
 	workerWg.Add(c.options.Concurrency)


### PR DESCRIPTION
Broker and limit correctness fixes.

**Fixes**
- Fix timestamptz text parsing that zeroed publication times.
- Strip the internal epoch tag before delivering NATS publications so it does not leak to clients.
- Enforce `connection_rate_limit` even when `connection_limit` is unset.
- Stop redisqueue from installing a process-global signal handler.