### PR TITLE
fix(consuming): do not treat unrelated context.Canceled as shutdown

### DIFF
--- a/internal/consuming/aws_sqs.go
+++ b/internal/consuming/aws_sqs.go
@@ -280,7 +280,9 @@ func (c *AwsSqsConsumer) processSingleMessage(ctx context.Context, msg types.Mes
 			}
 			break
 		}
-		if errors.Is(processErr, context.Canceled) {
+		// Only stop on our own cancellation: an unrelated context.Canceled bubbling up
+		// from the dispatcher must be retried rather than treated as shutdown.
+		if ctx.Err() != nil {
 			return false
 		}
 		retries++

--- a/internal/consuming/kafka.go
+++ b/internal/consuming/kafka.go
@@ -786,7 +786,11 @@ func (pc *partitionConsumer) processRecords(records []*kgo.Record) {
 				pc.cl.MarkCommitRecords(record)
 				break
 			}
-			if errors.Is(err, context.Canceled) {
+			// Only stop on our own cancellation: an unrelated context.Canceled bubbling up
+			// from the dispatcher must be retried, not treated as shutdown. Bailing out here
+			// would skip the rest of the batch and let a later batch commit an offset past
+			// this record — losing it for good.
+			if pc.partitionCtx.Err() != nil {
 				return
 			}
 			retries++

--- a/internal/consuming/kafka_test.go
+++ b/internal/consuming/kafka_test.go
@@ -359,6 +359,93 @@ func TestKafkaConsumer_RetryAfterDispatchError(t *testing.T) {
 	waitCh(t, consumerClosed, 30*time.Second, "timeout waiting for consumer closed")
 }
 
+// A context.Canceled coming from the dispatcher's own downstream call must not be mistaken
+// for consumer shutdown: the partition consumer used to bail out on any context.Canceled,
+// dropping the record and the rest of its batch. Since Kafka commits are offset based, the
+// next batch then committed an offset past the dropped records, losing them for good.
+func TestKafkaConsumer_UnrelatedContextCanceledIsRetried(t *testing.T) {
+	t.Parallel()
+	testKafkaTopic := "centrifugo_consumer_test_" + uuid.New().String()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	err := createTestTopic(ctx, testKafkaTopic, 1, 1)
+	require.NoError(t, err)
+
+	config := KafkaConfig{
+		Brokers:       []string{testKafkaBrokerURL},
+		Topics:        []string{testKafkaTopic},
+		ConsumerGroup: uuid.New().String(),
+	}
+
+	// A canceled context which has nothing to do with the consumer lifecycle.
+	unrelatedCtx, unrelatedCancel := context.WithCancel(context.Background())
+	unrelatedCancel()
+
+	makeMessage := func(key string) []byte {
+		message, err := json.Marshal(api.MethodWithRequestPayload{
+			Method:  "method",
+			Payload: api.JSONRawOrString(`{"key":"` + key + `"}`),
+		})
+		require.NoError(t, err)
+		return message
+	}
+	firstMessage := makeMessage("first")
+	secondMessage := makeMessage("second")
+
+	const numFailures = 3
+
+	var mu sync.Mutex
+	var retryCount int
+	var dispatched [][]byte
+
+	allDispatched := make(chan struct{})
+	consumerClosed := make(chan struct{})
+
+	mockDispatcher := &MockDispatcher{
+		onDispatchCommand: func(_ context.Context, _ string, data []byte) error {
+			mu.Lock()
+			defer mu.Unlock()
+			if bytes.Equal(data, firstMessage) && retryCount < numFailures {
+				retryCount++
+				return fmt.Errorf("dispatch error: %w", unrelatedCtx.Err())
+			}
+			dispatched = append(dispatched, data)
+			if len(dispatched) == 2 {
+				close(allDispatched)
+			}
+			return nil
+		},
+	}
+	consumer, err := NewKafkaConsumer(config, mockDispatcher, testCommon(prometheus.NewRegistry()))
+	require.NoError(t, err)
+
+	go func() {
+		err := consumer.Run(ctx)
+		require.ErrorIs(t, err, context.Canceled)
+		close(consumerClosed)
+	}()
+
+	err = produceManyRecords(
+		&kgo.Record{Topic: testKafkaTopic, Value: firstMessage},
+		&kgo.Record{Topic: testKafkaTopic, Value: secondMessage},
+	)
+	require.NoError(t, err)
+
+	waitCh(t, allDispatched, 30*time.Second, "timeout waiting for records to be processed")
+
+	mu.Lock()
+	require.Equal(t, numFailures, retryCount)
+	// Both records must be processed, in order – neither the retried one nor the rest of
+	// its batch may be skipped.
+	require.Equal(t, [][]byte{firstMessage, secondMessage}, dispatched)
+	mu.Unlock()
+
+	cancel()
+	waitCh(t, consumerClosed, 30*time.Second, "timeout waiting for consumer closed")
+}
+
 // In this test we simulate a scenario where a partition is blocked and the partition consumer
 // is stuck on it. We want to make sure that the consumer is not blocked and can still process
 // messages from other topics.


### PR DESCRIPTION
## Problem

`partitionConsumer.processRecords` treated **any** error matching `context.Canceled` as a shutdown signal and returned:

```go
err := pc.processRecord(pc.partitionCtx, record)
...
if errors.Is(err, context.Canceled) {
    return
}
```

But `processRecord` calls into the dispatcher, which can surface a `context.Canceled` that has nothing to do with the consumer lifecycle (a downstream call with its own context). When that happens:

1. the record is dropped without being retried,
2. the rest of the batch is skipped,
3. `consume()` pops the next batch and `MarkCommitRecords` on it.

Kafka commits are offset based, so committing a later offset implicitly commits the skipped ones. The messages are lost — no retry, no redelivery.

## Fix

Check the context, not the error — the idiom the file already uses in the poll loop (`kafka.go:387`):

```go
if pc.partitionCtx.Err() != nil {
    return
}
```

Genuine shutdown behaves exactly as before. An unrelated cancel now falls through to the normal backoff/retry path, whose `select` still watches `partitionCtx.Done()`, so there is no way to spin during shutdown.

The SQS consumer had the same pattern. The consequence there is milder — it returns `false`, so the message is not deleted and SQS redelivers it — but the retry budget was still burned on a spurious cancel, so it is aligned too.

## Test

`TestKafkaConsumer_UnrelatedContextCanceledIsRetried` produces two records to one partition. The dispatcher fails the first one 3 times with `fmt.Errorf("dispatch error: %w", context.Canceled)` from an unrelated canceled context, then succeeds. It asserts the retry count and that **both** payloads arrive in order — covering the record itself and the rest of its batch.

Verified against a live Kafka (docker-compose `kafka` service):

- with the fix: `PASS (3.65s)`
- with the old `errors.Is` check restored: `FAIL (30.09s) — timeout waiting for records to be processed`, both records dropped

Full `TestKafkaConsumer_*` suite passes.