### PR TITLE
fix(consuming): clone Kafka records before pushing to partition queue

### DIFF
--- a/internal/consuming/kafka.go
+++ b/internal/consuming/kafka.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -498,6 +499,18 @@ func (c *KafkaConsumer) pollUntilFatal(ctx context.Context) error {
 						pausedTopicPartitions[tp] = struct{}{}
 					}
 				}
+
+				// Clone p.Records to a fresh, tightly-sized backing array before enqueueing.
+				// The []*kgo.Record slice returned by franz-go points into the per-partition
+				// array franz-go grew via append while decoding the fetch response. That array
+				// can hold many more *Record pointers than the window we take here (up to
+				// MaxPollRecords); Go's GC tracks the whole backing allocation, so retaining
+				// the sub-slice keeps every pointer in the original array reachable — including
+				// records semantically stripped when the partition gets paused. That in turn
+				// keeps their Record structs and the batch buffers their Values point into
+				// alive, amplifying heap usage under lag. Cloning breaks the reference so the
+				// queue only pins the records we actually intend to process.
+				p.Records = slices.Clone(p.Records)
 
 				// Now submit to unbounded queue.
 				if !consumer.queue.Push(p) {


### PR DESCRIPTION
## Problem

The `[]*kgo.Record` slice returned by franz-go points into the per-partition backing array franz-go grows via `append` while decoding a fetch response — see [`source.takeNBuffered`](https://github.com/twmb/franz-go/blob/master/pkg/kgo/source.go): `rp.Records = p.Records[:take:take]`.

That array can hold many more `*Record` pointers than the window we take per poll (`MaxPollRecords`). Since Go's GC tracks whole allocations, pushing the sub-slice into the per-partition queue kept **every** pointer in the array reachable — including records that franz-go semantically stripped when the partition was paused. Those pointers in turn kept their `Record` structs and the fetched batch buffers their `Value`s point into alive, so heap usage under consumer lag was multiplied well beyond what `partition_queue_max_size` suggests.

## Fix

Clone `p.Records` into a fresh, tightly-sized backing array before `queue.Push`, so the queue only pins the records we actually intend to process. Franz-go can then GC the whole per-partition array (and everything reachable through the stripped pointers) as soon as it clears its buffered fetch.

Cost is one allocation of at most `MaxPollRecords` pointers per push (~800 B at the default 100) — negligible next to what it releases.

## Measurement

Measured with a throwaway reproducer (not part of this PR): 5000 records × 8 KB produced up front, `MaxPollRecords=10`, `PartitionQueueMaxSize=10` so the partition is paused on the first push, a blocking dispatcher so nothing drains, and the per-partition fetch limit raised so a single fetch buffers everything. `runtime.MemStats.HeapAlloc` after the first push+pause:

| | with clone | without clone |
|---|---|---|
| HeapAlloc after first push+pause | 3.3 MB | 42.6 MB |
| extra retention | — | 39.3 MB |

Note that with franz-go's default 1 MiB per-partition fetch limit the real-world amplification is bounded at roughly 1 MiB per queued item per partition, so impact scales with partition count rather than reaching the 40 MB above.

## Compatibility

No public API or configuration changes. Behavior for consumers that already drain faster than fetches is unchanged.
