### PR TITLE
Fix Sentinel TLS, WebTransport OOM, metric cardinality, stream proxy cancel

### DIFF
--- a/internal/confighelpers/redis.go
+++ b/internal/confighelpers/redis.go
@@ -109,7 +109,7 @@ func getRedisShardConfigs(redisConf configtypes.Redis) ([]centrifuge.RedisShardC
 			}
 			conf.SentinelClientName = redisConf.SentinelClientName
 			if redisConf.SentinelTLS.Enabled {
-				tlsConfig, err := redisConf.TLS.ToGoTLSConfig("redis_sentinel")
+				tlsConfig, err := redisConf.SentinelTLS.ToGoTLSConfig("redis_sentinel")
 				if err != nil {
 					return nil, fmt.Errorf("error creating Redis Sentinel TLS config: %v", err)
 				}

--- a/internal/middleware/http_instrumentation.go
+++ b/internal/middleware/http_instrumentation.go
@@ -16,6 +16,15 @@ func HTTPServerInstrumentation(next http.Handler) http.Handler {
 		rw := &statusResponseWriter{w, http.StatusOK}
 		next.ServeHTTP(rw, r)
 		status := strconv.Itoa(rw.status)
-		metrics.HTTPRequestsTotal.WithLabelValues(r.URL.Path, r.Method, status).Inc()
+		// Use the matched route pattern, not the raw request path. Subtree
+		// handlers (admin, swagger, dev, debug) accept arbitrary client-controlled
+		// sub-paths, so labeling by r.URL.Path would grow the Prometheus series map
+		// without bound (memory DoS). r.Pattern is the registered pattern that
+		// matched (e.g. "/admin/"), so cardinality is bounded by the route count.
+		path := r.Pattern
+		if path == "" {
+			path = "other"
+		}
+		metrics.HTTPRequestsTotal.WithLabelValues(path, r.Method, status).Inc()
 	})
 }

--- a/internal/proxy/subscribe_stream_handler.go
+++ b/internal/proxy/subscribe_stream_handler.go
@@ -173,6 +173,11 @@ func (h *SubscribeStreamHandler) Handle() SubscribeStreamHandlerFunc {
 
 		if subscribeRep.Disconnect != nil {
 			//proxyCallErrorCount.WithLabelValues(proxyName, "subscribe", "disconnect_"+strconv.FormatUint(uint64(subscribeRep.Disconnect.Code), 10)).Inc()
+			// SubscribeStream returned successfully here, so it has opened the stream
+			// and spawned its reader goroutine. Every rejection/error return below
+			// must cancel it or the stream context and goroutine leak until the
+			// client disconnects.
+			cancelFunc()
 			return centrifuge.SubscribeReply{}, nil, nil, &centrifuge.Disconnect{
 				Code:   subscribeRep.Disconnect.Code,
 				Reason: subscribeRep.Disconnect.Reason,
@@ -180,6 +185,7 @@ func (h *SubscribeStreamHandler) Handle() SubscribeStreamHandlerFunc {
 		}
 		if subscribeRep.Error != nil {
 			//proxyCallErrorCount.WithLabelValues(proxyName, "subscribe", "error_"+strconv.FormatUint(uint64(subscribeRep.Error.Code), 10)).Inc()
+			cancelFunc()
 			return centrifuge.SubscribeReply{}, nil, nil, &centrifuge.Error{
 				Code:    subscribeRep.Error.Code,
 				Message: subscribeRep.Error.Message,
@@ -199,6 +205,7 @@ func (h *SubscribeStreamHandler) Handle() SubscribeStreamHandlerFunc {
 				decodedInfo, err := base64.StdEncoding.DecodeString(subscribeRep.Result.B64Info)
 				if err != nil {
 					log.Error().Err(err).Str("client", client.ID()).Msg("error decoding base64 info")
+					cancelFunc()
 					return centrifuge.SubscribeReply{}, nil, nil, centrifuge.ErrorInternal
 				}
 				info = decodedInfo
@@ -209,6 +216,7 @@ func (h *SubscribeStreamHandler) Handle() SubscribeStreamHandlerFunc {
 				decodedData, err := base64.StdEncoding.DecodeString(subscribeRep.Result.B64Data)
 				if err != nil {
 					log.Error().Err(err).Str("client", client.ID()).Msg("error decoding base64 data")
+					cancelFunc()
 					return centrifuge.SubscribeReply{}, nil, nil, centrifuge.ErrorInternal
 				}
 				data = decodedData
@@ -337,6 +345,9 @@ func (p *SubscribeStreamProxy) SubscribeStream(
 	}()
 
 	if resp.SubscribeResponse == nil {
+		// The reader goroutine was already spawned above, so cancel before
+		// returning an error or it (and the derived context) leaks.
+		cancel()
 		return nil, nil, nil, errors.New("no subscribe response in first message from stream proxy")
 	}
 	return resp.SubscribeResponse, publishFunc, cancel, nil

--- a/internal/wt/handler.go
+++ b/internal/wt/handler.go
@@ -71,12 +71,21 @@ func (s *Handler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 		}(time.Now())
 	}
 
+	// Coerce 0 to the default, matching the other transports: in the stream
+	// decoder a limit of 0 means "unbounded", so without this an explicit
+	// message_size_limit: 0 (a natural "use default" choice for operators) would
+	// let a single frame trigger a huge allocation and OOM the process.
+	messageSizeLimit := int64(s.config.MessageSizeLimit)
+	if messageSizeLimit == 0 {
+		messageSizeLimit = defaultWebTransportMessageSizeLimit
+	}
+
 	var decoder protocol.StreamCommandDecoder
 	if protoType == centrifuge.ProtocolTypeJSON {
-		decoder = protocol.GetStreamCommandDecoderLimited(protocol.TypeJSON, stream, int64(s.config.MessageSizeLimit))
+		decoder = protocol.GetStreamCommandDecoderLimited(protocol.TypeJSON, stream, messageSizeLimit)
 		defer protocol.PutStreamCommandDecoder(protocol.TypeJSON, decoder)
 	} else {
-		decoder = protocol.NewProtobufStreamCommandDecoder(stream, int64(s.config.MessageSizeLimit))
+		decoder = protocol.NewProtobufStreamCommandDecoder(stream, messageSizeLimit)
 		defer protocol.PutStreamCommandDecoder(protocol.TypeProtobuf, decoder)
 	}
 

--- a/internal/wt/transport.go
+++ b/internal/wt/transport.go
@@ -13,6 +13,10 @@ import (
 
 const transportName = "webtransport"
 
+// defaultWebTransportMessageSizeLimit is used when message_size_limit is 0
+// (which the stream decoder treats as unbounded). Matches the config default.
+const defaultWebTransportMessageSizeLimit = 65536
+
 type webtransportTransport struct {
 	mu             sync.RWMutex
 	closeCh        chan struct{}


### PR DESCRIPTION
Several independent fixes.

**Fixes**
- Use the Redis Sentinel TLS config for the Sentinel connection (was using the main Redis TLS config).
- Coerce WebTransport `message_size_limit` 0 to the default, preventing an unbounded-message OOM.
- Bound HTTP metric label cardinality by the matched route pattern instead of the raw request path.
- Cancel the subscribe-stream proxy on all post-open error paths (leaked context/goroutine).