### PR TITLE
fix(config): reference real config keys in validation errors

### DIFF
--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -60,7 +60,7 @@ func (c Config) Validate() error {
 	var proxyNames []string
 	for _, p := range c.Proxies {
 		if slices.Contains(proxyNames, p.Name) {
-			return fmt.Errorf("duplicate proxy name in channel.named_proxies: %s", p.Name)
+			return fmt.Errorf("duplicate proxy name in proxies: %s", p.Name)
 		}
 		if err := validateProxy(p.Name, p.Proxy); err != nil {
 			return fmt.Errorf("in proxy %s: %v", p.Name, err)
@@ -181,10 +181,10 @@ func (c Config) Validate() error {
 	}
 
 	if err := validateConnectCodeTransforms(c.UniSSE.ConnectCodeToHTTPResponse.Transforms); err != nil {
-		return fmt.Errorf("in uni_sse.connect_code_to_http_status.transforms: %v", err)
+		return fmt.Errorf("in uni_sse.connect_code_to_http_response.transforms: %v", err)
 	}
 	if err := validateConnectCodeTransforms(c.UniHTTPStream.ConnectCodeToHTTPResponse.Transforms); err != nil {
-		return fmt.Errorf("in uni_http_stream.connect_code_to_http_status.transforms: %v", err)
+		return fmt.Errorf("in uni_http_stream.connect_code_to_http_response.transforms: %v", err)
 	}
 
 	// Map broker validation.
@@ -581,10 +581,10 @@ func validateStatusTransforms(transforms []configtypes.HttpStatusToCodeTransform
 func validateConnectCodeTransforms(transforms []configtypes.ConnectCodeToHTTPResponseTransform) error {
 	for i, transform := range transforms {
 		if transform.Code == 0 {
-			return fmt.Errorf("code should be set in connect_code_to_http_status.transforms[%d]", i)
+			return fmt.Errorf("code should be set in connect_code_to_http_response.transforms[%d]", i)
 		}
 		if transform.To.StatusCode == 0 {
-			return fmt.Errorf("status_code should be set in connect_code_to_http_status.transforms[%d].to_response", i)
+			return fmt.Errorf("status_code should be set in connect_code_to_http_response.transforms[%d].to", i)
 		}
 	}
 	return nil

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -607,3 +607,101 @@ func TestValidateMapNamespace_MapBrokerType(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateConnectCodeToHTTPResponseTransforms(t *testing.T) {
+	validTransform := configtypes.ConnectCodeToHTTPResponseTransform{
+		Code: 3500,
+		To: configtypes.TransformedConnectErrorHttpResponse{
+			StatusCode: 403,
+			Body:       "forbidden",
+		},
+	}
+	noCode := validTransform
+	noCode.Code = 0
+	noStatusCode := validTransform
+	noStatusCode.To.StatusCode = 0
+
+	tests := []struct {
+		name       string
+		transforms configtypes.ConnectCodeToHTTPResponseTransforms
+		wantErr    string
+	}{
+		{
+			name:       "valid transform",
+			transforms: configtypes.ConnectCodeToHTTPResponseTransforms{validTransform},
+		},
+		{
+			name:       "missing code",
+			transforms: configtypes.ConnectCodeToHTTPResponseTransforms{noCode},
+			wantErr:    "code should be set in connect_code_to_http_response.transforms[0]",
+		},
+		{
+			name:       "missing status code",
+			transforms: configtypes.ConnectCodeToHTTPResponseTransforms{validTransform, noStatusCode},
+			wantErr:    "status_code should be set in connect_code_to_http_response.transforms[1].to",
+		},
+	}
+
+	// The same transforms are validated for both unidirectional HTTP transports,
+	// each reporting under its own config path.
+	transports := []struct {
+		name   string
+		prefix string
+		set    func(cfg *Config, transforms configtypes.ConnectCodeToHTTPResponseTransforms)
+	}{
+		{
+			name:   "uni_sse",
+			prefix: "in uni_sse.connect_code_to_http_response.transforms: ",
+			set: func(cfg *Config, transforms configtypes.ConnectCodeToHTTPResponseTransforms) {
+				cfg.UniSSE.ConnectCodeToHTTPResponse.Transforms = transforms
+			},
+		},
+		{
+			name:   "uni_http_stream",
+			prefix: "in uni_http_stream.connect_code_to_http_response.transforms: ",
+			set: func(cfg *Config, transforms configtypes.ConnectCodeToHTTPResponseTransforms) {
+				cfg.UniHTTPStream.ConnectCodeToHTTPResponse.Transforms = transforms
+			},
+		},
+	}
+
+	for _, transport := range transports {
+		for _, tt := range tests {
+			t.Run(transport.name+"/"+tt.name, func(t *testing.T) {
+				cfg := DefaultConfig()
+				transport.set(&cfg, tt.transforms)
+				err := cfg.Validate()
+				if tt.wantErr == "" {
+					require.NoError(t, err)
+					return
+				}
+				require.EqualError(t, err, transport.prefix+tt.wantErr)
+			})
+		}
+	}
+}
+
+func TestValidateDuplicateProxyName(t *testing.T) {
+	proxy := configtypes.Proxy{
+		Endpoint: "http://localhost:3000/proxy",
+		Timeout:  configtypes.Duration(time.Second),
+	}
+
+	t.Run("unique names are valid", func(t *testing.T) {
+		cfg := DefaultConfig()
+		cfg.Proxies = configtypes.NamedProxies{
+			{Name: "first", Proxy: proxy},
+			{Name: "second", Proxy: proxy},
+		}
+		require.NoError(t, cfg.Validate())
+	})
+
+	t.Run("duplicate name is invalid", func(t *testing.T) {
+		cfg := DefaultConfig()
+		cfg.Proxies = configtypes.NamedProxies{
+			{Name: "first", Proxy: proxy},
+			{Name: "first", Proxy: proxy},
+		}
+		require.EqualError(t, cfg.Validate(), "duplicate proxy name in proxies: first")
+	})
+}


### PR DESCRIPTION
Several config validation errors named config keys that do not exist, so an operator following the message could not find the option to fix.

### What changed

| Reported path | Actual key |
|---|---|
| `channel.named_proxies` | top-level `proxies` (`mapstructure:"proxies"` on `Config.Proxies`) |
| `connect_code_to_http_status.transforms` | `connect_code_to_http_response.transforms` |
| `...transforms[N].to_response` | `...transforms[N].to` |

The `uni_sse` / `uni_http_stream` cases were doubly misleading: both the wrapping prefix and the inner message named `connect_code_to_http_status`, e.g.

```
in uni_sse.connect_code_to_http_status.transforms: status_code should be set in connect_code_to_http_status.transforms[0].to_response
```

when the configuration key is actually `uni_sse.connect_code_to_http_response.transforms[0].to`.

### Why

These are the messages Centrifugo prints when it refuses to start, so a wrong key name costs the operator a search through the config reference. The stale names appeared only in `internal/config/validate.go` — nothing else in the repo (docs, testdata, JSON configs) used them, which is consistent with them being names that were renamed in the types without the error strings following.

Only the error strings change; validation behaviour is untouched.

### Tests

Both validation paths had no coverage before. Added `TestValidateConnectCodeToHTTPResponseTransforms` (valid transform, missing `code`, missing `to.status_code` — across both unidirectional transports) and `TestValidateDuplicateProxyName` (unique vs. duplicate). They assert the exact message, so the reported paths cannot silently drift from the `mapstructure` tags again.

### Verification

- `go build ./...` — clean
- `go vet ./internal/config/` — clean
- `gofmt -l` on both touched files — clean
- Full suite `go test -count=1 $(go list ./... | grep -v /misc/)` — exit 0, and again with `-race` — exit 0. The same suite passed on `master` before the change, so this is not masking a pre-existing failure.