### PR TITLE
refactor(config): move channel name validation to Container

### DIFF
--- a/internal/client/handler.go
+++ b/internal/client/handler.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"sync"
 	"time"
-	"unicode"
 
 	"github.com/centrifugal/centrifugo/v6/internal/clientcontext"
 	"github.com/centrifugal/centrifugo/v6/internal/clientstorage"
@@ -498,7 +497,7 @@ func (h *Handler) OnClientConnecting(
 				userID = credentials.UserID
 			}
 
-			validChannelName, err := h.validChannelName(rest, chOpts, ch)
+			validChannelName, err := h.cfgContainer.ValidChannelName(ch, rest, chOpts)
 			if err != nil {
 				return centrifuge.ConnectReply{}, centrifuge.ErrorInternal
 			}
@@ -702,15 +701,6 @@ func (h *Handler) OnSubRefresh(c Client, subRefreshProxyHandler proxy.SubRefresh
 	}, SubRefreshExtra{}, nil
 }
 
-func isASCII(s string) bool {
-	for _, c := range s {
-		if c > unicode.MaxASCII {
-			return false
-		}
-	}
-	return true
-}
-
 // isSubscriptionTypeAllowed checks whether the given subscription type
 // matches the namespace's configured subscription_type.
 // When no type is configured, only stream subscriptions are allowed.
@@ -721,20 +711,8 @@ func isSubscriptionTypeAllowed(subType centrifuge.SubscriptionType, configuredTy
 	return configuredType == subType.String()
 }
 
-func (h *Handler) validChannelName(rest string, chOpts configtypes.ChannelOptions, channel string) (bool, error) {
-	if chOpts.ChannelRegex != "" {
-		regex := chOpts.Compiled.CompiledChannelRegex
-		if !regex.MatchString(rest) {
-			return false, nil
-		}
-	} else if !isASCII(channel) {
-		return false, nil
-	}
-	return true, nil
-}
-
 func (h *Handler) validateChannelName(c Client, rest string, chOpts configtypes.ChannelOptions, channel string) error {
-	ok, err := h.validChannelName(rest, chOpts, channel)
+	ok, err := h.cfgContainer.ValidChannelName(channel, rest, chOpts)
 	if err != nil {
 		log.Info().Err(err).Str("channel", channel).Str("client", c.ID()).Str("user", c.UserID()).Msg("error checking channel name")
 		return centrifuge.ErrorInternal

--- a/internal/config/container.go
+++ b/internal/config/container.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"time"
+	"unicode"
 
 	"github.com/centrifugal/centrifugo/v6/internal/configtypes"
 )
@@ -126,6 +127,30 @@ func (n *Container) ChannelOptions(ch string) (string, string, configtypes.Chann
 		n.channelOptionsCache.Set(ch, res, n.ChannelOptionsCacheTTL)
 	}
 	return res.nsName, res.rest, res.chOpts, res.ok, res.err
+}
+
+// ValidChannelName checks whether the channel name is valid for the resolved
+// channel options. When channel_regex is set it's matched against rest - the part
+// of the channel which follows the namespace, as returned by ChannelOptions. When
+// no channel_regex is set the channel must only contain ASCII characters.
+func (n *Container) ValidChannelName(ch string, rest string, chOpts configtypes.ChannelOptions) (bool, error) {
+	if chOpts.ChannelRegex != "" {
+		if !chOpts.Compiled.CompiledChannelRegex.MatchString(rest) {
+			return false, nil
+		}
+	} else if !isASCII(ch) {
+		return false, nil
+	}
+	return true, nil
+}
+
+func isASCII(s string) bool {
+	for _, c := range s {
+		if c > unicode.MaxASCII {
+			return false
+		}
+	}
+	return true
 }
 
 // NumNamespaces returns number of configured namespaces.

--- a/internal/config/container_test.go
+++ b/internal/config/container_test.go
@@ -199,6 +199,53 @@ func TestUserAllowed(t *testing.T) {
 	require.False(t, rules.UserAllowed("channel#1,2", "3"))
 }
 
+func TestValidChannelName(t *testing.T) {
+	c := defaultConfig(t)
+	c.Channel.Namespaces = []configtypes.ChannelNamespace{
+		{
+			Name: "digits",
+			ChannelOptions: configtypes.ChannelOptions{
+				ChannelRegex: `^\d+$`,
+			},
+		},
+		{
+			Name:           "plain",
+			ChannelOptions: configtypes.ChannelOptions{},
+		},
+		{
+			Name: "any",
+			ChannelOptions: configtypes.ChannelOptions{
+				ChannelRegex: `^.+$`,
+			},
+		},
+	}
+	container, err := NewContainer(c)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name    string
+		channel string
+		valid   bool
+	}{
+		{"no regex, ascii channel", "plain:index", true},
+		{"no regex, non-ascii channel", "plain:индекс", false},
+		{"regex matches rest, not the whole channel", "digits:42", true},
+		{"regex does not match rest", "digits:abc", false},
+		{"regex replaces the ascii check", "any:индекс", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, rest, chOpts, found, err := container.ChannelOptions(tt.channel)
+			require.NoError(t, err)
+			require.True(t, found)
+			valid, err := container.ValidChannelName(tt.channel, rest, chOpts)
+			require.NoError(t, err)
+			require.Equal(t, tt.valid, valid)
+		})
+	}
+}
+
 func TestIsUserLimited(t *testing.T) {
 	rules, err := NewContainer(defaultConfig(t))
 	require.NoError(t, err)


### PR DESCRIPTION
## What

`validChannelName` was a private method on `client.Handler`, which means the rule could only be evaluated while serving a client command. It doesn't depend on the client at all — it's a pure function of the channel, the namespace `rest`, and the resolved channel options, and both of those already come out of `Container.ChannelOptions`.

Moved it to `Container.ValidChannelName` (along with `isASCII`, its only user), and `Handler.validateChannelName` now delegates. Behavior is unchanged; the signature is the same modulo argument order (channel first).

This puts the check next to the resolution it belongs to: whether a channel name is acceptable is decided by the same config the namespace lookup uses, so keeping both on `Container` means a caller that resolves a channel can also ask whether Centrifugo would accept its name.

## Test

`TestValidChannelName` in `internal/config/container_test.go` — the rules were previously untested. It resolves through `Container.ChannelOptions` the way real callers do and covers the two easy-to-get-wrong parts:

- a configured `channel_regex` is matched against `rest` (the part after the namespace), not the whole channel — `^\d+$` accepts `digits:42`;
- `channel_regex` *replaces* the ASCII-only check rather than adding to it — `^.+$` accepts a non-ASCII name, while a namespace without a regex rejects it.

## How verified

- `go build ./...`
- `go test ./internal/config/... ./internal/client/...` — pass
- `go vet ./internal/config/... ./internal/client/...` — clean