### PR TITLE
Fix uni-gRPC server wiring and URL password redaction

### DIFF
--- a/internal/app/grpc.go
+++ b/internal/app/grpc.go
@@ -83,8 +83,8 @@ func runGRPCUniServer(cfg config.Config, node *centrifuge.Node) (*grpc.Server, e
 	}
 
 	var uniGrpcTLSConfig *tls.Config
-	if cfg.GrpcAPI.TLS.Enabled {
-		uniGrpcTLSConfig, err = cfg.GrpcAPI.TLS.ToGoTLSConfig("uni_grpc")
+	if cfg.UniGRPC.TLS.Enabled {
+		uniGrpcTLSConfig, err = cfg.UniGRPC.TLS.ToGoTLSConfig("uni_grpc")
 		if err != nil {
 			return nil, fmt.Errorf("error getting TLS config for uni GRPC: %v", err)
 		}

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -294,9 +294,9 @@ func Run(cmd *cobra.Command, configFile string) {
 	var grpcUniServer *grpc.Server
 	if cfg.UniGRPC.Enabled {
 		var err error
-		grpcAPIServer, err = runGRPCUniServer(cfg, node)
+		grpcUniServer, err = runGRPCUniServer(cfg, node)
 		if err != nil {
-			log.Fatal().Err(err).Msg("error creating GRPC API server")
+			log.Fatal().Err(err).Msg("error creating uni GRPC server")
 		}
 	}
 

--- a/internal/tools/logging.go
+++ b/internal/tools/logging.go
@@ -11,11 +11,11 @@ func StripPassword(address string) string {
 	if err != nil {
 		return address
 	}
-	pass, passSet := u.User.Password()
-	if passSet {
-		return strings.Replace(u.String(), pass+"@", "***@", 1)
-	}
-	return u.String()
+	// Use url.Redacted, which replaces the password in the parsed userinfo before
+	// re-encoding. The previous approach string-replaced the DECODED password in
+	// the ENCODED URL, so a password containing a URL-special char (e.g. "@", a
+	// space, or non-ASCII) never matched and was logged in the clear.
+	return u.Redacted()
 }
 
 // GetLogAddresses returns a string with addresses (concatenated with comma)


### PR DESCRIPTION
Wiring and logging fixes.

**Fixes**
- Use the uni-gRPC TLS config for the uni-gRPC server (was using the API-gRPC TLS config).
- Gracefully shut down the uni-gRPC server (shutdown was assigned to the wrong variable, so it was never stopped).
- Redact URL passwords containing special characters in logs (use `url.Redacted()`).