### PR TITLE
Resilient re-subscribe for Google Pub/Sub and NATS consumers

### DIFF
--- a/internal/consuming/google_pub_sub.go
+++ b/internal/consuming/google_pub_sub.go
@@ -9,16 +9,20 @@ import (
 	"sync"
 	"time"
 
-	"github.com/centrifugal/centrifugo/v6/internal/metrics"
 	"github.com/centrifugal/centrifugo/v6/internal/api"
 	"github.com/centrifugal/centrifugo/v6/internal/configtypes"
 	"github.com/centrifugal/centrifugo/v6/internal/logging"
+	"github.com/centrifugal/centrifugo/v6/internal/metrics"
 
 	"cloud.google.com/go/pubsub/v2"
 	"google.golang.org/api/option"
 )
 
 type GooglePubSubConsumerConfig = configtypes.GooglePubSubConsumerConfig
+
+// pubSubReceiveBackoffReset is the minimum duration a Receive call must run
+// before a subsequent failure is treated as fresh, resetting the retry backoff.
+const pubSubReceiveBackoffReset = 30 * time.Second
 
 // GooglePubSubConsumer represents a Google Pub/Sub consumer.
 type GooglePubSubConsumer struct {
@@ -83,15 +87,42 @@ func (c *GooglePubSubConsumer) Run(ctx context.Context) error {
 			sub.ReceiveSettings.MaxOutstandingBytes = c.config.MaxOutstandingBytes
 			sub.ReceiveSettings.NumGoroutines = 10
 
-			err := sub.Receive(ctx, func(ctx context.Context, msg *pubsub.Message) {
-				if logging.Enabled(logging.DebugLevel) {
-					c.common.log.Debug().Str("subscription", subID).
-						Msg("received message from subscription")
+			// Receive re-establishes the streaming pull and returns only on ctx
+			// cancellation or an error the SDK deems non-retryable. Such an error is
+			// not necessarily permanent (IAM propagation, quota reset, backend
+			// failover, subscription recreated), and without re-subscribing the
+			// subscription would stay silently dead for the whole process lifetime.
+			// Re-Receive with a capped backoff so a genuinely permanent error can't
+			// spin hot.
+			var backoff time.Duration
+			var retries int
+			for ctx.Err() == nil {
+				start := time.Now()
+				err := sub.Receive(ctx, func(ctx context.Context, msg *pubsub.Message) {
+					if logging.Enabled(logging.DebugLevel) {
+						c.common.log.Debug().Str("subscription", subID).
+							Msg("received message from subscription")
+					}
+					c.dispatchMessage(ctx, msg)
+				})
+				if err == nil || errors.Is(err, context.Canceled) || ctx.Err() != nil {
+					return
 				}
-				c.dispatchMessage(ctx, msg)
-			})
-			if err != nil && !errors.Is(err, context.Canceled) {
-				c.common.log.Error().Err(err).Msgf("error receiving messages for subscription %s", subscriptionID)
+				// A Receive that ran for a while before failing is a fresh failure,
+				// not an escalating one — reset the backoff ramp.
+				if time.Since(start) > pubSubReceiveBackoffReset {
+					backoff, retries = 0, 0
+				}
+				retries++
+				backoff = getNextBackoffDuration(backoff, retries)
+				metrics.ConsumerErrorsTotal.WithLabelValues(c.common.name).Inc()
+				c.common.log.Error().Err(err).Str("subscription", subscriptionID).
+					Dur("retry_in", backoff).Msg("error receiving messages, will re-subscribe")
+				select {
+				case <-time.After(backoff):
+				case <-ctx.Done():
+					return
+				}
 			}
 		}(subID)
 	}

--- a/internal/consuming/nats_jetstream.go
+++ b/internal/consuming/nats_jetstream.go
@@ -20,6 +20,10 @@ import (
 // NatsJetStreamConsumerConfig is an alias for our configuration type.
 type NatsJetStreamConsumerConfig = configtypes.NatsJetStreamConsumerConfig
 
+// natsConsumeBackoffReset is the minimum duration a consume session must run
+// before its end resets the recreation backoff, so rapid flapping still backs off.
+const natsConsumeBackoffReset = 30 * time.Second
+
 // NatsJetStreamConsumer consumes messages from NATS JetStream.
 type NatsJetStreamConsumer struct {
 	config         NatsJetStreamConsumerConfig
@@ -353,9 +357,8 @@ func (c *NatsJetStreamConsumer) Run(ctx context.Context) error {
 			continue
 		}
 
-		retries = 0
-		backoffDuration = 0
 		firstRun = false
+		startedAt := time.Now()
 
 		c.common.log.Info().Msg("consuming started, waiting for messages")
 		// Block until context cancellation or a recreation signal is received.
@@ -367,6 +370,15 @@ func (c *NatsJetStreamConsumer) Run(ctx context.Context) error {
 			c.common.log.Info().Msg("recreating consumer")
 			c.consumeContext.Stop()
 			// Recreate the consumer.
+		}
+
+		// Reset the backoff ramp only if the session ran healthily for a while. A
+		// session that starts fine but dies almost immediately (flapping) keeps the
+		// ramp so the recreation loop backs off instead of spinning, rather than
+		// resetting to zero on every short-lived start.
+		if time.Since(startedAt) > natsConsumeBackoffReset {
+			retries = 0
+			backoffDuration = 0
 		}
 	}
 }


### PR DESCRIPTION
Consumer resilience fixes.

**Fixes**
- Re-subscribe with capped backoff on a Google Pub/Sub receive error instead of exiting the receive loop (reset after a healthy session).
- Reset the NATS consume backoff only after a session ran healthy long enough, preventing rapid flap on immediate reconnect failures.