### PR TITLE
fix(postgres): pgmapbroker fast path was never taken, plus table_prefix validation

### DIFF
--- a/internal/controllers/config_test.go
+++ b/internal/controllers/config_test.go
@@ -1,0 +1,31 @@
+package controllers
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/centrifugal/centrifuge"
+)
+
+// A table prefix reaches DDL unquoted, so one PostgreSQL can't parse has to be
+// caught at construction — otherwise it surfaces much later as a syntax error
+// naming a generated table rather than the setting behind it.
+func TestNewPostgresController_RejectsBadTablePrefix(t *testing.T) {
+	node, err := centrifuge.New(centrifuge.Config{})
+	if err != nil {
+		t.Fatalf("centrifuge.New: %v", err)
+	}
+	t.Cleanup(func() { _ = node.Shutdown(t.Context()) })
+
+	// Rejected before any connection is attempted, so this needs no Postgres.
+	_, err = NewPostgresController(node, PostgresControllerConfig{
+		DSN:         "postgres://test:test@localhost:5432/test",
+		TablePrefix: "cf-prod",
+	})
+	if err == nil {
+		t.Fatal("expected an error for a prefix PostgreSQL cannot parse unquoted")
+	}
+	if !strings.Contains(err.Error(), "table_prefix") {
+		t.Fatalf("error should name the setting at fault, got: %v", err)
+	}
+}

--- a/internal/controllers/controller_postgres.go
+++ b/internal/controllers/controller_postgres.go
@@ -157,6 +157,10 @@ var _ centrifuge.Controller = (*PostgresController)(nil)
 func NewPostgresController(node *centrifuge.Node, conf PostgresControllerConfig) (*PostgresController, error) {
 	conf.setDefaults()
 
+	if err := pgschema.ValidateTablePrefix("postgres controller", conf.TablePrefix); err != nil {
+		return nil, err
+	}
+
 	ctx := context.Background()
 
 	poolConfig, err := pgxpool.ParseConfig(conf.DSN)

--- a/internal/pgmapbroker/config_test.go
+++ b/internal/pgmapbroker/config_test.go
@@ -1,0 +1,31 @@
+package pgmapbroker
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/centrifugal/centrifuge"
+)
+
+// A table prefix reaches DDL unquoted, so one PostgreSQL can't parse has to be
+// caught at construction — otherwise it surfaces much later as a syntax error
+// naming a generated table rather than the setting behind it.
+func TestNewPostgresMapBroker_RejectsBadTablePrefix(t *testing.T) {
+	node, err := centrifuge.New(centrifuge.Config{})
+	if err != nil {
+		t.Fatalf("centrifuge.New: %v", err)
+	}
+	t.Cleanup(func() { _ = node.Shutdown(t.Context()) })
+
+	// Rejected before any connection is attempted, so this needs no Postgres.
+	_, err = NewPostgresMapBroker(node, PostgresMapBrokerConfig{
+		DSN:         "postgres://test:test@localhost:5432/test",
+		TablePrefix: "cf-prod",
+	})
+	if err == nil {
+		t.Fatal("expected an error for a prefix PostgreSQL cannot parse unquoted")
+	}
+	if !strings.Contains(err.Error(), "table_prefix") {
+		t.Fatalf("error should name the setting at fault, got: %v", err)
+	}
+}

--- a/internal/pgmapbroker/pgmapbroker.go
+++ b/internal/pgmapbroker/pgmapbroker.go
@@ -435,6 +435,9 @@ func NewPostgresMapBroker(n *centrifuge.Node, conf PostgresMapBrokerConfig) (*Po
 	if conf.DSN == "" {
 		return nil, errors.New("postgres map broker: DSN is required")
 	}
+	if err := pgschema.ValidateTablePrefix("postgres map broker", conf.TablePrefix); err != nil {
+		return nil, err
+	}
 
 	ctx := context.Background()
 

--- a/internal/pgmapbroker/pgmapbroker.go
+++ b/internal/pgmapbroker/pgmapbroker.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/centrifugal/centrifuge"
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
@@ -97,14 +96,11 @@ func (e *PostgresMapBroker) execSchemaWithRetry(ctx context.Context, sql string)
 	if err == nil {
 		return nil
 	}
-	var pgErr *pgconn.PgError
-	if errors.As(err, &pgErr) {
-		return &SchemaError{
-			Object: SchemaObject{Type: "schema", Name: pgErr.TableName},
-			Op:     "create",
-			Err:    err,
-		}
-	}
+	// No object name: the batch spans every table of one variant, and a server
+	// error's TableName is not the one that failed to be created — on the
+	// catalog unique violation a lost DDL race produces it reads "pg_class",
+	// which points the reader at PostgreSQL's own catalog. The wrapped error
+	// carries the statement's real detail.
 	return &SchemaError{
 		Object: SchemaObject{Type: "schema", Name: ""},
 		Op:     "create",
@@ -701,7 +697,12 @@ func (e *SchemaError) Unwrap() error {
 // install where only one variant was created.
 func (e *PostgresMapBroker) bothVariantsPresent(ctx context.Context) bool {
 	for _, prefix := range []string{e.names.jsonbPrefix, e.names.binaryPrefix} {
-		table := strings.TrimRight(prefix, "_")
+		// <prefix>stream, not the trimmed prefix: this broker's tables are all
+		// suffixed (cf_map_stream), unlike pgstreambroker where the trimmed
+		// prefix IS the table (cf_stream). Probing "cf_map" — a relation that
+		// never exists — made this return false every time, so the fast path
+		// below was dead and every start re-ran the whole DDL batch.
+		table := prefix + "stream"
 		if _, err := e.pool.Exec(ctx, fmt.Sprintf(`SELECT 1 FROM %s LIMIT 0`, table)); err != nil {
 			return false
 		}
@@ -818,8 +819,8 @@ func (e *PostgresMapBroker) EnsureSchema(ctx context.Context) error {
 	}
 
 	// 2. Fast path: version matches AND the primary table exists. Reconcile
-	//    shard_lock (load-bearing, see comment in reconcileShardLock) and
-	//    return without touching DDL.
+	//    shard_lock (load-bearing, see comment in reconcileShardLock), refresh
+	//    the partition lookahead, and return without touching DDL.
 	if !isFresh && dbVersion == schemaVersion {
 		// Probe BOTH variants' primary tables, not just the active one. The two
 		// variants (jsonb + binary) are created by separate Exec calls, so a
@@ -834,7 +835,15 @@ func (e *PostgresMapBroker) EnsureSchema(ctx context.Context) error {
 			if err := e.reconcileShardLock(ctx); err != nil {
 				return err
 			}
-			return nil
+			// Partitions are the one part of the schema that expires: the
+			// lookahead window advances with the calendar, so a node coming
+			// back after the cluster was down longer than
+			// PartitionLookaheadDays finds today's partition missing. Without
+			// this the gap stays open until the partition worker's first tick
+			// — a full CleanupInterval of publishes failing with "no partition
+			// for value". pgstreambroker and the Postgres controller already
+			// close it on their fast paths.
+			return e.ensurePartitionedStream(ctx)
 		}
 	}
 
@@ -2262,8 +2271,10 @@ func (e *PostgresMapBroker) cleanupExpiredBatched(ctx context.Context, query str
 //     clear "drop the legacy tables manually" error.
 //  2. Pre-create today's + lookahead partitions via the pgoutbox helper.
 //
-// pgmapbroker is unreleased, so no automatic migration is provided — the
-// operator drops the legacy tables and starts fresh.
+// The stream table has been PARTITION BY RANGE since the broker shipped, so
+// no released version can hold the legacy shape and no automatic migration is
+// provided — an operator carrying it over from a pre-release build drops the
+// legacy tables and starts fresh.
 func (e *PostgresMapBroker) ensurePartitionedStream(ctx context.Context) error {
 	// Probe: verify the stream table is actually partitioned. The CREATE TABLE
 	// IF NOT EXISTS in the schema template skips creation if a non-partitioned

--- a/internal/pgmapbroker/pgmapbroker_test.go
+++ b/internal/pgmapbroker/pgmapbroker_test.go
@@ -1628,6 +1628,85 @@ func TestPostgresMapBroker_EnsureSchema_Idempotent(t *testing.T) {
 	verifySchemaComplete(t, ctx, broker.pool, "cf_binary_map_", false)
 }
 
+// TestPostgresMapBroker_EnsureSchema_FastPathReachable pins the probe the
+// fast path gates on. It used to look for the trimmed prefix (cf_map), a
+// relation this broker never creates — the shape pgstreambroker uses, where
+// the trimmed prefix IS the table. So it always reported "not present", the
+// fast path was unreachable, and every single node start re-ran the full DDL
+// for both variants, CREATE OR REPLACE FUNCTION included. Nothing failed
+// visibly, which is exactly why it needs a test.
+func TestPostgresMapBroker_EnsureSchema_FastPathReachable(t *testing.T) {
+	ctx := context.Background()
+	node, err := centrifuge.New(centrifuge.Config{})
+	require.NoError(t, err)
+	broker, err := NewPostgresMapBroker(node, PostgresMapBrokerConfig{
+		DSN:        getPostgresConnString(t),
+		NumShards:  4,
+		BinaryData: true,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = broker.Close(ctx)
+		_ = node.Shutdown(ctx)
+	})
+
+	require.NoError(t, broker.EnsureSchema(ctx))
+	require.True(t, broker.bothVariantsPresent(ctx),
+		"both variants exist after EnsureSchema, so the fast path must be reachable on the next start")
+}
+
+// TestPostgresMapBroker_EnsureSchema_FastPathRestoresPartitions covers the
+// one part of the schema that expires on its own. Tables and functions are
+// created once and stay; the daily partitions only cover
+// PartitionLookaheadDays ahead, so a cluster that was down longer than that
+// comes back to a stream table with no partition for today, and every publish
+// fails with "no partition for value". The fast path is what a restart of a
+// healthy cluster takes, so it has to repair that — before, the gap stayed
+// open until the partition worker's first tick, a full CleanupInterval later.
+func TestPostgresMapBroker_EnsureSchema_FastPathRestoresPartitions(t *testing.T) {
+	connString := getPostgresConnString(t)
+	ctx := context.Background()
+
+	// Built directly rather than through the test helper: no event handler
+	// means no partition worker, so EnsureSchema is the only thing that can
+	// create a partition and the assertion below can't be satisfied by a
+	// background tick.
+	node, err := centrifuge.New(centrifuge.Config{})
+	require.NoError(t, err)
+	broker, err := NewPostgresMapBroker(node, PostgresMapBrokerConfig{
+		DSN:        connString,
+		NumShards:  4,
+		BinaryData: true,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = broker.Close(ctx)
+		_ = node.Shutdown(ctx)
+	})
+
+	require.NoError(t, broker.EnsureSchema(ctx))
+
+	// Simulate the calendar having moved past the lookahead window.
+	today := fmt.Sprintf("%s_%s", broker.names.stream, time.Now().UTC().Format("2006_01_02"))
+	_, err = broker.pool.Exec(ctx, "DROP TABLE "+today)
+	require.NoError(t, err)
+	require.False(t, partitionExists(ctx, t, broker.pool, today))
+
+	// Schema version is current and both variants are present, so this call
+	// takes the fast path — the one a healthy restart takes.
+	require.NoError(t, broker.EnsureSchema(ctx))
+	require.True(t, partitionExists(ctx, t, broker.pool, today),
+		"fast path left today's partition missing — publishes would fail until the partition worker's first tick")
+}
+
+func partitionExists(ctx context.Context, t *testing.T, pool *pgxpool.Pool, name string) bool {
+	t.Helper()
+	var exists bool
+	require.NoError(t, pool.QueryRow(ctx,
+		"SELECT EXISTS(SELECT 1 FROM pg_class WHERE relname = $1 AND relkind = 'r')", name).Scan(&exists))
+	return exists
+}
+
 // TestPostgresMapBroker_EnsureSchema_ConcurrentNodes reproduces a cluster
 // whose nodes all start against the same empty database — the shape of a
 // fresh install rolled out to a whole deployment at once. CREATE TABLE/INDEX

--- a/internal/pgschema/pgschema.go
+++ b/internal/pgschema/pgschema.go
@@ -13,6 +13,7 @@ import (
 	"hash/fnv"
 	"math/rand/v2"
 	"time"
+	"unicode"
 
 	"github.com/jackc/pgerrcode"
 	"github.com/jackc/pgx/v5"
@@ -54,6 +55,42 @@ func ValidateMigrationMap(label string, target int, migrations map[int]string) {
 			panic(fmt.Sprintf("%s: schemaMigrations[%d] is outside the valid range [2..%d]", label, v, target))
 		}
 	}
+}
+
+// ValidateTablePrefix rejects a configured table prefix that can never work as
+// a PostgreSQL identifier. Every table, index and function name is this prefix
+// concatenated with a fixed suffix and interpolated into DDL unquoted, so a bad
+// prefix surfaces as a syntax error deep inside a generated CREATE statement,
+// naming the table it failed to create rather than the setting that produced
+// it. Call it once at construction, after defaults are applied.
+//
+// The rule is PostgreSQL's own for unquoted identifiers, so it rejects only
+// what could never have worked: a letter or underscore first, then letters,
+// digits, underscores or dollar signs. Uppercase stays valid — PostgreSQL
+// folds it, so a prefix of "MyApp" yields myapp_* tables and every generated
+// query folds to match — and so do non-ASCII letters.
+//
+// It deliberately says nothing about length. PostgreSQL truncates identifiers
+// at 63 bytes rather than erroring, so a long prefix degrades (partition names
+// losing their date suffix, for one) instead of failing outright, and rejecting
+// it here would refuse deployments that are running today.
+func ValidateTablePrefix(label, prefix string) error {
+	if prefix == "" {
+		return fmt.Errorf("%s: table_prefix is empty", label)
+	}
+	for i, r := range prefix {
+		switch {
+		case unicode.IsLetter(r) || r == '_':
+			// Valid anywhere, including first.
+		case (unicode.IsDigit(r) || r == '$') && i > 0:
+			// Valid only after the first character.
+		default:
+			return fmt.Errorf(
+				"%s: table_prefix %q contains %q, which PostgreSQL does not accept in an unquoted identifier — use letters, digits and underscores, and don't start with a digit",
+				label, prefix, r)
+		}
+	}
+	return nil
 }
 
 // ReadSchemaVersion reads the schema_version row from `table` and discriminates

--- a/internal/pgschema/pgschema_test.go
+++ b/internal/pgschema/pgschema_test.go
@@ -75,6 +75,44 @@ func TestCheckDowngrade_DBNewer_Rejected(t *testing.T) {
 	require.Contains(t, err.Error(), "downgrade not supported")
 }
 
+// ----- ValidateTablePrefix -----
+
+func TestValidateTablePrefix(t *testing.T) {
+	cases := []struct {
+		name    string
+		prefix  string
+		wantErr bool
+	}{
+		{"default", "cf", false},
+		{"underscores", "my_app_v2", false},
+		{"leading underscore", "_cf", false},
+		{"dollar after first", "cf$1", false},
+		// PostgreSQL folds unquoted identifiers, so this yields myapp_* tables
+		// and every generated query folds to match. Deployments run on it.
+		{"uppercase folds, stays valid", "MyApp", false},
+		{"non-ascii letter", "приложение", false},
+		{"empty", "", true},
+		{"leading digit", "1cf", true},
+		{"leading dollar", "$cf", true},
+		{"hyphen", "cf-prod", true},
+		{"space", "cf prod", true},
+		{"dot", "public.cf", true},
+		{"quote", `cf"x`, true},
+		{"semicolon", "cf;DROP TABLE x", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateTablePrefix("test", tc.prefix)
+			if tc.wantErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "test:")
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
 // ----- IsRetryableSchemaExecErr / RetrySchemaExec -----
 
 func TestIsRetryableSchemaExecErr(t *testing.T) {

--- a/internal/pgstreambroker/config_test.go
+++ b/internal/pgstreambroker/config_test.go
@@ -1,0 +1,31 @@
+package pgstreambroker
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/centrifugal/centrifuge"
+)
+
+// A table prefix reaches DDL unquoted, so one PostgreSQL can't parse has to be
+// caught at construction — otherwise it surfaces much later as a syntax error
+// naming a generated table rather than the setting behind it.
+func TestNewPostgresStreamBroker_RejectsBadTablePrefix(t *testing.T) {
+	node, err := centrifuge.New(centrifuge.Config{})
+	if err != nil {
+		t.Fatalf("centrifuge.New: %v", err)
+	}
+	t.Cleanup(func() { _ = node.Shutdown(t.Context()) })
+
+	// Rejected before any connection is attempted, so this needs no Postgres.
+	_, err = NewPostgresStreamBroker(node, PostgresStreamBrokerConfig{
+		DSN:         "postgres://test:test@localhost:5432/test",
+		TablePrefix: "cf-prod",
+	})
+	if err == nil {
+		t.Fatal("expected an error for a prefix PostgreSQL cannot parse unquoted")
+	}
+	if !strings.Contains(err.Error(), "table_prefix") {
+		t.Fatalf("error should name the setting at fault, got: %v", err)
+	}
+}

--- a/internal/pgstreambroker/pgstreambroker.go
+++ b/internal/pgstreambroker/pgstreambroker.go
@@ -394,6 +394,9 @@ func NewPostgresStreamBroker(n *centrifuge.Node, conf PostgresStreamBrokerConfig
 	if conf.DSN == "" {
 		return nil, errors.New("postgres stream broker: DSN is required")
 	}
+	if err := pgschema.ValidateTablePrefix("postgres stream broker", conf.TablePrefix); err != nil {
+		return nil, err
+	}
 
 	ctx := context.Background()
 


### PR DESCRIPTION
Follow-up to #1222 — things found while reviewing the Postgres code.

## 1. pgmapbroker re-ran its whole schema on every start

`EnsureSchema` has a fast path: if the schema version matches and the tables are already there, skip the DDL and return.

The "are the tables there?" check looked for a table called `cf_map`. This broker never creates that — its tables are `cf_map_stream`, `cf_map_meta` and so on. The check was written the way pgstreambroker does it, where that short name really is a table (`cf_stream`).

So the answer was always "no". The fast path was never taken, and every node start re-created the whole schema for both variants, `CREATE OR REPLACE FUNCTION` included. Nothing failed, which is why it went unnoticed — but it is wasted work on every restart, and it is exactly the DDL that nodes collide on when they start together (the collisions #1222 retries).

The check now looks for `<prefix>stream`.

Worth knowing: with the fast path finally working, the map broker re-applies function bodies only when the schema version changes — the same as pgstreambroker and the controller do today. A future change to a function body in `schema.sql` needs a schema version bump to reach existing databases.

## 2. The fast path did not create today's partition

Tables and functions are made once and stay. Daily partitions are different: they only cover a few days ahead. A cluster down longer than `partition_lookahead_days` comes back with no partition for today, and every publish fails with "no partition for value" until the partition worker's next tick, up to `cleanup_interval` later.

pgstreambroker and the controller already create the missing partitions on their fast path. pgmapbroker now does too.

## 3. An invalid table_prefix now fails at startup

Table names are the prefix plus a fixed suffix, put straight into the DDL. A prefix like `cf-prod` used to fail later on, as a syntax error naming a generated table rather than the setting behind it. It now fails at startup with a message naming `table_prefix`.

The rule is PostgreSQL's own for unquoted names, so it rejects only what could never have worked. Uppercase stays valid (PostgreSQL lowercases it), and so do non-ASCII letters. Length is not checked, because PostgreSQL truncates long names instead of failing and rejecting them would refuse setups that run today.

## Smaller things

- The schema error no longer labels itself with a table name taken from the server error. On a lost DDL race that reads `pg_class`, which is PostgreSQL's own catalog, not the table we failed to create.
- Fixed a comment saying pgmapbroker is unreleased — it shipped in v6.8.0.

## Testing

Each new test was checked by reverting its fix and confirming the test fails:

- the fast path is reachable after `EnsureSchema`
- the fast path re-creates a dropped partition
- each of the three constructors rejects a bad prefix
- table-driven cases for the prefix rule

`go build`, `go vet`, `gofmt` and `golangci-lint` are clean, and the unit and integration suites pass with `-race` against PostgreSQL 16.

Nothing that works today stops working.