### PR TITLE
HTTP/2 ping write deadline and NATS JetStream redelivery backoff

### DIFF
--- a/internal/consuming/nats_jetstream.go
+++ b/internal/consuming/nats_jetstream.go
@@ -185,10 +185,29 @@ func (c *NatsJetStreamConsumer) msgHandler(msg jetstream.Msg) {
 		}
 	} else {
 		c.common.log.Error().Err(processErr).Msg("processing message failed")
-		if err := msg.Nak(); err != nil {
+		// NakWithDelay, not Nak: a bare Nak triggers instant redelivery with no
+		// backoff and the consumer sets no MaxDeliver, so a persistently failing
+		// (poison) message or a downstream outage would spin in a tight
+		// redeliver->fail->redeliver loop, pinning CPU and blocking head-of-line
+		// progress. Delay grows with the delivery count, capped like the other
+		// consumers' backoff.
+		if err := msg.NakWithDelay(natsNakDelay(msg)); err != nil {
 			c.common.log.Error().Err(err).Msg("failed to nak message")
 		}
 	}
+}
+
+// natsNakDelay computes an exponential redelivery backoff (capped) from the
+// message's delivery count.
+func natsNakDelay(msg jetstream.Msg) time.Duration {
+	retries := 1
+	if md, err := msg.Metadata(); err == nil && md.NumDelivered > 0 {
+		retries = int(md.NumDelivered)
+		if retries > 10 { // cap to avoid 1<<retries overflow / overlong delays
+			retries = 10
+		}
+	}
+	return getNextBackoffDuration(0, retries)
 }
 
 // processPublicationDataMessage processes a message in publication data mode.

--- a/internal/uniws/transport.go
+++ b/internal/uniws/transport.go
@@ -66,6 +66,20 @@ func (t *websocketTransport) ping() {
 			_ = t.Close(centrifuge.DisconnectWriteError)
 			return
 		}
+		if t.opts.writeTimeout > 0 && t.opts.protoMajor > 1 {
+			// WriteControl set a write deadline on the underlying HTTP/2 stream but,
+			// unlike writeData, nothing clears it here. An expired HTTP/2 deadline
+			// cannot be extended and permanently RSTs the stream, so an idle
+			// connection would be dropped ~writeTimeout after each ping. Clear it,
+			// serialized against writeData via writeMu.
+			t.writeMu.Lock()
+			derr := t.conn.NetConn().SetWriteDeadline(time.Time{})
+			t.writeMu.Unlock()
+			if derr != nil {
+				_ = t.Close(centrifuge.DisconnectWriteError)
+				return
+			}
+		}
 		t.addPing()
 	}
 }


### PR DESCRIPTION
Transport and consumer fixes.

**Fixes**
- Clear the HTTP/2 write deadline after a uni-websocket frame ping (a stale deadline could fail later writes on the shared h2 stream).
- Back off NATS JetStream redelivery with capped exponential delay (via `NumDelivered`) instead of an instant `Nak`, avoiding hot redelivery loops.