### PR TITLE
Fix client.connection_rate_limit refilling at 1 req/sec

### DIFF
--- a/internal/middleware/connlimit.go
+++ b/internal/middleware/connlimit.go
@@ -54,7 +54,7 @@ func (l *ConnLimit) Middleware(h http.Handler) http.Handler {
 
 func connectionRateLimiter(connRateLimit int) *rate.Limiter {
 	if connRateLimit > 0 {
-		return rate.NewLimiter(rate.Every(time.Second), connRateLimit)
+		return rate.NewLimiter(rate.Limit(connRateLimit), connRateLimit)
 	}
 	return nil
 }

--- a/internal/middleware/connlimit_test.go
+++ b/internal/middleware/connlimit_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/centrifugal/centrifugo/v6/internal/tools"
 
 	"github.com/stretchr/testify/require"
+	"golang.org/x/time/rate"
 )
 
 func TestConnLimit_ConnectionRate(t *testing.T) {
@@ -21,7 +22,11 @@ func TestConnLimit_ConnectionRate(t *testing.T) {
 	cfgContainer, err := config.NewContainer(cfg)
 	require.NoError(t, err)
 
-	ts := httptest.NewServer(NewConnLimit(node, cfgContainer).Middleware(testHandler()))
+	connLimit := NewConnLimit(node, cfgContainer)
+	require.Equal(t, rate.Limit(10), connLimit.rl.Limit())
+	require.Equal(t, 10, connLimit.rl.Burst())
+
+	ts := httptest.NewServer(connLimit.Middleware(testHandler()))
 	defer ts.Close()
 
 	for i := 0; i < 20; i++ {


### PR DESCRIPTION
## Proposed changes

- Use `client.connection_rate_limit` as the token bucket's sustained per-second rate.
- Preserve the configured value as the burst size.
- Extend the existing connection-limit middleware test to assert both values.

The limiter currently uses `rate.Every(time.Second)`, which always refills at one request per second regardless of the configured limit. Converting the configured integer to `rate.Limit` makes the sustained rate match the documented behavior.

## Validation

- `go test -race ./internal/middleware -count=1`
- `go build ./...`
- `golangci-lint run --timeout 10m0s` with the repository-pinned v2.11.1

Fixes #1206
