### PR TITLE
fix(postgres): tolerate concurrent DDL when nodes start together

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/securecookie v1.1.2
 	github.com/hashicorp/go-envparse v0.1.0
+	github.com/jackc/pgerrcode v0.0.0-20250907135507-afb5586c32a6
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/joho/godotenv v1.5.1
 	github.com/justinas/alice v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -169,6 +169,8 @@ github.com/hashicorp/go-envparse v0.1.0 h1:bE++6bhIsNCPLvgDZkYqo3nA+/PFI51pkrHdm
 github.com/hashicorp/go-envparse v0.1.0/go.mod h1:OHheN1GoygLlAkTlXLXvAdnXdZxy8JUweQ1rAXx1xnc=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/jackc/pgerrcode v0.0.0-20250907135507-afb5586c32a6 h1:D/V0gu4zQ3cL2WKeVNVM4r2gLxGGf6McLwgXzRTo2RQ=
+github.com/jackc/pgerrcode v0.0.0-20250907135507-afb5586c32a6/go.mod h1:a/s9Lp5W7n/DD0VrVoyJ00FbP2ytTPDVOivvn2bMlds=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=

--- a/internal/controllers/controller_postgres.go
+++ b/internal/controllers/controller_postgres.go
@@ -3,7 +3,6 @@ package controllers
 import (
 	"context"
 	_ "embed"
-	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -15,7 +14,6 @@ import (
 
 	"github.com/centrifugal/centrifuge"
 	"github.com/centrifugal/centrifugo/v6/internal/pgschema"
-	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/rs/zerolog/log"
 )
@@ -322,6 +320,11 @@ func splitControllerSchemaSQL(sql string) (ddl, funcs string) {
 	return sql[:i], sql[i:]
 }
 
+// execSchemaWithRetry executes idempotent schema SQL, retrying on the
+// conflicts several nodes running the same DDL at once produce — see
+// pgschema.IsConcurrentDDLErr. The SQL is one multi-statement Exec, so the
+// server runs it in a single implicit transaction and a failed attempt rolls
+// back completely, which is what makes re-running the whole batch safe.
 func (c *PostgresController) execSchemaWithRetry(ctx context.Context, sql string) error {
 	const maxRetries = 3
 	for attempt := 0; attempt < maxRetries; attempt++ {
@@ -329,8 +332,7 @@ func (c *PostgresController) execSchemaWithRetry(ctx context.Context, sql string
 		if err == nil {
 			return nil
 		}
-		var pgErr *pgconn.PgError
-		if errors.As(err, &pgErr) && (pgErr.Code == "40P01" || pgErr.Code == "XX000") && attempt < maxRetries-1 {
+		if pgschema.IsConcurrentDDLErr(err) && attempt < maxRetries-1 {
 			time.Sleep(200 * time.Millisecond)
 			continue
 		}

--- a/internal/controllers/controller_postgres.go
+++ b/internal/controllers/controller_postgres.go
@@ -320,22 +320,17 @@ func splitControllerSchemaSQL(sql string) (ddl, funcs string) {
 	return sql[:i], sql[i:]
 }
 
-// execSchemaWithRetry executes idempotent schema SQL, retrying on the
-// conflicts several nodes running the same DDL at once produce — see
-// pgschema.IsConcurrentDDLErr. The SQL is one multi-statement Exec, so the
-// server runs it in a single implicit transaction and a failed attempt rolls
-// back completely, which is what makes re-running the whole batch safe.
+// execSchemaWithRetry executes idempotent schema SQL, retrying the batch on
+// the conflicts several nodes running the same DDL at once produce — see
+// pgschema.RetrySchemaExec for the policy and for the invariant the SQL has
+// to keep (one multi-statement Exec with no arguments, so the server runs it
+// in a single implicit transaction that rolls back completely on failure).
 func (c *PostgresController) execSchemaWithRetry(ctx context.Context, sql string) error {
-	const maxRetries = 3
-	for attempt := 0; attempt < maxRetries; attempt++ {
+	err := pgschema.RetrySchemaExec(ctx, func(ctx context.Context) error {
 		_, err := c.pool.Exec(ctx, sql)
-		if err == nil {
-			return nil
-		}
-		if pgschema.IsConcurrentDDLErr(err) && attempt < maxRetries-1 {
-			time.Sleep(200 * time.Millisecond)
-			continue
-		}
+		return err
+	})
+	if err != nil {
 		return fmt.Errorf("postgres controller: schema exec: %w", err)
 	}
 	return nil

--- a/internal/controllers/controller_postgres_test.go
+++ b/internal/controllers/controller_postgres_test.go
@@ -154,6 +154,77 @@ func waitForMessages(t *testing.T, counter *atomic.Int64, expectedCount int64, t
 	}
 }
 
+// TestPostgresController_EnsureSchema_ConcurrentNodes reproduces a cluster
+// whose nodes all start against the same empty database — the shape of a
+// fresh install rolled out to a whole deployment at once. CREATE TABLE/INDEX
+// IF NOT EXISTS probes the catalog before it takes any lock, so every node
+// but the winner loses the race and gets a hard error (42P07, or 23505 on
+// pg_type/pg_class when it reached its own catalog inserts first) instead of
+// the NOTICE a sequential re-run produces. EnsureSchema returning that error
+// means the node refuses to start, so every node here must come up clean.
+//
+// The race is timing-dependent and won't fire on every run — the test is a
+// regression guard, not a reproducer: it must never fail.
+func TestPostgresController_EnsureSchema_ConcurrentNodes(t *testing.T) {
+	const (
+		nodes  = 8
+		rounds = 3
+	)
+	ctx := context.Background()
+	prefix := fmt.Sprintf("test_concurrent_%d", time.Now().UnixNano()%100000)
+
+	// Separate controllers with separate pools — one per simulated node.
+	controllers := make([]*PostgresController, 0, nodes)
+	for range nodes {
+		node, err := centrifuge.New(centrifuge.Config{})
+		require.NoError(t, err)
+		c, err := NewPostgresController(node, PostgresControllerConfig{
+			DSN:          getPostgresConnString(t),
+			TablePrefix:  prefix,
+			PollInterval: time.Hour,
+		})
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			c.closeOnce.Do(func() {
+				close(c.closeCh)
+				c.cancelFunc()
+				c.pool.Close()
+			})
+			_ = node.Shutdown(context.Background())
+		})
+		controllers = append(controllers, c)
+	}
+
+	for round := range rounds {
+		dropTestControllerSchema(t, controllers[0])
+
+		start := make(chan struct{})
+		errs := make([]error, nodes)
+		var wg sync.WaitGroup
+		for i, c := range controllers {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				<-start
+				errs[i] = c.EnsureSchema(ctx)
+			}()
+		}
+		close(start)
+		wg.Wait()
+
+		for i, err := range errs {
+			require.NoErrorf(t, err, "round %d: node %d failed to bring up the schema", round, i)
+		}
+		for _, table := range []string{
+			controllers[0].names.messages, controllers[0].names.shardLock, controllers[0].names.schemaVersion,
+		} {
+			var reg *string
+			require.NoError(t, controllers[0].pool.QueryRow(ctx, "SELECT to_regclass($1)::text", table).Scan(&reg))
+			require.NotNilf(t, reg, "round %d: table %s missing after concurrent EnsureSchema", round, table)
+		}
+	}
+}
+
 func TestPostgresController_PublishAndReceive(t *testing.T) {
 	var received atomic.Int64
 	var receivedData []byte

--- a/internal/controllers/schema_template_test.go
+++ b/internal/controllers/schema_template_test.go
@@ -1,0 +1,29 @@
+package controllers
+
+import (
+	"regexp"
+	"testing"
+)
+
+// execSchemaWithRetry re-runs the whole batch on a concurrent-DDL conflict,
+// which is only safe while the batch stays one implicit transaction: no
+// statement of its own opening or closing a transaction, and nothing that
+// cannot run inside a transaction block at all (CREATE INDEX CONCURRENTLY
+// would fail outright with 25001, and a retry could not undo the half of the
+// batch that already committed). The invariant lives in the SQL template, so
+// pin it here rather than in a comment.
+func TestControllerSchemaTemplate_StaysOneImplicitTransaction(t *testing.T) {
+	concurrently := regexp.MustCompile(`(?i)\bCONCURRENTLY\b`)
+	txControl := regexp.MustCompile(`(?im)^\s*(BEGIN|COMMIT|ROLLBACK|START\s+TRANSACTION)\b`)
+
+	sql := renderControllerTemplate(postgresControllerSchemaTemplate, "cf_")
+	if loc := concurrently.FindString(sql); loc != "" {
+		t.Errorf("schema template uses %q — it cannot run inside the implicit transaction execSchemaWithRetry relies on", loc)
+	}
+	// Only the DDL half is checked for transaction control: the funcs half is
+	// dollar-quoted PL/pgSQL, where BEGIN opens a block.
+	ddl, _ := splitControllerSchemaSQL(sql)
+	if loc := txControl.FindString(ddl); loc != "" {
+		t.Errorf("schema DDL contains explicit transaction control %q — the batch must be left to the server's implicit transaction", loc)
+	}
+}

--- a/internal/pgmapbroker/pgmapbroker.go
+++ b/internal/pgmapbroker/pgmapbroker.go
@@ -84,37 +84,32 @@ func renderSchema(prefix string, binary bool) string {
 	return renderSchemaTemplate(postgresSchemaTemplate, prefix, binary)
 }
 
-// execSchemaWithRetry executes idempotent schema SQL, retrying on the
-// conflicts several nodes running the same DDL at once produce — see
-// pgschema.IsConcurrentDDLErr. The SQL is one multi-statement Exec, so the
-// server runs it in a single implicit transaction and a failed attempt rolls
-// back completely, which is what makes re-running the whole batch safe.
+// execSchemaWithRetry executes idempotent schema SQL, retrying the batch on
+// the conflicts several nodes running the same DDL at once produce — see
+// pgschema.RetrySchemaExec for the policy and for the invariant the SQL has
+// to keep (one multi-statement Exec with no arguments, so the server runs it
+// in a single implicit transaction that rolls back completely on failure).
 func (e *PostgresMapBroker) execSchemaWithRetry(ctx context.Context, sql string) error {
-	const maxRetries = 3
-	for attempt := range maxRetries {
+	err := pgschema.RetrySchemaExec(ctx, func(ctx context.Context) error {
 		_, err := e.pool.Exec(ctx, sql)
-		if err == nil {
-			return nil
-		}
-		if pgschema.IsConcurrentDDLErr(err) && attempt < maxRetries-1 {
-			time.Sleep(200 * time.Millisecond)
-			continue
-		}
-		var pgErr *pgconn.PgError
-		if errors.As(err, &pgErr) {
-			return &SchemaError{
-				Object: SchemaObject{Type: "schema", Name: pgErr.TableName},
-				Op:     "create",
-				Err:    err,
-			}
-		}
+		return err
+	})
+	if err == nil {
+		return nil
+	}
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) {
 		return &SchemaError{
-			Object: SchemaObject{Type: "schema", Name: ""},
+			Object: SchemaObject{Type: "schema", Name: pgErr.TableName},
 			Op:     "create",
 			Err:    err,
 		}
 	}
-	return nil
+	return &SchemaError{
+		Object: SchemaObject{Type: "schema", Name: ""},
+		Op:     "create",
+		Err:    err,
+	}
 }
 
 // splitSchemaSQL splits the schema SQL into DDL (tables+indexes) and function

--- a/internal/pgmapbroker/pgmapbroker.go
+++ b/internal/pgmapbroker/pgmapbroker.go
@@ -84,10 +84,11 @@ func renderSchema(prefix string, binary bool) string {
 	return renderSchemaTemplate(postgresSchemaTemplate, prefix, binary)
 }
 
-// execSchemaWithRetry executes idempotent schema SQL, retrying on transient
-// conflicts: deadlock (40P01) and "tuple concurrently updated" (XX000).
-// The latter occurs when concurrent CREATE OR REPLACE FUNCTION statements
-// race on the same function (e.g. during rolling deploys).
+// execSchemaWithRetry executes idempotent schema SQL, retrying on the
+// conflicts several nodes running the same DDL at once produce — see
+// pgschema.IsConcurrentDDLErr. The SQL is one multi-statement Exec, so the
+// server runs it in a single implicit transaction and a failed attempt rolls
+// back completely, which is what makes re-running the whole batch safe.
 func (e *PostgresMapBroker) execSchemaWithRetry(ctx context.Context, sql string) error {
 	const maxRetries = 3
 	for attempt := range maxRetries {
@@ -95,11 +96,11 @@ func (e *PostgresMapBroker) execSchemaWithRetry(ctx context.Context, sql string)
 		if err == nil {
 			return nil
 		}
-		var pgErr *pgconn.PgError
-		if errors.As(err, &pgErr) && (pgErr.Code == "40P01" || pgErr.Code == "XX000") && attempt < maxRetries-1 {
+		if pgschema.IsConcurrentDDLErr(err) && attempt < maxRetries-1 {
 			time.Sleep(200 * time.Millisecond)
 			continue
 		}
+		var pgErr *pgconn.PgError
 		if errors.As(err, &pgErr) {
 			return &SchemaError{
 				Object: SchemaObject{Type: "schema", Name: pgErr.TableName},

--- a/internal/pgmapbroker/pgmapbroker_test.go
+++ b/internal/pgmapbroker/pgmapbroker_test.go
@@ -1628,6 +1628,75 @@ func TestPostgresMapBroker_EnsureSchema_Idempotent(t *testing.T) {
 	verifySchemaComplete(t, ctx, broker.pool, "cf_binary_map_", false)
 }
 
+// TestPostgresMapBroker_EnsureSchema_ConcurrentNodes reproduces a cluster
+// whose nodes all start against the same empty database — the shape of a
+// fresh install rolled out to a whole deployment at once. CREATE TABLE/INDEX
+// IF NOT EXISTS probes the catalog before it takes any lock, so every node
+// but the winner loses the race and gets a hard error (42P07, or 23505 on
+// pg_type/pg_class when it reached its own catalog inserts first) instead of
+// the NOTICE a sequential re-run produces. EnsureSchema returning that error
+// means the node refuses to start, so every node here must come up clean.
+//
+// The race is timing-dependent and won't fire on every run — the test is a
+// regression guard, not a reproducer: it must never fail.
+func TestPostgresMapBroker_EnsureSchema_ConcurrentNodes(t *testing.T) {
+	const (
+		nodes  = 8
+		rounds = 3
+	)
+	connString := getPostgresConnString(t)
+	ctx := context.Background()
+
+	// Separate brokers with separate pools — one per simulated node.
+	brokers := make([]*PostgresMapBroker, 0, nodes)
+	for range nodes {
+		node, _ := centrifuge.New(centrifuge.Config{
+			Map: centrifuge.MapConfig{
+				GetMapChannelOptions: func(channel string) centrifuge.MapChannelOptions {
+					return centrifuge.MapChannelOptions{
+						Mode:   centrifuge.MapModeRecoverable,
+						KeyTTL: 60 * time.Second,
+					}
+				},
+			},
+		})
+		broker, err := NewPostgresMapBroker(node, PostgresMapBrokerConfig{
+			DSN:       connString,
+			NumShards: 4,
+		})
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			_ = broker.Close(ctx)
+			_ = node.Shutdown(ctx)
+		})
+		brokers = append(brokers, broker)
+	}
+
+	for round := range rounds {
+		dropAllSchemaObjects(ctx, brokers[0].pool)
+
+		start := make(chan struct{})
+		errs := make([]error, nodes)
+		var wg sync.WaitGroup
+		for i, broker := range brokers {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				<-start
+				errs[i] = broker.EnsureSchema(ctx)
+			}()
+		}
+		close(start)
+		wg.Wait()
+
+		for i, err := range errs {
+			require.NoErrorf(t, err, "round %d: node %d failed to bring up the schema", round, i)
+		}
+		verifySchemaComplete(t, ctx, brokers[0].pool, "cf_map_", true)
+		verifySchemaComplete(t, ctx, brokers[0].pool, "cf_binary_map_", false)
+	}
+}
+
 // TestPostgresMapBroker_EnsureSchema_PartialState tests that EnsureSchema handles partial schema.
 func TestPostgresMapBroker_EnsureSchema_PartialState(t *testing.T) {
 	connString := getPostgresConnString(t)

--- a/internal/pgmapbroker/schema_template_test.go
+++ b/internal/pgmapbroker/schema_template_test.go
@@ -1,0 +1,40 @@
+package pgmapbroker
+
+import (
+	"regexp"
+	"testing"
+)
+
+// execSchemaWithRetry re-runs the whole batch on a concurrent-DDL conflict,
+// which is only safe while the batch stays one implicit transaction: no
+// statement of its own opening or closing a transaction, and nothing that
+// cannot run inside a transaction block at all (CREATE INDEX CONCURRENTLY
+// would fail outright with 25001, and a retry could not undo the half of the
+// batch that already committed). The invariant lives in the SQL template, so
+// pin it here rather than in a comment.
+func TestSchemaTemplate_StaysOneImplicitTransaction(t *testing.T) {
+	concurrently := regexp.MustCompile(`(?i)\bCONCURRENTLY\b`)
+	txControl := regexp.MustCompile(`(?im)^\s*(BEGIN|COMMIT|ROLLBACK|START\s+TRANSACTION)\b`)
+
+	for _, tc := range []struct {
+		name   string
+		prefix string
+		binary bool
+	}{
+		{"jsonb", "cf_map_", false},
+		{"binary", "cf_binary_map_", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			sql := renderSchema(tc.prefix, tc.binary)
+			if loc := concurrently.FindString(sql); loc != "" {
+				t.Errorf("schema template uses %q — it cannot run inside the implicit transaction execSchemaWithRetry relies on", loc)
+			}
+			// Only the DDL half is checked for transaction control: the funcs
+			// half is dollar-quoted PL/pgSQL, where BEGIN opens a block.
+			ddl, _ := splitSchemaSQL(sql)
+			if loc := txControl.FindString(ddl); loc != "" {
+				t.Errorf("schema DDL contains explicit transaction control %q — the batch must be left to the server's implicit transaction", loc)
+			}
+		})
+	}
+}

--- a/internal/pgoutbox/partitioner.go
+++ b/internal/pgoutbox/partitioner.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/centrifugal/centrifugo/v6/internal/pgschema"
+
 	"github.com/jackc/pgerrcode"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -86,8 +88,9 @@ type Partitioner struct {
 // EnsureLookaheadPartitions creates today's daily partition and up to
 // LookaheadDays future daily partitions as PARTITION OF ParentTable.
 // The CREATE TABLE IF NOT EXISTS form makes this safe to call repeatedly, and
-// tolerating 42P07 makes it safe to call concurrently: every node runs the
-// partitioner, so the same partition is routinely created by two of them at once.
+// tolerating 42P07 (plus retrying the other concurrent-DDL conflicts) makes it
+// safe to call concurrently: every node runs the partitioner, so the same
+// partition is routinely created by two of them at once.
 //
 // Boundaries are written as fully-qualified UTC timestamps (e.g.
 // '2026-04-23 00:00:00+00'). Using a bare DATE/date-text literal would
@@ -102,13 +105,26 @@ func (p *Partitioner) EnsureLookaheadPartitions(ctx context.Context) error {
 		day := now.AddDate(0, 0, d)
 		nextDay := day.AddDate(0, 0, 1)
 		partName := fmt.Sprintf("%s_%s", p.ParentTable, day.Format("2006_01_02"))
-		_, err := p.Pool.Exec(ctx, fmt.Sprintf(
+		stmt := fmt.Sprintf(
 			`CREATE TABLE IF NOT EXISTS %s PARTITION OF %s FOR VALUES FROM ('%s') TO ('%s')`,
 			partName, p.ParentTable,
 			day.Format("2006-01-02 00:00:00+00"),
 			nextDay.Format("2006-01-02 00:00:00+00"),
-		))
-		if err != nil && !isDuplicateTableErr(err) {
+		)
+		// Nodes that start together run this at the same moment, so the same
+		// concurrent-DDL conflicts the schema batch retries apply here too —
+		// and this runs on the startup path (EnsureSchema pre-creates the
+		// lookahead), where a bare failure means the node refuses to start.
+		// 42P07 is the one conflict that needs no retry: the partition exists,
+		// which is the outcome the statement was asking for.
+		err := pgschema.RetrySchemaExec(ctx, func(ctx context.Context) error {
+			_, err := p.Pool.Exec(ctx, stmt)
+			if isDuplicateTableErr(err) {
+				return nil
+			}
+			return err
+		})
+		if err != nil {
 			return fmt.Errorf("create partition %s: %w", partName, err)
 		}
 	}

--- a/internal/pgoutbox/partitioner.go
+++ b/internal/pgoutbox/partitioner.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/jackc/pgerrcode"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
@@ -27,7 +28,7 @@ func isShutdownErr(err error) bool {
 // outcome the statement was asking for.
 func isDuplicateTableErr(err error) bool {
 	var pgErr *pgconn.PgError
-	return errors.As(err, &pgErr) && pgErr.Code == "42P07"
+	return errors.As(err, &pgErr) && pgErr.Code == pgerrcode.DuplicateTable
 }
 
 // Partitioner manages daily time-based partition maintenance for an

--- a/internal/pgoutbox/partitioner_test.go
+++ b/internal/pgoutbox/partitioner_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jackc/pgerrcode"
 	"github.com/jackc/pgx/v5/pgconn"
 )
 
@@ -217,17 +218,17 @@ func TestIsDuplicateTableErr(t *testing.T) {
 	}{
 		{
 			name: "duplicate table from a concurrent creator",
-			err:  &pgconn.PgError{Code: "42P07", Message: `relation "cf_stream_history_2026_09_11" already exists`},
+			err:  &pgconn.PgError{Code: pgerrcode.DuplicateTable, Message: `relation "cf_stream_history_2026_09_11" already exists`},
 			want: true,
 		},
 		{
 			name: "wrapped duplicate table",
-			err:  fmt.Errorf("create partition: %w", &pgconn.PgError{Code: "42P07"}),
+			err:  fmt.Errorf("create partition: %w", &pgconn.PgError{Code: pgerrcode.DuplicateTable}),
 			want: true,
 		},
 		{
 			name: "a different server error is still a failure",
-			err:  &pgconn.PgError{Code: "42501", Message: "permission denied"},
+			err:  &pgconn.PgError{Code: pgerrcode.InsufficientPrivilege, Message: "permission denied"},
 			want: false,
 		},
 		{

--- a/internal/pgschema/pgschema.go
+++ b/internal/pgschema/pgschema.go
@@ -13,6 +13,7 @@ import (
 	"hash/fnv"
 	"time"
 
+	"github.com/jackc/pgerrcode"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -79,7 +80,7 @@ func ReadSchemaVersion(ctx context.Context, q querier, table string) (int, bool,
 		return 0, true, nil
 	}
 	var pgErr *pgconn.PgError
-	if errors.As(err, &pgErr) && pgErr.Code == "42P01" {
+	if errors.As(err, &pgErr) && pgErr.Code == pgerrcode.UndefinedTable {
 		return 0, true, nil
 	}
 	return 0, false, fmt.Errorf("read schema_version from %s: %w", table, err)
@@ -118,6 +119,46 @@ type MigrationVariant struct {
 	VersionTable string
 }
 
+// IsConcurrentDDLErr reports whether err is a conflict caused by several nodes
+// running the same idempotent schema DDL at the same time. That is the normal
+// situation on a cluster start or a rolling restart: every node runs its own
+// EnsureSchema against the same database and nothing serialises them.
+//
+//   - 40P01 deadlock_detected — nodes taking the same catalog locks in
+//     different orders.
+//   - XX000 internal_error, which is how "tuple concurrently updated" arrives
+//     — raised by concurrent CREATE OR REPLACE FUNCTION on the same function.
+//   - 42P07 duplicate_table and 23505 unique_violation — CREATE TABLE/INDEX
+//     IF NOT EXISTS probes the catalog before it takes any lock, so two nodes
+//     both pass the probe and the loser gets a hard error instead of the
+//     NOTICE a sequential re-run produces. Which of the two it gets depends on
+//     whether the winner had committed by the time the loser looked again:
+//     42P07 from the explicit check in heap_create_with_catalog if it had,
+//     23505 from the unique index on pg_type/pg_class if the loser reached its
+//     own catalog inserts first.
+//
+// Retrying is the right response to all four: either the object now exists,
+// which is the outcome the statement asked for, or the next attempt creates
+// it. Retrying is only safe for callers that run their schema batch as a
+// single implicit transaction — one multi-statement Exec with no explicit
+// BEGIN/COMMIT — so a failed attempt rolls back completely and the retry
+// starts from a clean state.
+//
+// Migrations deliberately do not use this: they run under
+// AcquireMigrationLock, which serialises nodes cluster-wide, so a duplicate
+// object there is a real bug and must surface rather than be retried away.
+func IsConcurrentDDLErr(err error) bool {
+	var pgErr *pgconn.PgError
+	if !errors.As(err, &pgErr) {
+		return false
+	}
+	switch pgErr.Code {
+	case pgerrcode.DeadlockDetected, pgerrcode.InternalError, pgerrcode.DuplicateTable, pgerrcode.UniqueViolation:
+		return true
+	}
+	return false
+}
+
 // ApplyMigrationInTx applies one migration step. For each variant in the
 // slice:
 //   - The variant's SQL is executed.
@@ -128,11 +169,12 @@ type MigrationVariant struct {
 // retries safe even when migration SQL is not perfectly idempotent — the
 // previous attempt has fully rolled back.
 //
-// The body is retried up to migrationRetryAttempts times on the same
-// transient codes execSchemaWithRetry retries (40P01 deadlock_detected,
-// XX000 "tuple concurrently updated" — surfaces from concurrent
-// CREATE OR REPLACE in a rolling deploy). ctx cancellation aborts the
-// retry loop immediately.
+// The body is retried up to migrationRetryAttempts times on transient
+// conflicts (40P01 deadlock_detected, XX000 "tuple concurrently updated" —
+// surfaces from concurrent CREATE OR REPLACE in a rolling deploy). ctx
+// cancellation aborts the retry loop immediately. This is deliberately
+// narrower than IsConcurrentDDLErr — see the note there on why migrations
+// must not retry away duplicate-object errors.
 func ApplyMigrationInTx(ctx context.Context, p txBeginner, label string, version int, variants []MigrationVariant) error {
 	if len(variants) == 0 {
 		return fmt.Errorf("%s: ApplyMigrationInTx v%d called with no variants", label, version)
@@ -144,7 +186,7 @@ func ApplyMigrationInTx(ctx context.Context, p txBeginner, label string, version
 			return nil
 		}
 		var pgErr *pgconn.PgError
-		if errors.As(err, &pgErr) && (pgErr.Code == "40P01" || pgErr.Code == "XX000") && attempt < migrationRetryAttempts-1 {
+		if errors.As(err, &pgErr) && (pgErr.Code == pgerrcode.DeadlockDetected || pgErr.Code == pgerrcode.InternalError) && attempt < migrationRetryAttempts-1 {
 			lastErr = err
 			select {
 			case <-ctx.Done():

--- a/internal/pgschema/pgschema.go
+++ b/internal/pgschema/pgschema.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"hash/fnv"
+	"math/rand/v2"
 	"time"
 
 	"github.com/jackc/pgerrcode"
@@ -119,10 +120,10 @@ type MigrationVariant struct {
 	VersionTable string
 }
 
-// IsConcurrentDDLErr reports whether err is a conflict caused by several nodes
-// running the same idempotent schema DDL at the same time. That is the normal
-// situation on a cluster start or a rolling restart: every node runs its own
-// EnsureSchema against the same database and nothing serialises them.
+// IsRetryableSchemaExecErr reports whether err is a conflict caused by several
+// nodes running the same idempotent schema DDL at the same time. That is the
+// normal situation on a cluster start or a rolling restart: every node runs its
+// own EnsureSchema against the same database and nothing serialises them.
 //
 //   - 40P01 deadlock_detected — nodes taking the same catalog locks in
 //     different orders.
@@ -137,17 +138,14 @@ type MigrationVariant struct {
 //     23505 from the unique index on pg_type/pg_class if the loser reached its
 //     own catalog inserts first.
 //
-// Retrying is the right response to all four: either the object now exists,
-// which is the outcome the statement asked for, or the next attempt creates
-// it. Retrying is only safe for callers that run their schema batch as a
-// single implicit transaction — one multi-statement Exec with no explicit
-// BEGIN/COMMIT — so a failed attempt rolls back completely and the retry
-// starts from a clean state.
+// The name is deliberately bound to schema execs: 23505 and XX000 are ordinary
+// application failures anywhere else, and retrying them on a data path would
+// paper over real bugs. Only classify statements from a schema batch with this.
 //
-// Migrations deliberately do not use this: they run under
-// AcquireMigrationLock, which serialises nodes cluster-wide, so a duplicate
-// object there is a real bug and must surface rather than be retried away.
-func IsConcurrentDDLErr(err error) bool {
+// Migrations deliberately do not use it: they run under AcquireMigrationLock,
+// which serialises nodes cluster-wide, so a duplicate object there is a real
+// bug and must surface rather than be retried away.
+func IsRetryableSchemaExecErr(err error) bool {
 	var pgErr *pgconn.PgError
 	if !errors.As(err, &pgErr) {
 		return false
@@ -157,6 +155,63 @@ func IsConcurrentDDLErr(err error) bool {
 		return true
 	}
 	return false
+}
+
+const (
+	schemaExecAttempts    = 5
+	schemaExecBaseBackoff = 100 * time.Millisecond
+	schemaExecMaxBackoff  = 800 * time.Millisecond
+)
+
+// RetrySchemaExec runs exec, repeating it while it fails with a concurrent-DDL
+// conflict (see IsRetryableSchemaExecErr) and attempts remain. Any other error
+// is returned on the first occurrence, as is the last conflict once the
+// attempts are exhausted; a cancelled ctx aborts the loop and returns
+// ctx.Err(), so a shutdown mid-retry is reported as cancellation rather than
+// as a schema failure.
+//
+// Callers must make exec idempotent AND self-contained: a retry re-runs the
+// whole thing, so a schema batch has to be a single multi-statement Exec with
+// no arguments (pgx sends those over the simple query protocol, so the server
+// wraps them in one implicit transaction and a failed attempt rolls back
+// completely). A batch that opens its own BEGIN/COMMIT, or contains a
+// statement that cannot run inside a transaction block such as CREATE INDEX
+// CONCURRENTLY, breaks that invariant and must not be retried this way — the
+// schema-template tests in each consumer package pin it.
+//
+// The backoff is exponential with jitter: nodes that started together lose the
+// same race at the same instant, and retrying them in lockstep just recreates
+// the collision.
+func RetrySchemaExec(ctx context.Context, exec func(ctx context.Context) error) error {
+	var err error
+	for attempt := range schemaExecAttempts {
+		err = exec(ctx)
+		if err == nil {
+			return nil
+		}
+		if !IsRetryableSchemaExecErr(err) || attempt == schemaExecAttempts-1 {
+			return err
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(schemaExecBackoff(attempt)):
+		}
+	}
+	return err
+}
+
+// schemaExecBackoff returns the delay before the attempt after this one:
+// exponential from schemaExecBaseBackoff, capped at schemaExecMaxBackoff, and
+// spread over the upper half of that window so concurrent nodes separate
+// without any of them waiting the full cap.
+func schemaExecBackoff(attempt int) time.Duration {
+	d := schemaExecBaseBackoff << attempt
+	if d > schemaExecMaxBackoff {
+		d = schemaExecMaxBackoff
+	}
+	//nolint:gosec // it's a jitter.
+	return d/2 + time.Duration(rand.Int64N(int64(d/2)+1))
 }
 
 // ApplyMigrationInTx applies one migration step. For each variant in the
@@ -173,8 +228,8 @@ func IsConcurrentDDLErr(err error) bool {
 // conflicts (40P01 deadlock_detected, XX000 "tuple concurrently updated" —
 // surfaces from concurrent CREATE OR REPLACE in a rolling deploy). ctx
 // cancellation aborts the retry loop immediately. This is deliberately
-// narrower than IsConcurrentDDLErr — see the note there on why migrations
-// must not retry away duplicate-object errors.
+// narrower than IsRetryableSchemaExecErr — see the note there on why
+// migrations must not retry away duplicate-object errors.
 func ApplyMigrationInTx(ctx context.Context, p txBeginner, label string, version int, variants []MigrationVariant) error {
 	if len(variants) == 0 {
 		return fmt.Errorf("%s: ApplyMigrationInTx v%d called with no variants", label, version)

--- a/internal/pgschema/pgschema_test.go
+++ b/internal/pgschema/pgschema_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jackc/pgerrcode"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -72,6 +73,31 @@ func TestCheckDowngrade_DBNewer_Rejected(t *testing.T) {
 	require.Contains(t, err.Error(), "schema_version is 5")
 	require.Contains(t, err.Error(), "supports only up to 3")
 	require.Contains(t, err.Error(), "downgrade not supported")
+}
+
+// ----- IsConcurrentDDLErr -----
+
+func TestIsConcurrentDDLErr(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"deadlock", &pgconn.PgError{Code: pgerrcode.DeadlockDetected}, true},
+		{"tuple concurrently updated", &pgconn.PgError{Code: pgerrcode.InternalError}, true},
+		{"duplicate table from a concurrent creator", &pgconn.PgError{Code: pgerrcode.DuplicateTable}, true},
+		{"catalog unique violation from a concurrent creator", &pgconn.PgError{Code: pgerrcode.UniqueViolation}, true},
+		{"wrapped", fmt.Errorf("schema exec: %w", &pgconn.PgError{Code: pgerrcode.DuplicateTable}), true},
+		{"permission denied is a real failure", &pgconn.PgError{Code: pgerrcode.InsufficientPrivilege}, false},
+		{"undefined table is a real failure", &pgconn.PgError{Code: pgerrcode.UndefinedTable}, false},
+		{"non-server error", errors.New("connection reset"), false},
+		{"nil", nil, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, IsConcurrentDDLErr(tc.err))
+		})
+	}
 }
 
 // ----- Integration helpers -----
@@ -213,7 +239,7 @@ func TestReadSchemaVersion_ColumnMissing_PropagatesError(t *testing.T) {
 	// Verify it surfaces as a pg error (column missing).
 	var pgErr *pgconn.PgError
 	require.True(t, errors.As(err, &pgErr))
-	require.Equal(t, "42703", pgErr.Code)
+	require.Equal(t, pgerrcode.UndefinedColumn, pgErr.Code)
 }
 
 // ----- ApplyMigrationInTx -----

--- a/internal/pgschema/pgschema_test.go
+++ b/internal/pgschema/pgschema_test.go
@@ -75,9 +75,9 @@ func TestCheckDowngrade_DBNewer_Rejected(t *testing.T) {
 	require.Contains(t, err.Error(), "downgrade not supported")
 }
 
-// ----- IsConcurrentDDLErr -----
+// ----- IsRetryableSchemaExecErr / RetrySchemaExec -----
 
-func TestIsConcurrentDDLErr(t *testing.T) {
+func TestIsRetryableSchemaExecErr(t *testing.T) {
 	cases := []struct {
 		name string
 		err  error
@@ -95,8 +95,66 @@ func TestIsConcurrentDDLErr(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			require.Equal(t, tc.want, IsConcurrentDDLErr(tc.err))
+			require.Equal(t, tc.want, IsRetryableSchemaExecErr(tc.err))
 		})
+	}
+}
+
+func TestRetrySchemaExec_RetriesConflictThenSucceeds(t *testing.T) {
+	var calls int
+	err := RetrySchemaExec(context.Background(), func(context.Context) error {
+		calls++
+		if calls < 3 {
+			return &pgconn.PgError{Code: pgerrcode.DuplicateTable}
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, 3, calls)
+}
+
+func TestRetrySchemaExec_RealFailureNotRetried(t *testing.T) {
+	var calls int
+	want := &pgconn.PgError{Code: pgerrcode.InsufficientPrivilege}
+	err := RetrySchemaExec(context.Background(), func(context.Context) error {
+		calls++
+		return want
+	})
+	require.ErrorIs(t, err, want)
+	require.Equal(t, 1, calls, "a permission error must surface on the first attempt")
+}
+
+func TestRetrySchemaExec_ExhaustedReturnsLastError(t *testing.T) {
+	var calls int
+	err := RetrySchemaExec(context.Background(), func(context.Context) error {
+		calls++
+		return &pgconn.PgError{Code: pgerrcode.UniqueViolation}
+	})
+	var pgErr *pgconn.PgError
+	require.ErrorAs(t, err, &pgErr)
+	require.Equal(t, pgerrcode.UniqueViolation, pgErr.Code)
+	require.Equal(t, schemaExecAttempts, calls)
+}
+
+// A node shutting down mid-retry must report cancellation, not a schema
+// failure — pgoutbox's Run loop discriminates on it to keep shutdown quiet.
+func TestRetrySchemaExec_ContextCancelledDuringBackoff(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	var calls int
+	err := RetrySchemaExec(ctx, func(context.Context) error {
+		calls++
+		cancel()
+		return &pgconn.PgError{Code: pgerrcode.DeadlockDetected}
+	})
+	require.ErrorIs(t, err, context.Canceled)
+	require.Equal(t, 1, calls)
+}
+
+func TestSchemaExecBackoff_StaysInsideCap(t *testing.T) {
+	for attempt := range schemaExecAttempts {
+		d := schemaExecBackoff(attempt)
+		require.Positive(t, d)
+		require.LessOrEqual(t, d, schemaExecMaxBackoff)
 	}
 }
 

--- a/internal/pgstreambroker/pgstreambroker.go
+++ b/internal/pgstreambroker/pgstreambroker.go
@@ -636,22 +636,17 @@ func pgColFormatsFromRows(rows pgx.Rows) pgColFormats {
 	return fmts
 }
 
-// execSchemaWithRetry executes idempotent schema SQL, retrying on the
-// conflicts several nodes running the same DDL at once produce — see
-// pgschema.IsConcurrentDDLErr. The SQL is one multi-statement Exec, so the
-// server runs it in a single implicit transaction and a failed attempt rolls
-// back completely, which is what makes re-running the whole batch safe.
+// execSchemaWithRetry executes idempotent schema SQL, retrying the batch on
+// the conflicts several nodes running the same DDL at once produce — see
+// pgschema.RetrySchemaExec for the policy and for the invariant the SQL has
+// to keep (one multi-statement Exec with no arguments, so the server runs it
+// in a single implicit transaction that rolls back completely on failure).
 func (e *PostgresStreamBroker) execSchemaWithRetry(ctx context.Context, sql string) error {
-	const maxRetries = 3
-	for attempt := 0; attempt < maxRetries; attempt++ {
+	err := pgschema.RetrySchemaExec(ctx, func(ctx context.Context) error {
 		_, err := e.pool.Exec(ctx, sql)
-		if err == nil {
-			return nil
-		}
-		if pgschema.IsConcurrentDDLErr(err) && attempt < maxRetries-1 {
-			time.Sleep(200 * time.Millisecond)
-			continue
-		}
+		return err
+	})
+	if err != nil {
 		return &SchemaError{
 			Object: SchemaObject{Type: "schema", Name: ""},
 			Op:     "create",

--- a/internal/pgstreambroker/pgstreambroker.go
+++ b/internal/pgstreambroker/pgstreambroker.go
@@ -35,7 +35,6 @@ import (
 
 	"github.com/centrifugal/centrifuge"
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/rs/zerolog/log"
 )
@@ -637,8 +636,11 @@ func pgColFormatsFromRows(rows pgx.Rows) pgColFormats {
 	return fmts
 }
 
-// execSchemaWithRetry executes idempotent schema SQL, retrying on transient
-// conflicts: deadlock (40P01) and "tuple concurrently updated" (XX000).
+// execSchemaWithRetry executes idempotent schema SQL, retrying on the
+// conflicts several nodes running the same DDL at once produce — see
+// pgschema.IsConcurrentDDLErr. The SQL is one multi-statement Exec, so the
+// server runs it in a single implicit transaction and a failed attempt rolls
+// back completely, which is what makes re-running the whole batch safe.
 func (e *PostgresStreamBroker) execSchemaWithRetry(ctx context.Context, sql string) error {
 	const maxRetries = 3
 	for attempt := 0; attempt < maxRetries; attempt++ {
@@ -646,8 +648,7 @@ func (e *PostgresStreamBroker) execSchemaWithRetry(ctx context.Context, sql stri
 		if err == nil {
 			return nil
 		}
-		var pgErr *pgconn.PgError
-		if errors.As(err, &pgErr) && (pgErr.Code == "40P01" || pgErr.Code == "XX000") && attempt < maxRetries-1 {
+		if pgschema.IsConcurrentDDLErr(err) && attempt < maxRetries-1 {
 			time.Sleep(200 * time.Millisecond)
 			continue
 		}

--- a/internal/pgstreambroker/pgstreambroker_test.go
+++ b/internal/pgstreambroker/pgstreambroker_test.go
@@ -138,6 +138,88 @@ func hardResetTestSchema(tb testing.TB, e *PostgresStreamBroker) {
 	}
 }
 
+// TestPostgresStreamBroker_EnsureSchema_ConcurrentNodes reproduces a cluster
+// whose nodes all start against the same empty database — the shape of a
+// fresh install rolled out to a whole deployment at once. CREATE TABLE/INDEX
+// IF NOT EXISTS probes the catalog before it takes any lock, so every node
+// but the winner loses the race and gets a hard error (42P07, or 23505 on
+// pg_type/pg_class when it reached its own catalog inserts first) instead of
+// the NOTICE a sequential re-run produces. EnsureSchema returning that error
+// means the node refuses to start, so every node here must come up clean.
+// The daily partitions EnsureSchema pre-creates race the same way.
+//
+// The race is timing-dependent and won't fire on every run — the test is a
+// regression guard, not a reproducer: it must never fail.
+func TestPostgresStreamBroker_EnsureSchema_ConcurrentNodes(t *testing.T) {
+	const (
+		nodes  = 8
+		rounds = 3
+	)
+	connString := getPostgresConnString(t)
+	ctx := context.Background()
+
+	// Separate brokers with separate pools — one per simulated node.
+	brokers := make([]*PostgresStreamBroker, 0, nodes)
+	for range nodes {
+		node, err := centrifuge.New(centrifuge.Config{})
+		require.NoError(t, err)
+		e, err := NewPostgresStreamBroker(node, PostgresStreamBrokerConfig{
+			DSN:                    connString,
+			NumShards:              4,
+			BinaryData:             true,
+			CleanupInterval:        time.Hour,
+			StreamRetention:        24 * time.Hour,
+			PartitionLookaheadDays: 1,
+			PartitionRetentionDays: 1,
+		})
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			_ = e.Close(context.Background())
+			_ = node.Shutdown(context.Background())
+		})
+		brokers = append(brokers, e)
+	}
+
+	for round := range rounds {
+		hardResetTestSchema(t, brokers[0])
+
+		start := make(chan struct{})
+		errs := make([]error, nodes)
+		var wg sync.WaitGroup
+		for i, e := range brokers {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				<-start
+				errs[i] = e.EnsureSchema(ctx)
+			}()
+		}
+		close(start)
+		wg.Wait()
+
+		for i, err := range errs {
+			require.NoErrorf(t, err, "round %d: node %d failed to bring up the schema", round, i)
+		}
+		// Every object the nodes raced to create must be present exactly once.
+		for _, prefix := range []string{brokers[0].names.jsonbPrefix, brokers[0].names.binaryPrefix} {
+			for _, table := range []string{
+				strings.TrimRight(prefix, "_"), prefix + "meta", prefix + "idempotency",
+				prefix + "shard_lock", prefix + "schema_version",
+			} {
+				var reg *string
+				require.NoError(t, brokers[0].pool.QueryRow(ctx, "SELECT to_regclass($1)::text", table).Scan(&reg))
+				require.NotNilf(t, reg, "round %d: table %s missing after concurrent EnsureSchema", round, table)
+			}
+		}
+		// And today's partition, created outside the schema batch.
+		var partitions int
+		require.NoError(t, brokers[0].pool.QueryRow(ctx,
+			"SELECT count(*) FROM pg_inherits WHERE inhparent = $1::regclass", brokers[0].names.stream,
+		).Scan(&partitions))
+		require.Positivef(t, partitions, "round %d: no partitions after concurrent EnsureSchema", round)
+	}
+}
+
 // TestPostgresStreamBroker_PublishAndHistory verifies basic publish + history
 // round-trip: a few messages with HistoryTTL set should be readable in order
 // from History().

--- a/internal/pgstreambroker/schema_template_test.go
+++ b/internal/pgstreambroker/schema_template_test.go
@@ -1,0 +1,40 @@
+package pgstreambroker
+
+import (
+	"regexp"
+	"testing"
+)
+
+// execSchemaWithRetry re-runs the whole batch on a concurrent-DDL conflict,
+// which is only safe while the batch stays one implicit transaction: no
+// statement of its own opening or closing a transaction, and nothing that
+// cannot run inside a transaction block at all (CREATE INDEX CONCURRENTLY
+// would fail outright with 25001, and a retry could not undo the half of the
+// batch that already committed). The invariant lives in the SQL template, so
+// pin it here rather than in a comment.
+func TestSchemaTemplate_StaysOneImplicitTransaction(t *testing.T) {
+	concurrently := regexp.MustCompile(`(?i)\bCONCURRENTLY\b`)
+	txControl := regexp.MustCompile(`(?im)^\s*(BEGIN|COMMIT|ROLLBACK|START\s+TRANSACTION)\b`)
+
+	for _, tc := range []struct {
+		name   string
+		prefix string
+		binary bool
+	}{
+		{"jsonb", "cf_stream_", false},
+		{"binary", "cf_binary_stream_", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			sql := renderSchema(tc.prefix, tc.binary)
+			if loc := concurrently.FindString(sql); loc != "" {
+				t.Errorf("schema template uses %q — it cannot run inside the implicit transaction execSchemaWithRetry relies on", loc)
+			}
+			// Only the DDL half is checked for transaction control: the funcs
+			// half is dollar-quoted PL/pgSQL, where BEGIN opens a block.
+			ddl, _ := splitSchemaSQL(sql)
+			if loc := txControl.FindString(ddl); loc != "" {
+				t.Errorf("schema DDL contains explicit transaction control %q — the batch must be left to the server's implicit transaction", loc)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Follow-up to #1220, which fixed the partition case.

### Context

`CREATE TABLE IF NOT EXISTS` probes the catalog before it takes any lock, so nodes creating the same object at the same moment all pass the probe and every one but the winner gets a hard error instead of the `NOTICE ... skipping` a sequential re-run produces. #1220 handled that for the daily partitions; the same race applies to the schema batch itself.

Every node's `EnsureSchema` creates the parent tables and their indexes with `CREATE TABLE/INDEX IF NOT EXISTS`, with nothing serialising them — the advisory lock covers only the migration chain, and the fresh-install DDL path runs outside it. `execSchemaWithRetry` retried just `40P01` and `XX000`, so a node that lost the race on a fresh install did not merely log noise: the error propagates out of `EnsureSchema` and the node refuses to start with `error initializing Postgres ... schema` (`internal/app/engine.go`, `internal/controllers/controllers.go`).

Unlike the `PARTITION OF` case, there is no parent `ACCESS EXCLUSIVE` lock to serialise the racers here, so the loser can get either code: `42P07` from the explicit check in `heap_create_with_catalog` if the winner had committed by the time it looked again, or `23505` on `pg_type`/`pg_class` if it reached its own catalog inserts first.

### Description

- `pgschema.IsConcurrentDDLErr` becomes the single classifier for the four codes (`40P01`, `XX000`, `42P07`, `23505`), replacing the two-code condition inlined in each of the three `execSchemaWithRetry` copies (pgstreambroker, pgmapbroker, controllers).
- Retrying the whole batch is safe, and the doc comment records why: it is one multi-statement `Exec` with no arguments, which pgx sends over the simple query protocol, so PostgreSQL runs it in a single implicit transaction and a failed attempt rolls back completely. The schema templates contain no explicit `BEGIN`/`COMMIT` (the `BEGIN`s are PL/pgSQL bodies, split into a separate exec) and no `CREATE INDEX CONCURRENTLY`.
- Migrations deliberately keep the narrower set. They run under `AcquireMigrationLock`, which serialises nodes cluster-wide, so a duplicate object there is a real bug and must surface rather than be retried away. `ApplyMigrationInTx`'s doc comment used to cross-reference `execSchemaWithRetry`'s code list, which this divergence made stale; it now states why it is narrower.
- SQLSTATE string literals are replaced with `github.com/jackc/pgerrcode` constants, in code and tests. pgx exports no SQLSTATE constants of its own — `pgconn` only has `PgError.Code` as a string, and pgx's own code compares raw literals. The new module is generated from PostgreSQL's `errcodes.txt`, is a single file, and has no dependencies of its own, so nothing transitive enters the tree. This also lets `pgoutbox` share the constant with `pgschema` without either package depending on the other.

No behaviour change for a single node, and no change to what gets created.

### Steps to review

`internal/pgschema/pgschema.go` carries the whole argument — `IsConcurrentDDLErr` and its doc comment. The three call sites are one condition each.

Verified: `go build ./...`, `go vet`, `gofmt`, `go test ./internal/...` and `golangci-lint run` over the five touched packages are all clean. (Several pre-existing `gofmt` offenders elsewhere under `internal/` were left alone.)

### Checklist

- [x] Tests added — `TestIsConcurrentDDLErr` covers all four retryable codes, a wrapped error, two real-failure codes, a non-server error and nil.
- [x] Related issue linked (#1219, #1220).
- [x] One logical change.
