### PR TITLE
fix(origin): lowercase allowed_origins patterns before matching

### DIFF
--- a/internal/origin/origin.go
+++ b/internal/origin/origin.go
@@ -15,7 +15,7 @@ type PatternChecker struct {
 func NewPatternChecker(allowedOrigins []string) (*PatternChecker, error) {
 	var globs []glob.Glob
 	for _, pattern := range allowedOrigins {
-		g, err := glob.Compile(pattern)
+		g, err := glob.Compile(strings.ToLower(pattern))
 		if err != nil {
 			return nil, fmt.Errorf("malformed origin pattern: %w", err)
 		}

--- a/internal/origin/origin_test.go
+++ b/internal/origin/origin_test.go
@@ -52,6 +52,14 @@ func TestPatternCheck(t *testing.T) {
 			success: false,
 		},
 		{
+			name:   "origin_patterns_uppercase_pattern_matches",
+			origin: "https://two.example.com",
+			originPatterns: []string{
+				"*.Example.com",
+			},
+			success: true,
+		},
+		{
 			name:   "file_origin",
 			origin: "file://",
 			originPatterns: []string{


### PR DESCRIPTION
## What

`PatternChecker.Check` lowercases the incoming `Origin` header before matching it against the configured glob patterns, but `NewPatternChecker` never lowercased the patterns themselves when compiling them.

## Why

Any `allowed_origins` pattern containing uppercase letters (e.g. `*.Example.com`, easy to end up with when copy-pasting a domain) could never match a real (lowercased) incoming origin, silently rejecting legitimate WebSocket/SSE connections from browsers, which always send `Origin` as configured by the page's actual origin casing conventions but get compared against a lowercased value here.

Fix: lowercase the pattern in `NewPatternChecker` before compiling it with `glob.Compile`, so pattern casing no longer matters (mirroring how the origin value itself is already normalized).

## How verified

Added a regression test case (`origin_patterns_uppercase_pattern_matches`) to the existing table-driven test in `internal/origin/origin_test.go`, using pattern `*.Example.com` against origin `https://two.example.com`, expecting a match.

- Confirmed it fails against the old code (pattern compiled as `*.Example.com`, origin normalized to lowercase `two.example.com`, glob doesn't match → test fails).
- Applied the one-line fix and confirmed the full `TestPatternCheck` suite passes.
- Ran `go build ./...` for the full repo — passes.
- Checked for other callers of `origin.NewPatternChecker`/`PatternChecker` — only one call site (`internal/app/origin.go`), unaffected by this normalization.

Kept the added test case permanently since it guards a distinct regression class (case-sensitive pattern vs. case-normalized origin) not covered by existing cases.