### PR TITLE
Fix reverse history pagination and Subscribe b64 decoding

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -443,11 +443,34 @@ func (h *Executor) Subscribe(_ context.Context, cmd *SubscribeRequest) *Subscrib
 		}
 	}
 
+	// Prefer the base64 fields when set (they exist for binary payloads that
+	// can't be carried in a JSON bytes field), matching publish/broadcast. Without
+	// this, b64data/b64info were silently dropped and the subscription got empty
+	// data/info.
+	data := cmd.Data
+	if cmd.B64Data != "" {
+		decoded, err := base64.StdEncoding.DecodeString(cmd.B64Data)
+		if err != nil {
+			resp.Error = ErrorBadRequest
+			return resp
+		}
+		data = decoded
+	}
+	info := cmd.Info
+	if cmd.B64Info != "" {
+		decoded, err := base64.StdEncoding.DecodeString(cmd.B64Info)
+		if err != nil {
+			resp.Error = ErrorBadRequest
+			return resp
+		}
+		info = decoded
+	}
+
 	err = h.node.Subscribe(user, channel,
-		centrifuge.WithSubscribeData(cmd.Data),
+		centrifuge.WithSubscribeData(data),
 		centrifuge.WithSubscribeClient(cmd.Client),
 		centrifuge.WithSubscribeSession(cmd.Session),
-		centrifuge.WithChannelInfo(cmd.Info),
+		centrifuge.WithChannelInfo(info),
 		centrifuge.WithExpireAt(cmd.ExpireAt),
 		centrifuge.WithEmitJoinLeave(joinLeave),
 		centrifuge.WithPushJoinLeave(pushJoinLeave),

--- a/internal/pgstreambroker/history.go
+++ b/internal/pgstreambroker/history.go
@@ -78,7 +78,12 @@ func (e *PostgresStreamBroker) History(ch string, opts centrifuge.HistoryOptions
 	effectiveStart := windowStart
 	effectiveEnd := topOffset
 	if opts.Filter.Reverse {
-		if opts.Filter.Since != nil {
+		// Reverse returns publications strictly before Since (descending).
+		// Guard sinceOffset == 0: centrifuge's Since.Offset is uint64, so its
+		// `since.Offset - 1` underflows to MaxUint64 for offset 0, which means
+		// "read the whole stream from the top". We keep effectiveEnd = topOffset
+		// in that case instead of computing -1 (which would match no rows).
+		if opts.Filter.Since != nil && sinceOffset > 0 {
 			effectiveEnd = sinceOffset - 1
 		}
 	} else {

--- a/internal/pgstreambroker/history.go
+++ b/internal/pgstreambroker/history.go
@@ -69,9 +69,23 @@ func (e *PostgresStreamBroker) History(ch string, opts centrifuge.HistoryOptions
 	if opts.Filter.Since != nil {
 		sinceOffset = int64(opts.Filter.Since.Offset)
 	}
-	effectiveStart := sinceOffset + 1
-	if windowStart > effectiveStart {
-		effectiveStart = windowStart
+	// Compute the offset window [effectiveStart, effectiveEnd]. Forward returns
+	// publications after Since (ascending); reverse returns publications before
+	// Since (descending) - the boundary sits on the opposite side of the cursor,
+	// as in the memory/redis/pgmapbroker brokers. Using Since+1 for both
+	// directions made reverse pagination return already-seen or empty pages and
+	// never reach older messages.
+	effectiveStart := windowStart
+	effectiveEnd := topOffset
+	if opts.Filter.Reverse {
+		if opts.Filter.Since != nil {
+			effectiveEnd = sinceOffset - 1
+		}
+	} else {
+		effectiveStart = sinceOffset + 1
+		if windowStart > effectiveStart {
+			effectiveStart = windowStart
+		}
 	}
 
 	effectiveLimit := math.MaxInt32
@@ -115,7 +129,7 @@ func (e *PostgresStreamBroker) History(ch string, opts centrifuge.HistoryOptions
 		 LIMIT $6
 	`, e.names.stream, order)
 
-	rows, err := pool.Query(ctx, rowsQuery, ch, effectiveStart, topOffset, cutoff, epoch, effectiveLimit)
+	rows, err := pool.Query(ctx, rowsQuery, ch, effectiveStart, effectiveEnd, cutoff, epoch, effectiveLimit)
 	if err != nil {
 		return nil, centrifuge.StreamPosition{}, fmt.Errorf("postgres stream broker: history query: %w", err)
 	}


### PR DESCRIPTION
Server API and broker fixes.

**Fixes**
- Fix reverse history pagination in the Postgres stream broker (bounds computed per direction).
- Decode `b64data` / `b64info` in the server API `Subscribe` method (they were ignored).