### PR TITLE
fix(consuming): do not acknowledge messages consumed during shutdown

### DIFF
--- a/internal/api/consuming.go
+++ b/internal/api/consuming.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 
 	"github.com/centrifugal/centrifugo/v6/internal/apiproto"
 
@@ -39,6 +40,18 @@ func logNonRetryableConsumingError(err error, method string) {
 	log.Error().Err(err).Str("method", method).Msg("non retryable error during consuming, skip message")
 }
 
+// ErrShutdown is returned to consumers for messages received after Node shutdown
+// started. Such messages must not be acknowledged: this node is no longer able to
+// deliver them, and depending on the broker a publish may still return success (a
+// memory broker never fails, so without this check a message would be committed
+// while going nowhere). Returning an error makes consumers leave the message
+// unacknowledged, so it's redelivered to another node or after restart.
+//
+// It wraps context.Canceled since consumers treat cancellation as a stop signal
+// and give up immediately instead of retrying with backoff until the shutdown
+// timeout is reached.
+var ErrShutdown = fmt.Errorf("node is shutting down: %w", context.Canceled)
+
 type Dispatcher struct {
 	handler *ConsumingHandler
 }
@@ -46,6 +59,16 @@ type Dispatcher struct {
 func NewDispatcher(handler *ConsumingHandler) *Dispatcher {
 	return &Dispatcher{
 		handler: handler,
+	}
+}
+
+// shuttingDown returns true once Node shutdown started.
+func (d *Dispatcher) shuttingDown() bool {
+	select {
+	case <-d.handler.node.NotifyShutdown():
+		return true
+	default:
+		return false
 	}
 }
 
@@ -104,6 +127,9 @@ type ConsumedPublication struct {
 func (d *Dispatcher) DispatchPublication(
 	ctx context.Context, channels []string, pub ConsumedPublication,
 ) error {
+	if d.shuttingDown() {
+		return ErrShutdown
+	}
 	if len(channels) == 0 {
 		return nil
 	}
@@ -264,6 +290,9 @@ type MethodWithRequestPayload struct {
 
 // DispatchCommand processes commands received from asynchronous consumers.
 func (d *Dispatcher) DispatchCommand(ctx context.Context, method string, payload []byte) error {
+	if d.shuttingDown() {
+		return ErrShutdown
+	}
 	if method != "" {
 		// If method already known – we can skip decoding into MethodWithRequestPayload.
 		return d.dispatchMethodPayload(ctx, method, payload)

--- a/internal/api/consuming.go
+++ b/internal/api/consuming.go
@@ -73,6 +73,9 @@ func (d *Dispatcher) shuttingDown() bool {
 }
 
 func (d *Dispatcher) Publish(ctx context.Context, req *apiproto.PublishRequest) error {
+	if d.shuttingDown() {
+		return ErrShutdown
+	}
 	resp := d.handler.api.Publish(ctx, req)
 	if d.handler.config.UseOpenTelemetry && resp.Error != nil {
 		span := trace.SpanFromContext(ctx)
@@ -88,6 +91,9 @@ func (d *Dispatcher) Publish(ctx context.Context, req *apiproto.PublishRequest) 
 }
 
 func (d *Dispatcher) Broadcast(ctx context.Context, req *apiproto.BroadcastRequest) error {
+	if d.shuttingDown() {
+		return ErrShutdown
+	}
 	resp := d.handler.api.Broadcast(ctx, req)
 	if d.handler.config.UseOpenTelemetry && resp.Error != nil {
 		span := trace.SpanFromContext(ctx)

--- a/internal/api/consuming_test.go
+++ b/internal/api/consuming_test.go
@@ -28,3 +28,35 @@ func TestNewConsumingHandler(t *testing.T) {
 	err = dispatcher.DispatchCommand(context.Background(), "publish", []byte(`{}`))
 	require.NoError(t, err)
 }
+
+func TestDispatcherErrorsAfterNodeShutdown(t *testing.T) {
+	n := nodeWithMemoryEngine()
+
+	cfg := config.DefaultConfig()
+	cfgContainer, err := config.NewContainer(cfg)
+	require.NoError(t, err)
+
+	dispatcher := NewDispatcher(NewConsumingHandler(n, NewExecutor(n, cfgContainer, nil, ExecutorConfig{
+		Protocol: "consumer",
+	}), ConsumingHandlerConfig{}))
+
+	const payload = `{"channel": "test", "data": {}}`
+
+	// While node is running message must be dispatched successfully.
+	require.NoError(t, dispatcher.DispatchCommand(context.Background(), "publish", []byte(payload)))
+
+	require.NoError(t, n.Shutdown(context.Background()))
+
+	// Memory broker keeps accepting publications even after Node shutdown – without
+	// an explicit check a consumer would acknowledge a message which was never and
+	// will never be delivered.
+	err = dispatcher.DispatchCommand(context.Background(), "publish", []byte(payload))
+	require.ErrorIs(t, err, ErrShutdown)
+	// Consumers must stop processing instead of retrying until shutdown timeout.
+	require.ErrorIs(t, err, context.Canceled)
+
+	err = dispatcher.DispatchPublication(context.Background(), []string{"test"}, ConsumedPublication{
+		Data: []byte(`{}`),
+	})
+	require.ErrorIs(t, err, ErrShutdown)
+}

--- a/internal/api/consuming_test.go
+++ b/internal/api/consuming_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/centrifugal/centrifugo/v6/internal/apiproto"
 	"github.com/centrifugal/centrifugo/v6/internal/config"
 
 	"github.com/stretchr/testify/require"
@@ -57,6 +58,17 @@ func TestDispatcherErrorsAfterNodeShutdown(t *testing.T) {
 
 	err = dispatcher.DispatchPublication(context.Background(), []string{"test"}, ConsumedPublication{
 		Data: []byte(`{}`),
+	})
+	require.ErrorIs(t, err, ErrShutdown)
+
+	// Typed entry points must behave the same way.
+	err = dispatcher.Publish(context.Background(), &apiproto.PublishRequest{
+		Channel: "test", Data: []byte(`{}`),
+	})
+	require.ErrorIs(t, err, ErrShutdown)
+
+	err = dispatcher.Broadcast(context.Background(), &apiproto.BroadcastRequest{
+		Channels: []string{"test"}, Data: []byte(`{}`),
 	})
 	require.ErrorIs(t, err, ErrShutdown)
 }

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -59,6 +59,11 @@ func Run(cmd *cobra.Command, configFile string) {
 	ctx, serviceCancel := context.WithCancel(context.Background())
 	defer serviceCancel()
 
+	// Ingest services (async consumers) have a separate lifecycle from the rest of
+	// services – see the shutdown sequence in handleSignals.
+	ingestCtx, ingestCancel := context.WithCancel(context.Background())
+	defer ingestCancel()
+
 	centrifugeLogHandler, logCloseFn := logging.Setup(cfg)
 	if logCloseFn != nil {
 		defer logCloseFn()
@@ -220,7 +225,11 @@ func Run(cmd *cobra.Command, configFile string) {
 		log.Fatal().Err(err).Msg("error initializing consumers")
 	}
 
-	serviceManager.Register(consumingServices...)
+	// Consumers are registered in a separate manager: unlike other services they
+	// must be stopped before Node shutdown, so that no consumed message is
+	// acknowledged after this node lost the ability to deliver it.
+	ingestManager := service.NewManager()
+	ingestManager.Register(consumingServices...)
 
 	if cfg.Graphite.Enabled {
 		serviceManager.Register(graphiteExporter(cfg, nodeCfg))
@@ -271,16 +280,8 @@ func Run(cmd *cobra.Command, configFile string) {
 		log.Fatal().Err(err).Msg("error running node")
 	}
 
-	serviceDone := make(chan struct{})
-	serviceManager.Run(ctx)
-	go func() {
-		defer close(serviceDone)
-		err := serviceManager.Wait()
-		if err != nil && !errors.Is(err, context.Canceled) {
-			log.Error().Err(err).Msg("error running service")
-			os.Exit(1)
-		}
-	}()
+	serviceDone := runServices(ctx, serviceManager)
+	ingestDone := runServices(ingestCtx, ingestManager)
 
 	var grpcAPIServer *grpc.Server
 	if cfg.GrpcAPI.Enabled {
@@ -310,15 +311,31 @@ func Run(cmd *cobra.Command, configFile string) {
 	handleSignals(
 		cmd, configFile, node, cfgContainer, tokenVerifier, subTokenVerifier,
 		httpServers, grpcAPIServer, grpcUniServer,
-		serviceDone, serviceCancel,
+		serviceDone, serviceCancel, ingestDone, ingestCancel,
 	)
+}
+
+// runServices runs all services registered in the manager and returns a channel
+// closed when all of them stopped.
+func runServices(ctx context.Context, manager *service.Manager) chan struct{} {
+	done := make(chan struct{})
+	manager.Run(ctx)
+	go func() {
+		defer close(done)
+		err := manager.Wait()
+		if err != nil && !errors.Is(err, context.Canceled) {
+			log.Error().Err(err).Msg("error running service")
+			os.Exit(1)
+		}
+	}()
+	return done
 }
 
 func handleSignals(
 	cmd *cobra.Command, configFile string, n *centrifuge.Node, cfgContainer *config.Container,
 	tokenVerifier *jwtverify.VerifierJWT, subTokenVerifier *jwtverify.VerifierJWT, httpServers []*http.Server,
 	grpcAPIServer *grpc.Server, grpcUniServer *grpc.Server, serviceDone chan struct{},
-	serviceCancel context.CancelFunc,
+	serviceCancel context.CancelFunc, ingestDone chan struct{}, ingestCancel context.CancelFunc,
 ) {
 	cfg := cfgContainer.Config()
 	sigCh := make(chan os.Signal, 1)
@@ -402,6 +419,16 @@ func handleSignals(
 					_ = srv.Shutdown(context.Background()) // We have a separate timeout goroutine.
 				}(srv)
 			}
+
+			// Stop consuming messages before Node shutdown and wait until consumers
+			// stopped. Otherwise a message consumed here may be acknowledged while
+			// this node is already unable to deliver it – such message must be left
+			// unacknowledged instead, to be redelivered upon restart. Note that we
+			// don't wait for HTTP/GRPC servers here: their shutdown only completes
+			// after Node disconnected clients, since long-lived streaming requests
+			// (SSE, HTTP-streaming, unidirectional GRPC) are in-flight until then.
+			ingestCancel()
+			<-ingestDone
 
 			_ = n.Shutdown(context.Background()) // We have a separate timeout goroutine.
 			wg.Wait()


### PR DESCRIPTION
## Problem

Async consumers were stopped **after** Node shutdown, so a message consumed during the shutdown window could be published into an already shut down node.

Whether that publish failed depended on the broker in use. The memory broker never fails, so from the consumer's point of view the message was processed successfully and its offset committed — while the message was never delivered and never persisted anywhere. With Kafka, marked offsets are committed on consumer close, so the message was lost.

## Fix

Two changes, so the outcome no longer depends on the broker:

1. **Consumers are stopped before Node shutdown.** They are registered in a separate `service.Manager` ("ingest") with its own context, which is canceled and waited for before `node.Shutdown()`. This closes the window rather than handling it.

   HTTP/GRPC servers are intentionally *not* waited for at that point: their shutdown only completes after the Node disconnects clients, since long-lived streaming requests (SSE, HTTP-streaming, unidirectional GRPC) stay in flight until then.

2. **`Dispatcher` returns `ErrShutdown`** for messages received after Node shutdown started. It wraps `context.Canceled`, since all consumers treat cancellation as a stop signal and leave the message unacknowledged — instead of retrying with backoff until the shutdown timeout is reached.

Other services keep the previous lifecycle and are still stopped after Node and server shutdown.

## Result

A message consumed during shutdown is left unacknowledged and gets redelivered — to another node, or after restart.
