### PR TITLE
fix(middleware): fix racy log throttle in connection limit check

### DIFF
--- a/internal/middleware/connlimit.go
+++ b/internal/middleware/connlimit.go
@@ -2,22 +2,18 @@ package middleware
 
 import (
 	"net/http"
-	"sync/atomic"
 	"time"
 
 	"github.com/centrifugal/centrifugo/v6/internal/config"
 	"github.com/centrifugal/centrifugo/v6/internal/metrics"
+	"github.com/centrifugal/centrifugo/v6/internal/tools"
 
 	"github.com/centrifugal/centrifuge"
 	"github.com/rs/zerolog/log"
 	"golang.org/x/time/rate"
 )
 
-var (
-	connLimitReachedLoggedAt int64
-)
-
-const connLimitReachedLogThrottle = int64(3 * time.Second)
+var connLimitReachedLogLimiter = tools.NewIntervalLimiter(3 * time.Second)
 
 type ConnLimit struct {
 	node         *centrifuge.Node
@@ -39,11 +35,8 @@ func (l *ConnLimit) Middleware(h http.Handler) http.Handler {
 		connLimit := l.cfgContainer.Config().Client.ConnectionLimit
 		if connLimit > 0 && l.node.Hub().NumClients() >= connLimit {
 			metrics.ConnLimitReached.Inc()
-			now := time.Now().UnixNano()
-			prevLoggedAt := atomic.LoadInt64(&connLimitReachedLoggedAt)
-			if prevLoggedAt == 0 || now-prevLoggedAt > connLimitReachedLogThrottle {
+			if connLimitReachedLogLimiter.Allow() {
 				log.Warn().Int("limit", connLimit).Msg("node connection limit reached")
-				atomic.StoreInt64(&connLimitReachedLoggedAt, now)
 			}
 			w.WriteHeader(http.StatusServiceUnavailable)
 			return


### PR DESCRIPTION
## What changed

`internal/middleware/connlimit.go` throttled the "node connection limit reached" warning log using a hand-rolled `atomic.LoadInt64` / compare / `atomic.StoreInt64` sequence on a package-level int64 timestamp.

## Why

That load-then-store is not atomic as a pair. Under concurrent requests — which is exactly what happens once the connection limit is hit, since every subsequent inbound request takes this branch simultaneously — multiple goroutines can all load the same stale timestamp, all decide the throttle window has elapsed, and all log before any of them stores the new timestamp. That produces bursts of duplicate warning log lines at the worst possible time (a saturated node under connection pressure) instead of the intended one-log-per-throttle-window.

The codebase already has a correct primitive for this exact pattern: `tools.IntervalLimiter`, which uses `CompareAndSwap` so at most one caller per interval proceeds. It's already used the same way for log throttling in `internal/proxy/proxy.go` (`droppedEmulatedHeaderLogLimiter`). This change swaps the ad-hoc logic in `connlimit.go` for the same utility, removing the race and ~7 lines of duplicated code.

No exported API changes; behavior is identical except the throttle now actually holds under concurrency.

## How verified

- `go build ./...` — passes
- `go vet ./internal/middleware/...` — passes
- `gofmt -l internal/middleware/connlimit.go` — no output (clean)
- `go test ./internal/middleware/... -v` — all tests pass, including `TestConnLimit_ConnectionRate`
- Confirmed no other references to the removed `connLimitReachedLoggedAt` / `connLimitReachedLogThrottle` identifiers exist anywhere in the repo