### PR TITLE
fix: apply publication_data_format on map, shared poll and proxy paths

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -943,6 +943,12 @@ func (h *Executor) MapPublish(ctx context.Context, cmd *MapPublishRequest) *MapP
 		data = cmd.Data
 	}
 
+	if err := config.ValidatePublicationData(data, chOpts.PublicationDataFormat); err != nil {
+		log.Error().Err(err).Str("channel", ch).Msg("bad map publish request")
+		resp.Error = ErrorBadRequest
+		return resp
+	}
+
 	delta := cmd.Delta
 	if chOpts.DeltaPublish {
 		delta = true
@@ -1307,6 +1313,12 @@ func (h *Executor) SharedPollPublish(ctx context.Context, cmd *SharedPollPublish
 		data = byteInfo
 	} else {
 		data = cmd.Data
+	}
+
+	if err := config.ValidatePublicationData(data, chOpts.PublicationDataFormat); err != nil {
+		log.Error().Err(err).Str("channel", ch).Msg("bad shared poll publish request")
+		resp.Error = ErrorBadRequest
+		return resp
 	}
 
 	err = h.node.SharedPollPublish(ctx, ch, cmd.Key, cmd.Version, cmd.Epoch, data)

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -2,6 +2,8 @@ package api
 
 import (
 	"context"
+	"encoding/base64"
+	"fmt"
 	"os"
 	"testing"
 	"time"
@@ -626,4 +628,120 @@ func TestMapAPIs_RejectUnknownChannel(t *testing.T) {
 
 	clResp := api.MapClear(context.Background(), &MapClearRequest{Channel: "missing:test"})
 	require.Equal(t, ErrorUnknownChannel, clResp.Error)
+}
+
+// nodeWithMapSupport builds a node able to actually serve map operations for
+// channels of the given config container, so that valid publishes really reach
+// the map broker instead of failing on options resolution.
+func nodeWithMapSupport(cfgContainer *config.Container) *centrifuge.Node {
+	n, err := centrifuge.New(centrifuge.Config{
+		Map: centrifuge.MapConfig{
+			GetMapChannelOptions: func(channel string) centrifuge.MapChannelOptions {
+				_, _, chOpts, ok, err := cfgContainer.ChannelOptions(channel)
+				if err != nil || !ok {
+					return centrifuge.MapChannelOptions{}
+				}
+				var mode centrifuge.MapMode
+				switch chOpts.Map.Mode {
+				case "ephemeral":
+					mode = centrifuge.MapModeEphemeral
+				case "recoverable":
+					mode = centrifuge.MapModeRecoverable
+				case "persistent":
+					mode = centrifuge.MapModePersistent
+				}
+				return centrifuge.MapChannelOptions{Mode: mode, KeyTTL: chOpts.Map.KeyTTL.ToDuration()}
+			},
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
+	if err = n.Run(); err != nil {
+		panic(err)
+	}
+	return n
+}
+
+// TestMapPublishAPI_DataFormat ensures map_publish applies the namespace
+// publication_data_format policy, same as the stream Publish endpoint does.
+func TestMapPublishAPI_DataFormat(t *testing.T) {
+	cases := []struct {
+		format     string
+		data       []byte
+		b64Data    string
+		wantReject bool
+	}{
+		{configtypes.PublicationDataFormatJSONObject, []byte(`{"v":1}`), "", false},
+		{configtypes.PublicationDataFormatJSONObject, []byte(`[1,2]`), "", true},
+		{configtypes.PublicationDataFormatJSONObject, []byte(`not-json-object`), "", true},
+		{configtypes.PublicationDataFormatJSON, []byte(`[1,2]`), "", false},
+		{configtypes.PublicationDataFormatJSON, []byte(`nope`), "", true},
+		{configtypes.PublicationDataFormatBinary, nil, "", false},
+		{"", []byte(`whatever`), "", false},
+		{"", nil, "", true}, // default format rejects empty data
+		// b64data must be validated after decoding, not before.
+		{configtypes.PublicationDataFormatJSONObject, nil, base64.StdEncoding.EncodeToString([]byte(`{"v":1}`)), false},
+		{configtypes.PublicationDataFormatJSONObject, nil, base64.StdEncoding.EncodeToString([]byte(`nope`)), true},
+	}
+	for i, c := range cases {
+		t.Run(fmt.Sprintf("%d_format=%q", i, c.format), func(t *testing.T) {
+			cfg := configWithNamespace("ns", "map")
+			cfg.Channel.Namespaces[0].PublicationDataFormat = c.format
+			cfgContainer, err := config.NewContainer(cfg)
+			require.NoError(t, err)
+			node := nodeWithMapSupport(cfgContainer)
+			defer func() { _ = node.Shutdown(context.Background()) }()
+
+			api := NewExecutor(node, cfgContainer, &testSurveyCaller{}, ExecutorConfig{Protocol: "test"})
+			resp := api.MapPublish(context.Background(), &MapPublishRequest{
+				Channel: "ns:test", Key: "k", Data: c.data, B64Data: c.b64Data,
+			})
+			if c.wantReject {
+				require.Equal(t, ErrorBadRequest, resp.Error)
+			} else {
+				require.Nil(t, resp.Error)
+			}
+		})
+	}
+}
+
+// TestSharedPollPublishAPI_DataFormat ensures shared_poll_publish applies the
+// namespace publication_data_format policy.
+func TestSharedPollPublishAPI_DataFormat(t *testing.T) {
+	cases := []struct {
+		format     string
+		data       []byte
+		wantReject bool
+	}{
+		{configtypes.PublicationDataFormatJSONObject, []byte(`{"v":1}`), false},
+		{configtypes.PublicationDataFormatJSONObject, []byte(`nope`), true},
+		{configtypes.PublicationDataFormatJSON, []byte(`nope`), true},
+		{configtypes.PublicationDataFormatBinary, nil, false},
+		{"", nil, true}, // default format rejects empty data
+	}
+	for i, c := range cases {
+		t.Run(fmt.Sprintf("%d_format=%q", i, c.format), func(t *testing.T) {
+			cfg := configWithNamespace("ns", "shared_poll")
+			cfg.Channel.Namespaces[0].PublicationDataFormat = c.format
+			cfg.Channel.Namespaces[0].SharedPoll.PublishEnabled = true
+			cfgContainer, err := config.NewContainer(cfg)
+			require.NoError(t, err)
+			node := nodeWithMemoryEngine()
+			defer func() { _ = node.Shutdown(context.Background()) }()
+
+			api := NewExecutor(node, cfgContainer, &testSurveyCaller{}, ExecutorConfig{Protocol: "test"})
+			resp := api.SharedPollPublish(context.Background(), &SharedPollPublishRequest{
+				Channel: "ns:test", Key: "k", Version: 1, Data: c.data,
+			})
+			if c.wantReject {
+				require.Equal(t, ErrorBadRequest, resp.Error)
+			} else {
+				// The test node has no shared poll manager, so a valid payload
+				// gets past validation and fails later — the point is that it is
+				// not rejected as a bad request.
+				require.NotEqual(t, ErrorBadRequest, resp.Error)
+			}
+		})
+	}
 }

--- a/internal/client/handler.go
+++ b/internal/client/handler.go
@@ -177,7 +177,14 @@ func (h *Handler) Setup() error {
 			if !ok {
 				return centrifuge.SharedPollResult{}, centrifuge.ErrorInternal
 			}
-			return handler(ctx, event)
+			result, err := handler(ctx, event)
+			if err != nil {
+				return centrifuge.SharedPollResult{}, err
+			}
+			if err := validateSharedPollRefreshData(event.Channel, chOpts.PublicationDataFormat, result.Items); err != nil {
+				return centrifuge.SharedPollResult{}, err
+			}
+			return result, nil
 		})
 	}
 
@@ -977,6 +984,32 @@ func (h *Handler) OnPublish(c Client, e centrifuge.PublishEvent, publishProxyHan
 		log.Error().Err(err).Str("channel", e.Channel).Str("client", c.ID()).Str("user", c.UserID()).Msg("error publishing message")
 	}
 	return centrifuge.PublishReply{Result: &result}, err
+}
+
+// validateSharedPollRefreshData checks data returned by a shared poll refresh
+// proxy against the channel publication_data_format. Data comes from the
+// application backend, so a format mismatch is a configuration/implementation
+// mistake rather than untrusted input – reject the entire batch loudly instead
+// of delivering payloads subscribers are not able to parse.
+//
+// Items without data are skipped: a refresh response carries no data both for
+// removals and for keys the backend reports as unchanged, and this layer can't
+// tell "unchanged" from "changed to empty" (only the shared poll manager knows
+// the current version of a key). So the empty-data rule of the default format
+// is not applied here, while json/json_object still catch malformed payloads.
+func validateSharedPollRefreshData(channel string, format string, items []centrifuge.SharedPollRefreshItem) error {
+	for _, item := range items {
+		if item.Removed || len(item.Data) == 0 {
+			continue
+		}
+		if err := config.ValidatePublicationData(item.Data, format); err != nil {
+			log.Error().Err(err).Str("channel", channel).Str("key", item.Key).
+				Str("publication_data_format", format).
+				Msg("shared poll refresh data does not match channel publication_data_format, rejecting the whole refresh batch – fix the data returned by the shared poll refresh proxy")
+			return centrifuge.ErrorBadRequest
+		}
+	}
+	return nil
 }
 
 // OnMapPublish ...

--- a/internal/client/handler.go
+++ b/internal/client/handler.go
@@ -996,6 +996,12 @@ func (h *Handler) OnMapPublish(c Client, e centrifuge.MapPublishEvent, mapPublis
 		return centrifuge.MapPublishReply{}, err
 	}
 
+	// Data format validation
+	if err := config.ValidatePublicationData(e.Data, chOpts.PublicationDataFormat); err != nil {
+		log.Info().Err(err).Str("channel", e.Channel).Str("client", c.ID()).Str("user", c.UserID()).Msg("map publish data validation failed")
+		return centrifuge.MapPublishReply{}, centrifuge.ErrorBadRequest
+	}
+
 	if chOpts.Map.PublishProxyEnabled {
 		if mapPublishProxyHandler == nil {
 			log.Info().Str("channel", e.Channel).Str("client", c.ID()).Str("user", c.UserID()).Msg("map publish proxy not enabled")

--- a/internal/client/handler_test.go
+++ b/internal/client/handler_test.go
@@ -1764,3 +1764,65 @@ func TestSingleConnection(t *testing.T) {
 		return res.NumClients == 1 && res.NumUsers == 1
 	}, 5*time.Second, 100*time.Millisecond, "expected presence stats to show 1 client and 1 user")
 }
+
+// TestOnMapPublishDataFormat ensures client map publish applies the namespace
+// publication_data_format policy, same as client stream publish does.
+func TestOnMapPublishDataFormat(t *testing.T) {
+	cases := []struct {
+		format     string
+		data       []byte
+		wantReject bool
+	}{
+		{configtypes.PublicationDataFormatJSONObject, []byte(`{"v":1}`), false},
+		{configtypes.PublicationDataFormatJSONObject, []byte(`[1,2]`), true},
+		{configtypes.PublicationDataFormatJSON, []byte(`nope`), true},
+		{configtypes.PublicationDataFormatBinary, nil, false},
+		{"", nil, true}, // default format rejects empty data
+	}
+	for _, c := range cases {
+		t.Run("format="+c.format, func(t *testing.T) {
+			node := tools.NodeWithMemoryEngineNoHandlers()
+			defer func() { _ = node.Shutdown(context.Background()) }()
+
+			cfg := config.DefaultConfig()
+			cfg.Channel.Namespaces = []configtypes.ChannelNamespace{
+				{
+					Name: "mp",
+					ChannelOptions: configtypes.ChannelOptions{
+						SubscriptionType:      "map",
+						PublicationDataFormat: c.format,
+						Map: configtypes.MapConfig{
+							Mode:                  "ephemeral",
+							KeyTTL:                configtypes.Duration(time.Minute),
+							AllowPublishForClient: true,
+						},
+					},
+				},
+			}
+			cfgContainer, err := config.NewContainer(cfg)
+			require.NoError(t, err)
+			h := NewHandler(node, cfgContainer, hmacJWTVerifier(t, cfgContainer), nil, &ProxyMap{})
+
+			node.OnConnecting(func(ctx context.Context, e centrifuge.ConnectEvent) (centrifuge.ConnectReply, error) {
+				return centrifuge.ConnectReply{Credentials: &centrifuge.Credentials{UserID: "42"}}, nil
+			})
+			transport := tools.NewTestTransport()
+			client, closeFn, err := centrifuge.NewClient(context.Background(), node, transport)
+			require.NoError(t, err)
+			defer func() { _ = closeFn() }()
+			enc := protocol.NewJSONCommandEncoder()
+			data, err := enc.Encode(&protocol.Command{Id: 1, Connect: &protocol.ConnectRequest{}})
+			require.NoError(t, err)
+			require.True(t, centrifuge.HandleReadFrame(client, bytes.NewReader(data), 1<<20))
+
+			_, err = h.OnMapPublish(client, centrifuge.MapPublishEvent{
+				Channel: "mp:test", Key: "k", Data: c.data,
+			}, nil)
+			if c.wantReject {
+				require.Equal(t, centrifuge.ErrorBadRequest, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/internal/client/handler_test.go
+++ b/internal/client/handler_test.go
@@ -1826,3 +1826,51 @@ func TestOnMapPublishDataFormat(t *testing.T) {
 		})
 	}
 }
+
+// TestValidateSharedPollRefreshData ensures a shared poll refresh batch is
+// rejected as a whole when the backend returns data not matching the channel
+// publication_data_format, while removals and data-less "unchanged" items pass.
+func TestValidateSharedPollRefreshData(t *testing.T) {
+	const ch = "sp:test"
+
+	t.Run("valid batch accepted", func(t *testing.T) {
+		err := validateSharedPollRefreshData(ch, configtypes.PublicationDataFormatJSONObject, []centrifuge.SharedPollRefreshItem{
+			{Key: "k1", Data: []byte(`{"v":1}`), Version: 1},
+			{Key: "k2", Data: []byte(`{"v":2}`), Version: 1},
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("one bad item rejects whole batch", func(t *testing.T) {
+		err := validateSharedPollRefreshData(ch, configtypes.PublicationDataFormatJSONObject, []centrifuge.SharedPollRefreshItem{
+			{Key: "k1", Data: []byte(`{"v":1}`), Version: 1},
+			{Key: "k2", Data: []byte(`[1,2]`), Version: 1},
+			{Key: "k3", Data: []byte(`{"v":3}`), Version: 1},
+		})
+		require.Equal(t, centrifuge.ErrorBadRequest, err)
+	})
+
+	t.Run("invalid json rejected", func(t *testing.T) {
+		err := validateSharedPollRefreshData(ch, configtypes.PublicationDataFormatJSON, []centrifuge.SharedPollRefreshItem{
+			{Key: "k1", Data: []byte(`not json`), Version: 1},
+		})
+		require.Equal(t, centrifuge.ErrorBadRequest, err)
+	})
+
+	t.Run("removals and data-less items skipped", func(t *testing.T) {
+		// Removals carry no data, and an unchanged key may come back without
+		// data — neither must trip the empty-data rule of the default format.
+		err := validateSharedPollRefreshData(ch, "", []centrifuge.SharedPollRefreshItem{
+			{Key: "k1", Removed: true},
+			{Key: "k2", Version: 7},
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("binary format allows anything", func(t *testing.T) {
+		err := validateSharedPollRefreshData(ch, configtypes.PublicationDataFormatBinary, []centrifuge.SharedPollRefreshItem{
+			{Key: "k1", Data: []byte{0x00, 0x01, 0xff}, Version: 1},
+		})
+		require.NoError(t, err)
+	})
+}

--- a/internal/proxy/map_publish_handler.go
+++ b/internal/proxy/map_publish_handler.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"time"
 
+	"github.com/centrifugal/centrifugo/v6/internal/config"
 	"github.com/centrifugal/centrifugo/v6/internal/configtypes"
 	"github.com/centrifugal/centrifugo/v6/internal/metrics"
 	"github.com/centrifugal/centrifugo/v6/internal/proxyproto"
@@ -147,6 +148,13 @@ func (h *MapPublishHandler) Handle(node *centrifuge.Node) MapPublishHandlerFunc 
 			useDelta = mapPublishRep.Result.Delta
 			version = mapPublishRep.Result.Version
 			versionEpoch = mapPublishRep.Result.VersionEpoch
+		}
+
+		// The proxy may replace the data client sent, so validate the final data
+		// against the channel format – same policy as for the client-supplied one.
+		if err := config.ValidatePublicationData(data, chOpts.PublicationDataFormat); err != nil {
+			log.Info().Err(err).Str("channel", e.Channel).Str("client", client.ID()).Msg("map publish proxy data validation failed")
+			return centrifuge.MapPublishReply{}, centrifuge.ErrorBadRequest
 		}
 
 		result, err := node.MapPublish(

--- a/internal/proxy/map_publish_handler_test.go
+++ b/internal/proxy/map_publish_handler_test.go
@@ -1,0 +1,75 @@
+package proxy
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"log"
+	"net/http"
+	"testing"
+
+	"github.com/centrifugal/centrifugo/v6/internal/configtypes"
+	"github.com/centrifugal/centrifugo/v6/internal/tools"
+
+	"github.com/centrifugal/centrifuge"
+	"github.com/stretchr/testify/require"
+)
+
+type httpMapPublishHandleTestCase struct {
+	*tools.CommonHTTPProxyTestCase
+	mapPublishProxyHandler *MapPublishHandler
+	channelOpts            configtypes.ChannelOptions
+}
+
+func newMapPublishHandleHTTPTestCase(ctx context.Context, endpoint string, opts configtypes.ChannelOptions) httpMapPublishHandleTestCase {
+	commonProxyTestCase := tools.NewCommonHTTPProxyTestCase(ctx)
+
+	mapPublishProxy, err := NewHTTPMapPublishProxy(getTestHttpProxy(commonProxyTestCase, endpoint))
+	if err != nil {
+		log.Fatalln("could not create http map publish proxy: ", err)
+	}
+
+	mapPublishProxyHandler := NewMapPublishHandler(MapPublishHandlerConfig{
+		Proxies: map[string]MapPublishProxy{
+			"test": mapPublishProxy,
+		},
+	})
+
+	return httpMapPublishHandleTestCase{commonProxyTestCase, mapPublishProxyHandler, opts}
+}
+
+func (c httpMapPublishHandleTestCase) invokeHandle(event centrifuge.MapPublishEvent) (centrifuge.MapPublishReply, error) {
+	handler := c.mapPublishProxyHandler.Handle(c.Node)
+	return handler(c.Client, event, c.channelOpts, PerCallData{})
+}
+
+// TestHandleMapPublishProxyResultDataValidated ensures data returned by a map
+// publish proxy is validated against the channel publication_data_format — the
+// proxy can replace what the client sent, so checking only the client data in
+// the client handler is not enough.
+func TestHandleMapPublishProxyResultDataValidated(t *testing.T) {
+	// Not a JSON object, while the channel requires one.
+	badDataB64 := base64.StdEncoding.EncodeToString([]byte(`"just a string"`))
+	chOpts := configtypes.ChannelOptions{
+		SubscriptionType:      "map",
+		PublicationDataFormat: configtypes.PublicationDataFormatJSONObject,
+		Map: configtypes.MapConfig{
+			Mode:                "persistent",
+			PublishProxyEnabled: true,
+			PublishProxyName:    "test",
+		},
+	}
+
+	testCase := newMapPublishHandleHTTPTestCase(context.Background(), "/map_publish", chOpts)
+	testCase.Mux.HandleFunc("/map_publish", func(w http.ResponseWriter, req *http.Request) {
+		_, _ = w.Write([]byte(fmt.Sprintf(`{"result": {"key": "k", "b64data": "%s"}}`, badDataB64)))
+	})
+	defer testCase.Teardown()
+
+	_, err := testCase.invokeHandle(centrifuge.MapPublishEvent{
+		Channel: "test_channel",
+		Key:     "k",
+		Data:    []byte(`{"valid":"object"}`), // client data is fine, proxy data is not
+	})
+	require.Equal(t, centrifuge.ErrorBadRequest, err)
+}

--- a/internal/proxy/publish_handler.go
+++ b/internal/proxy/publish_handler.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"time"
 
+	"github.com/centrifugal/centrifugo/v6/internal/config"
 	"github.com/centrifugal/centrifugo/v6/internal/configtypes"
 	"github.com/centrifugal/centrifugo/v6/internal/metrics"
 	"github.com/centrifugal/centrifugo/v6/internal/proxyproto"
@@ -151,6 +152,13 @@ func (h *PublishHandler) Handle(node *centrifuge.Node) PublishHandlerFunc {
 			useDelta = publishRep.Result.Delta
 			version = publishRep.Result.Version
 			versionEpoch = publishRep.Result.VersionEpoch
+		}
+
+		// The proxy may replace the data client sent, so validate the final data
+		// against the channel format – same policy as for the client-supplied one.
+		if err := config.ValidatePublicationData(data, chOpts.PublicationDataFormat); err != nil {
+			log.Info().Err(err).Str("channel", e.Channel).Str("client", client.ID()).Msg("publish proxy data validation failed")
+			return centrifuge.PublishReply{}, centrifuge.ErrorBadRequest
 		}
 
 		result, err := node.Publish(

--- a/internal/proxy/publish_handler_test.go
+++ b/internal/proxy/publish_handler_test.go
@@ -286,3 +286,34 @@ func TestHandlePublishWithInvalidCustomData(t *testing.T) {
 		require.Equal(t, centrifuge.PublishReply{}, reply, c.protocol)
 	}
 }
+
+// TestHandlePublishProxyResultDataValidated ensures data returned by a publish
+// proxy is validated against the channel publication_data_format — the proxy can
+// replace what the client sent, so the client-side check is not enough.
+func TestHandlePublishProxyResultDataValidated(t *testing.T) {
+	// Not a JSON object, while the channel requires one.
+	badDataB64 := base64.StdEncoding.EncodeToString([]byte(`"just a string"`))
+	chOpts := configtypes.ChannelOptions{
+		PublishProxyEnabled:   true,
+		PublishProxyName:      "test",
+		PublicationDataFormat: configtypes.PublicationDataFormatJSONObject,
+	}
+
+	opts := proxyGRPCTestServerOptions{
+		B64Data: badDataB64,
+	}
+	grpcTestCase := newPublishHandleGRPCTestCase(context.Background(), newProxyGRPCTestServer("result", opts), chOpts)
+	defer grpcTestCase.Teardown()
+
+	httpTestCase := newPublishHandleHTTPTestCase(context.Background(), "/publish", chOpts)
+	httpTestCase.Mux.HandleFunc("/publish", func(w http.ResponseWriter, req *http.Request) {
+		_, _ = w.Write([]byte(fmt.Sprintf(`{"result": {"b64data": "%s"}}`, badDataB64)))
+	})
+	defer httpTestCase.Teardown()
+
+	cases := newPublishHandleTestCases(httpTestCase, grpcTestCase)
+	for _, c := range cases {
+		_, err := c.invokeHandle()
+		require.Equal(t, centrifuge.ErrorBadRequest, err, c.protocol)
+	}
+}


### PR DESCRIPTION
## Problem

`publication_data_format` is documented as a channel-level policy for publication data (`json`, `json_object`, `binary`, and the default which rejects empty data). It was only enforced on stream publishes — `config.ValidatePublicationData` had exactly three call sites: API `publish`, API `broadcast`, and client stream publish.

Everything else putting data into a channel skipped it:

- `Executor.MapPublish` (HTTP / gRPC / legacy API and async consumers)
- `Executor.SharedPollPublish`
- client `OnMapPublish`
- the map publish proxy
- the stream publish proxy
- the shared poll refresh proxy

So a namespace configured with `publication_data_format: json_object` accepted the option at config load and then silently did nothing for map and shared poll channels: malformed payloads were stored and delivered, and the default format's empty-data rule did not apply either.

The two proxy cases are worth calling out separately: both proxies replace the data the client sent with `Result.Data` / `Result.B64Data` and publish that, while the only existing check ran on the client-supplied bytes *before* the proxy call. That left the same hole in the stream path everyone assumed was enforced.

## Fix

Validate after data/`b64data` decoding at every remaining point:

| Path | Behavior |
|---|---|
| `Executor.MapPublish` | `ErrorBadRequest` |
| `Executor.SharedPollPublish` | `ErrorBadRequest` |
| client `OnMapPublish` | `ErrorBadRequest`, before the proxy branch — mirrors `OnPublish` |
| map publish proxy | validates the final data after a proxy override |
| stream publish proxy | validates the final data after a proxy override |
| shared poll refresh proxy | rejects the whole refresh batch |

Refresh data comes from the application backend, so a format mismatch there is a developer mistake rather than untrusted input — the whole batch is rejected and the log line names the channel, the offending key and the expected format, instead of partially applying a batch.

Map remove carries no data on either the API request or the proxy reply, so there is nothing to validate there.

## One deliberate asymmetry

On the refresh path, items without data are skipped. A refresh response legitimately carries no data both for removals and for keys the backend reports as unchanged, and that layer cannot tell "unchanged" from "changed to empty" — only the shared poll manager knows the current version of a key. So `json` / `json_object` still catch malformed payloads there, while the empty-data rule of the default format does not apply on that path. The reasoning is in a comment above the helper.

## Tests

Format tables (`json_object` / `json` / `binary` / default) across API map publish (including `b64data`, validated after decoding rather than before), API shared poll publish, client map publish, both proxy handlers, and the refresh batch (valid batch, one bad item rejecting the whole batch, removals and data-less items skipped, binary accepting arbitrary bytes).

Each suite was verified to fail without the corresponding fix.

Reported via GHSA-5hhg-gr8h-wphh; the stream publish proxy and shared poll refresh proxy gaps were found while fixing it.