### PR TITLE
Drop admin auth token fallbacks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.45.0
 	github.com/aws/aws-sdk-go-v2/service/sts v1.44.0
 	github.com/aws/smithy-go v1.27.3
-	github.com/centrifugal/centrifuge v0.38.1-0.20260706180729-dfb23bc79623
+	github.com/centrifugal/centrifuge v0.38.1-0.20260711082514-84d40cc4dbf6
 	github.com/centrifugal/protocol v0.19.2
 	github.com/cristalhq/jwt/v5 v5.4.0
 	github.com/go-viper/mapstructure/v2 v2.5.0

--- a/go.sum
+++ b/go.sum
@@ -73,8 +73,8 @@ github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6r
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/centrifugal/centrifuge v0.38.1-0.20260706180729-dfb23bc79623 h1:i6TFbT39MhGCfmQLXA0XEkcmHADmOPBi6xLiCsR/hvU=
-github.com/centrifugal/centrifuge v0.38.1-0.20260706180729-dfb23bc79623/go.mod h1:BZxC8CIQt7XEHmWpYejySRT2pFhDQfLLJR71gRRpD0E=
+github.com/centrifugal/centrifuge v0.38.1-0.20260711082514-84d40cc4dbf6 h1:/XP5pLhqScolSqDbeR9MNvAxW0Xt7TzFN/Ce3cw2bkk=
+github.com/centrifugal/centrifuge v0.38.1-0.20260711082514-84d40cc4dbf6/go.mod h1:BZxC8CIQt7XEHmWpYejySRT2pFhDQfLLJR71gRRpD0E=
 github.com/centrifugal/protocol v0.19.2 h1:wc1S75EJvX5/KczsqEG74Bt/Jw/XwECDUzWR/vE/E9U=
 github.com/centrifugal/protocol v0.19.2/go.mod h1:zFsp4f1ZRejq1dkyNUbabdPj4dMYOpK8RRXDwHGVpVY=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=

--- a/internal/admin/handlers.go
+++ b/internal/admin/handlers.go
@@ -90,8 +90,6 @@ func (s *Handler) adminSecureTokenAuth(h http.Handler) http.Handler {
 				return
 			}
 			token = parts[1]
-		} else {
-			token = r.URL.Query().Get("token")
 		}
 
 		if token == "" || !checkSecureAdminToken(secret, token) {
@@ -123,9 +121,6 @@ func (s *Handler) initHandler(w http.ResponseWriter, r *http.Request) {
 			if len(parts) == 2 && strings.ToLower(parts[0]) == "token" {
 				token = parts[1]
 			}
-		}
-		if token == "" {
-			token = r.URL.Query().Get("token")
 		}
 		if token != "" && checkSecureAdminToken(secret, token) {
 			authenticated = true

--- a/internal/admin/handlers_test.go
+++ b/internal/admin/handlers_test.go
@@ -157,7 +157,8 @@ func TestAdminSecureTokenAuth_ValidToken(t *testing.T) {
 	require.NoError(t, err)
 
 	authHandler := handler.adminSecureTokenAuth(finalHandler)
-	req := httptest.NewRequest("GET", "/admin/api?token="+token, nil)
+	req := httptest.NewRequest("GET", "/admin/api", nil)
+	req.Header.Set("Authorization", "token "+token)
 	resp := httptest.NewRecorder()
 
 	authHandler.ServeHTTP(resp, req)
@@ -176,7 +177,8 @@ func TestAdminSecureTokenAuth_InvalidToken(t *testing.T) {
 	})
 
 	authHandler := handler.adminSecureTokenAuth(finalHandler)
-	req := httptest.NewRequest("GET", "/admin/api?token=invalid-token", nil)
+	req := httptest.NewRequest("GET", "/admin/api", nil)
+	req.Header.Set("Authorization", "token invalid-token")
 	resp := httptest.NewRecorder()
 
 	authHandler.ServeHTTP(resp, req)


### PR DESCRIPTION
Dropping unused and non-documented admin auth fallbacks to `token` from URL params.