### PR TITLE
Bound command failure time on silently stalled connections under 5s by default

### DIFF
--- a/internal/redisshard/shard.go
+++ b/internal/redisshard/shard.go
@@ -52,6 +52,19 @@ func NewRedisShard(conf RedisShardConfig) (*RedisShard, error) {
 		MaxFlushDelay:    100 * time.Microsecond,
 		Dialer: net.Dialer{
 			Timeout: conf.ConnectTimeout,
+			// KeepAlive doubles as the rueidis keepalive PING cadence — the
+			// mechanism that detects a silently stalled connection (peer
+			// stops replying while TCP stays open) and errors out every
+			// pending command. Worst-case failure time for a command on a
+			// stalled connection is 2*KeepAlive + IOTimeout: a straggler
+			// reply can make one keepalive tick look active, only the next
+			// tick sends a PING, and the PING waits a full IOTimeout. The
+			// rueidis default of 1s gives 6s with the default 4s IOTimeout;
+			// 400ms keeps the worst case within 5s (4.8s), since commands
+			// are issued without per-request context deadlines. Same change
+			// as in centrifuge RedisShard, where a regression test pins the
+			// bound against a blackholed connection.
+			KeepAlive: 400 * time.Millisecond,
 		},
 	}
 


### PR DESCRIPTION
Redis commands are issued without per-request context deadlines and callers rely on failure within a bounded time when Redis is unreachable. For a silently stalled connection (peer stops replying, TCP stays open) the rescue is the rueidis keepalive PING, and the worst-case failure time is 2*KeepAlive + IOTimeout — 6 seconds with the rueidis default KeepAlive of 1s and the default 4s IOTimeout. Set KeepAlive to 400ms so the worst case stays within 5 seconds.

Mirrors the same change in the centrifuge RedisShard, where a regression test reproduces the silent stall through a blackholing TCP proxy and observes the predicted bound almost exactly; without a working keepalive the same command hangs indefinitely.

