### PR TITLE
logging: raise log handler buffer from 64 to 1024

### DIFF
--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -51,13 +51,26 @@ var logStringToLevel = map[string]centrifuge.LogLevel{
 	"none":  centrifuge.LogLevelNone,
 }
 
+// centrifugeLogHandlerBufferSize is the number of log entries buffered between
+// the (many) goroutines producing them and the single goroutine writing them
+// out. Handle drops entries when this is full, so the buffer has to absorb
+// bursts rather than merely smooth a steady rate.
+//
+// Bursts are exactly when the logs matter. A Redis failover, for instance, makes
+// every shard's client and control PUB/SUB loop log connection errors, subscribe
+// errors and lifecycle transitions at nearly the same instant, while the drain
+// goroutine is rate-limited by writing to stdout. The previous value of 64 was
+// overrun easily in that situation — and with log_level debug, which is what an
+// operator turns on to investigate, it fills faster still.
+const centrifugeLogHandlerBufferSize = 1024
+
 type centrifugeLogHandler struct {
 	entries chan centrifuge.LogEntry
 }
 
 func newCentrifugeLogHandler() *centrifugeLogHandler {
 	h := &centrifugeLogHandler{
-		entries: make(chan centrifuge.LogEntry, 64),
+		entries: make(chan centrifuge.LogEntry, centrifugeLogHandlerBufferSize),
 	}
 	go h.readEntries()
 	return h


### PR DESCRIPTION
Increases buffer size for log entries to catch more logs during spikes.

Most probably a follow-up should count dropped entries and surface them (log line plus metric), so operators know when the log stream is lossy.