### PR TITLE
Bound proxy HTTP response body read to a fixed size limit

### DIFF
--- a/internal/proxy/http.go
+++ b/internal/proxy/http.go
@@ -32,6 +32,12 @@ var httpDecoder = &proxyproto.JSONDecoder{}
 // DefaultMaxIdleConnsPerHost is a reasonable value for all HTTP clients.
 const DefaultMaxIdleConnsPerHost = 255
 
+// maxProxyResponseBodySize bounds how much of a proxy backend's HTTP response
+// body we buffer in memory. Without this, a misbehaving or compromised proxy
+// backend can force unbounded memory growth via io.ReadAll on every proxied
+// call (connect/refresh/publish/subscribe/rpc/etc).
+const maxProxyResponseBodySize = 5 << 20 // 5MB
+
 // HTTPCaller is responsible for calling HTTP.
 type HTTPCaller interface {
 	CallHTTP(context.Context, string, http.Header, []byte) ([]byte, error)
@@ -89,9 +95,13 @@ func (c *httpCaller) CallHTTP(ctx context.Context, endpoint string, header http.
 	if resp.StatusCode != http.StatusOK {
 		return nil, &statusCodeError{resp.StatusCode}
 	}
-	respData, err := io.ReadAll(resp.Body)
+	limitedReader := io.LimitReader(resp.Body, maxProxyResponseBodySize+1)
+	respData, err := io.ReadAll(limitedReader)
 	if err != nil {
 		return nil, fmt.Errorf("error reading HTTP body: %w", err)
+	}
+	if len(respData) > maxProxyResponseBodySize {
+		return nil, fmt.Errorf("proxy response exceeds max allowed size of %d bytes", maxProxyResponseBodySize)
 	}
 	return respData, nil
 }


### PR DESCRIPTION
## Summary

`CallHTTP` in `internal/proxy/http.go` reads the entire response body from a proxy backend via `io.ReadAll(resp.Body)` with no upper bound. Every HTTP proxy call type (connect, refresh, publish, subscribe, sub_refresh, rpc, map_publish, map_remove, shared_poll_refresh) shares this same function, so a slow-but-huge or fast-but-massive response from the configured proxy backend gets fully buffered into memory regardless of size. The client `Timeout` only bounds wall-clock time, not response size.

This is defense-in-depth hardening, not an exploit against a normal client — the proxy `Endpoint` is fixed at startup from operator config and is never influenced by request/client data. But if a configured proxy backend is buggy, misconfigured, or itself compromised, it can currently force unbounded memory growth in Centrifugo, since many concurrent client connections can each be mid-proxy-call at once.

Other request-body reads in this codebase already follow a bounded-size pattern (`unisse`/`unihttpstream`'s `MaxRequestBodySize` + `http.MaxBytesReader`), so this brings the proxy response path in line with that existing convention.

## Change

```go
limitedReader := io.LimitReader(resp.Body, maxProxyResponseBodySize+1)
respData, err := io.ReadAll(limitedReader)
if err != nil {
    return nil, fmt.Errorf("error reading HTTP body: %w", err)
}
if len(respData) > maxProxyResponseBodySize {
    return nil, fmt.Errorf("proxy response exceeds max allowed size of %d bytes", maxProxyResponseBodySize)
}
```

`maxProxyResponseBodySize` is a new 5MB constant in the same file. The explicit over-limit check is needed because `io.LimitReader` truncates silently rather than erroring — reading `limit+1` bytes and checking the actual length is what turns that into a real error instead of silently accepting a truncated response.

## Test plan
- [x] `go build ./internal/proxy/...`
- [x] `go test ./internal/proxy/...` — existing tests pass unchanged
- [ ] Maintainer call on whether 5MB is the right default, and whether it should be made configurable per-proxy (kept it as a fixed constant here to keep the change minimal — happy to add a config option if preferred)
