### PR TITLE
Fix map read error translation and config validation

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -1044,6 +1044,10 @@ func (h *Executor) MapReadState(ctx context.Context, cmd *MapReadStateRequest) *
 
 	result, err := h.node.MapStateRead(ctx, ch, opts)
 	if err != nil {
+		if errors.Is(err, centrifuge.ErrorUnrecoverablePosition) {
+			resp.Error = ErrorUnrecoverablePosition
+			return resp
+		}
 		log.Error().Err(err).Str("channel", ch).Msg("error in map read state")
 		resp.Error = ErrorInternal
 		return resp
@@ -1114,6 +1118,10 @@ func (h *Executor) MapReadStream(ctx context.Context, cmd *MapReadStreamRequest)
 
 	result, err := h.node.MapStreamRead(ctx, ch, opts)
 	if err != nil {
+		if errors.Is(err, centrifuge.ErrorUnrecoverablePosition) {
+			resp.Error = ErrorUnrecoverablePosition
+			return resp
+		}
 		log.Error().Err(err).Str("channel", ch).Msg("error in map read stream")
 		resp.Error = ErrorInternal
 		return resp

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -19,7 +19,7 @@ var knownBrokers = []string{"memory", "nats", "redis", "redisnats", "postgres"}
 
 // Validate validates config and returns error if problems found.
 func (c Config) Validate() error {
-	if c.HTTP.H2CExternal && strconv.Itoa(c.HTTP.Port) == c.HTTP.InternalPort {
+	if c.HTTP.H2CExternal && (c.HTTP.InternalPort == "" || strconv.Itoa(c.HTTP.Port) == c.HTTP.InternalPort) {
 		return fmt.Errorf("external_h2c requires custom separate internal_port to be configured")
 	}
 	if c.HTTP.TLS.Enabled && c.HTTP.H2CExternal {
@@ -596,10 +596,10 @@ func validateCodeToUniDisconnectTransforms(transforms configtypes.UniConnectCode
 			return fmt.Errorf("no code specified in transforms[%d]", i)
 		}
 		if t.To.Code == 0 {
-			return errors.New("no disconnect code specified in transforms[%d].to")
+			return fmt.Errorf("no disconnect code specified in transforms[%d].to", i)
 		}
 		if !tools.IsASCII(t.To.Reason) {
-			return errors.New("disconnect reason must be ASCII in transforms[%d].to")
+			return fmt.Errorf("disconnect reason must be ASCII in transforms[%d].to", i)
 		}
 	}
 	return nil


### PR DESCRIPTION
Correctness fixes.

**Fixes**
- Translate the unrecoverable-position error in the map read API methods so clients receive the proper error.
- Fix config validation: use `fmt.Errorf` args in transform error messages, and correct the `h2c_external` check when the internal port is empty.